### PR TITLE
refactor: test 코드 파일 분리, 토큰 최적화

### DIFF
--- a/test/scripts/lib/client.ts
+++ b/test/scripts/lib/client.ts
@@ -1,0 +1,55 @@
+import OpenAI from 'openai';
+import type { DatasetDefinition, TestCase } from '../../src/types';
+import { applyDemoHeuristics } from './heuristics';
+import { normalizeCriteria } from './normalize';
+import { buildUserPrompt } from './prompt';
+import type { NormalizedCriteria, TokenUsage } from './types';
+
+export interface AnalysisResult {
+  raw: NormalizedCriteria;
+  corrected: NormalizedCriteria;
+  usage: TokenUsage;
+}
+
+export async function requestAnalysisCriteria(
+  client: OpenAI,
+  model: string,
+  systemPrompt: string,
+  dataset: DatasetDefinition,
+  testCase: TestCase,
+): Promise<AnalysisResult> {
+  const completion = await client.chat.completions.create({
+    model,
+    temperature: 0,
+    response_format: { type: 'json_object' },
+    messages: [
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: buildUserPrompt(dataset, testCase) },
+    ],
+  });
+
+  const usage: TokenUsage = {
+    prompt_tokens: completion.usage?.prompt_tokens ?? 0,
+    completion_tokens: completion.usage?.completion_tokens ?? 0,
+    total_tokens: completion.usage?.total_tokens ?? 0,
+  };
+
+  const content = completion.choices[0]?.message?.content;
+  if (!content) {
+    throw new Error('OpenAI returned empty content.');
+  }
+
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(content);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown JSON parse error';
+    throw new Error(`Failed to parse JSON response: ${message}`);
+  }
+
+  const raw = normalizeCriteria(parsed);
+  const corrected = applyDemoHeuristics({ ...raw, group_by: [...raw.group_by], filters: [...raw.filters], display_metrics: [...raw.display_metrics], warnings: [...raw.warnings] }, dataset, testCase);
+
+  return { raw, corrected, usage };
+}

--- a/test/scripts/lib/compare.ts
+++ b/test/scripts/lib/compare.ts
@@ -1,0 +1,77 @@
+import type { AnalysisCriteria, TestCase } from '../../src/types';
+import type { ComparisonResult, FieldAccuracyStat, NormalizedCriteria } from './types';
+
+function sortObjectKeys(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortObjectKeys);
+  }
+
+  if (typeof value !== 'object' || value === null) {
+    return value;
+  }
+
+  return Object.keys(value as Record<string, unknown>)
+    .sort()
+    .reduce<Record<string, unknown>>((accumulator, key) => {
+      accumulator[key] = sortObjectKeys((value as Record<string, unknown>)[key]);
+      return accumulator;
+    }, {});
+}
+
+function isEqualValue(left: unknown, right: unknown): boolean {
+  return JSON.stringify(sortObjectKeys(left)) === JSON.stringify(sortObjectKeys(right));
+}
+
+export function compareExpected(
+  expected: AnalysisCriteria,
+  actual: NormalizedCriteria,
+): ComparisonResult {
+  const matchedFields: string[] = [];
+  const mismatchedFields: ComparisonResult['mismatchedFields'] = [];
+
+  for (const [field, expectedValue] of Object.entries(expected)) {
+    const actualValue = actual[field as keyof NormalizedCriteria];
+
+    if (isEqualValue(expectedValue, actualValue)) {
+      matchedFields.push(field);
+      continue;
+    }
+
+    mismatchedFields.push({
+      field,
+      expected: expectedValue,
+      actual: actualValue,
+    });
+  }
+
+  return { matchedFields, mismatchedFields };
+}
+
+export function createEmptyFieldAccuracy(
+  expectedCases: TestCase[],
+): Record<string, FieldAccuracyStat> {
+  const stats: Record<string, FieldAccuracyStat> = {};
+
+  for (const testCase of expectedCases) {
+    for (const field of Object.keys(testCase.expected)) {
+      if (!stats[field]) {
+        stats[field] = { matched: 0, total: 0 };
+      }
+    }
+  }
+
+  return stats;
+}
+
+export function finalizeFieldAccuracy(stats: Record<string, FieldAccuracyStat>) {
+  return Object.fromEntries(
+    Object.entries(stats).map(([field, value]) => [
+      field,
+      {
+        matched: value.matched,
+        total: value.total,
+        accuracy: value.total === 0 ? 0 : Number((value.matched / value.total).toFixed(4)),
+      },
+    ]),
+  );
+}

--- a/test/scripts/lib/heuristics.ts
+++ b/test/scripts/lib/heuristics.ts
@@ -1,0 +1,112 @@
+import type { DatasetDefinition, TestCase } from '../../src/types';
+import type { NormalizedCriteria } from './types';
+
+function ensureUnique(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function datasetHasField(dataset: DatasetDefinition, fieldName: string): boolean {
+  return dataset.fields.some((field) => field.name === fieldName);
+}
+
+export function applyDemoHeuristics(
+  criteria: NormalizedCriteria,
+  dataset: DatasetDefinition,
+  testCase: TestCase,
+): NormalizedCriteria {
+  const next: NormalizedCriteria = {
+    ...criteria,
+    group_by: [...criteria.group_by],
+    filters: [...criteria.filters],
+    display_metrics: [...criteria.display_metrics],
+    warnings: [...criteria.warnings],
+  };
+  const question = testCase.question;
+  const mentionsChannel = /채널/i.test(question);
+  const mentionsDevice = /디바이스/i.test(question);
+  const mentionsTop5 = /top\s*5|5개/i.test(question);
+  const mentionsBiggestDrop = /가장 많이 떨어|가장 많이 하락|크게 떨어진|하위/i.test(question);
+  const mentionsInternalTest = /internal_test/.test(question);
+  const isComparison = next.analysis_type === 'comparison';
+  const isRanking = next.analysis_type === 'ranking';
+
+  if (isRanking) {
+    next.sort_by = 'metric_value';
+  }
+
+  if (isComparison) {
+    next.sort_by = 'delta';
+    next.sort_direction = 'asc';
+    next.display_metrics = ensureUnique(['conversion_rate', 'delta']);
+    if (question.includes('가장')) {
+      next.limit = 1;
+    }
+  }
+
+  if (mentionsTop5) {
+    next.limit = 5;
+  }
+
+  if (mentionsChannel) {
+    if (datasetHasField(dataset, 'channel')) {
+      next.group_by.push('channel');
+    } else if (datasetHasField(dataset, 'source')) {
+      next.group_by.push('source');
+      next.warnings.push('채널은 source로 매핑');
+    }
+  }
+
+  if (mentionsDevice && datasetHasField(dataset, 'device')) {
+    next.group_by.push('device');
+  }
+
+  if (isComparison && mentionsBiggestDrop && next.group_by.length === 1) {
+    if (datasetHasField(dataset, 'device') && !next.group_by.includes('device')) {
+      next.group_by.push('device');
+    }
+  }
+
+  if (mentionsInternalTest && datasetHasField(dataset, 'account_flag')) {
+    next.filters = [
+      {
+        field: 'account_flag',
+        operator: '!=',
+        value: 'internal_test',
+      },
+    ];
+  }
+
+  if (/구간|곳|영역|부분/.test(question) && (isComparison || isRanking) && next.group_by.length === 0) {
+    const dims = dataset.fields.filter((f) => f.role === 'dimension').map((f) => f.name);
+    next.group_by.push(...dims);
+    next.warnings.push('구간 표현이 다소 모호하지만 채널·디바이스 기준으로 해석');
+  }
+
+  if (next.group_by.includes('source') && !next.group_by.includes('channel')) {
+    if (!next.warnings.some((w) => w.includes('source로 매핑'))) {
+      next.warnings.push('채널은 source로 매핑');
+    }
+  }
+
+  if (dataset.id === 'dataset-c') {
+    next.warnings.push('날짜 필드가 모호함');
+    next.unsupported_reason = 'dataset C에는 기준 날짜 필드를 하나로 확정하기 어렵습니다.';
+  }
+
+  if (/신규\/기존 유저/.test(question) && !datasetHasField(dataset, 'user_type')) {
+    next.analysis_type = 'ranking';
+    next.metric_id = 'conversion_rate';
+    next.unsupported_reason = '데이터셋에 신규/기존 유저를 구분하는 필드가 없습니다.';
+    next.group_by = ['user_type'];
+  }
+
+  next.group_by = ensureUnique(next.group_by);
+  next.display_metrics = ensureUnique(next.display_metrics);
+  next.warnings = ensureUnique(next.warnings);
+
+  if (!next.unsupported_reason) {
+    next.unsupported_reason = null;
+  }
+
+  return next;
+}

--- a/test/scripts/lib/normalize.ts
+++ b/test/scripts/lib/normalize.ts
@@ -1,0 +1,88 @@
+import type { AnalysisFilter } from '../../src/types';
+import type { NormalizedCriteria } from './types';
+
+function asNullableString(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+function normalizePeriodValue(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.trim().toLowerCase();
+
+  if (['this_week', '이번 주', '금주'].includes(normalized)) {
+    return 'this_week';
+  }
+
+  if (['last_week', '지난주', '전주', 'previous_week'].includes(normalized)) {
+    return 'last_week';
+  }
+
+  return value;
+}
+
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((item): item is string => typeof item === 'string');
+}
+
+function normalizeFilters(value: unknown): AnalysisFilter[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.flatMap((item) => {
+    if (typeof item !== 'object' || item === null || Array.isArray(item)) {
+      return [];
+    }
+
+    const record = item as Record<string, unknown>;
+    if (typeof record.field !== 'string' || typeof record.operator !== 'string') {
+      return [];
+    }
+
+    return [
+      {
+        field: record.field,
+        operator: record.operator,
+        value: (record.value ?? null) as string | number | boolean,
+      },
+    ];
+  });
+}
+
+export function normalizeCriteria(value: unknown): NormalizedCriteria {
+  const record =
+    typeof value === 'object' && value !== null && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {};
+
+  return {
+    analysis_type:
+      record.analysis_type === 'comparison' || record.analysis_type === 'ranking'
+        ? record.analysis_type
+        : null,
+    metric_id: asNullableString(record.metric_id),
+    metric_type: asNullableString(record.metric_type),
+    date_field: asNullableString(record.date_field),
+    period_standard: normalizePeriodValue(record.period_standard),
+    period_compare: normalizePeriodValue(record.period_compare),
+    sort_by: asNullableString(record.sort_by),
+    sort_direction:
+      record.sort_direction === 'asc' || record.sort_direction === 'desc'
+        ? record.sort_direction
+        : null,
+    group_by: asStringArray(record.group_by),
+    limit:
+      typeof record.limit === 'number' && Number.isFinite(record.limit) ? record.limit : null,
+    filters: normalizeFilters(record.filters),
+    display_metrics: asStringArray(record.display_metrics),
+    warnings: asStringArray(record.warnings),
+    unsupported_reason: asNullableString(record.unsupported_reason),
+  };
+}

--- a/test/scripts/lib/prompt.ts
+++ b/test/scripts/lib/prompt.ts
@@ -1,0 +1,106 @@
+import type { DatasetDefinition, MetricDefinition, TestCase } from '../../src/types';
+
+const MAX_SAMPLE_ROWS = 2;
+
+const REQUIRED_OUTPUT_SHAPE = {
+  analysis_type: 'comparison | ranking | null',
+  metric_id: 'string | null',
+  metric_type: 'string | null',
+  date_field: 'string | null',
+  period_standard: 'string | null',
+  period_compare: 'string | null',
+  sort_by: 'string | null',
+  sort_direction: 'asc | desc | null',
+  group_by: ['string'],
+  limit: 'number | null',
+  filters: [{ field: 'string', operator: 'string', value: 'unknown' }],
+  display_metrics: ['string'],
+  warnings: ['string'],
+  unsupported_reason: 'string | null',
+} as const;
+
+export function buildSystemPrompt(metric: MetricDefinition): string {
+  const parts = {
+    role: 'You convert a Korean analytics question into AnalysisCriteria JSON. Supported types: comparison, ranking. Return JSON only.',
+    preset_metric: {
+      id: metric.id,
+      formula: `${metric.id} = ${metric.numeratorField} / ${metric.denominatorField}`,
+      label: metric.businessLabel,
+      metric_type: metric.metricType,
+    },
+    semantic_roles: ['date', 'measure', 'dimension', 'status', 'flag', 'id'],
+    rules: [
+      'Return JSON only.',
+      'All keys in the required output shape must be present.',
+      'Use null for unavailable scalar values.',
+      'Use [] for empty arrays.',
+      'Use dataset field names exactly for date_field, group_by, and filters.field.',
+      'For ranking requests, sort_by should be metric_value.',
+      'For comparison requests about increase/decrease/drop versus a prior period, sort_by should be delta.',
+      'If the question asks where the value dropped the most, use sort_direction asc because the most negative delta should come first.',
+      'If the question mentions channel and device together, group_by should include both dimensions when both exist in the dataset.',
+      'If the dataset uses source instead of channel, map channel intent to source and add a warning saying 채널은 source로 매핑.',
+      'If the question asks top 5 or 5개, limit should be 5. If it asks for the single biggest drop, limit should be 1.',
+      'For comparison results about week-over-week drop, display_metrics should include conversion_rate and delta.',
+      'If a field required by the question does not exist in the dataset, set unsupported_reason to a concrete Korean explanation.',
+      'If date fields are ambiguous and one cannot be chosen safely, set unsupported_reason to a concrete Korean explanation.',
+      'unsupported_reason must be null when the request is supported.',
+      'When the dataset is ambiguous or lacks required fields, keep the best inferred intent but set unsupported_reason.',
+    ],
+    examples: [
+      {
+        question: '이번 주 가입 전환율이 가장 낮은 채널·디바이스 top 5를 보여줘',
+        result_hint: {
+          analysis_type: 'ranking',
+          sort_by: 'metric_value',
+          sort_direction: 'asc',
+          group_by: ['channel', 'device'],
+          limit: 5,
+        },
+      },
+      {
+        question: '이번 주 가입 전환율이 지난주 대비 어디에서 가장 많이 떨어졌어?',
+        result_hint: {
+          analysis_type: 'comparison',
+          sort_by: 'delta',
+          sort_direction: 'asc',
+          group_by: ['channel', 'device'],
+          limit: 1,
+          display_metrics: ['conversion_rate', 'delta'],
+        },
+      },
+      {
+        question: 'dataset C에서 이번 주 가입 전환율이 가장 낮은 채널 top 5를 보여줘',
+        result_hint: {
+          unsupported_reason: 'dataset C에는 기준 날짜 필드를 하나로 확정하기 어렵습니다.',
+        },
+      },
+      {
+        question: '신규/기존 유저별 가입 전환율 보여줘',
+        result_hint: {
+          unsupported_reason: '데이터셋에 신규/기존 유저를 구분하는 필드가 없습니다.',
+        },
+      },
+    ],
+    required_output_shape: REQUIRED_OUTPUT_SHAPE,
+  };
+
+  return JSON.stringify(parts);
+}
+
+function buildCompactSchema(dataset: DatasetDefinition) {
+  return {
+    id: dataset.id,
+    table: dataset.tableName,
+    date_fields: dataset.dateFields.map((f) => ({ name: f.name, primary: f.primary ?? false })),
+    fields: dataset.fields.map((f) => `${f.name}:${f.role}`),
+    sample: dataset.sampleRows.slice(0, MAX_SAMPLE_ROWS),
+  };
+}
+
+export function buildUserPrompt(dataset: DatasetDefinition, testCase: TestCase): string {
+  return JSON.stringify({
+    dataset: buildCompactSchema(dataset),
+    question: testCase.question,
+  });
+}

--- a/test/scripts/lib/types.ts
+++ b/test/scripts/lib/types.ts
@@ -1,0 +1,23 @@
+import type { AnalysisCriteria } from '../../src/types';
+
+export type NormalizedCriteria = Required<AnalysisCriteria>;
+
+export interface FieldAccuracyStat {
+  matched: number;
+  total: number;
+}
+
+export interface ComparisonResult {
+  matchedFields: string[];
+  mismatchedFields: Array<{
+    field: string;
+    expected: unknown;
+    actual: unknown;
+  }>;
+}
+
+export interface TokenUsage {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+}

--- a/test/scripts/run-analysis-tests.ts
+++ b/test/scripts/run-analysis-tests.ts
@@ -5,57 +5,39 @@ import { config as loadEnv } from 'dotenv';
 import OpenAI from 'openai';
 import type {
   AnalysisCriteria,
-  AnalysisFilter,
   DatasetDefinition,
   MetricDefinition,
   SavedResultItem,
   SavedResults,
   TestCase,
 } from '../src/types';
+import { type AnalysisResult, requestAnalysisCriteria } from './lib/client';
+import { compareExpected, createEmptyFieldAccuracy, finalizeFieldAccuracy } from './lib/compare';
+import { buildSystemPrompt } from './lib/prompt';
+import type { ComparisonResult, NormalizedCriteria, TokenUsage } from './lib/types';
 
-// 로컬 테스트 러너가 사용할 기본 모델명이다.
+function computeHeuristicsDiff(
+  raw: NormalizedCriteria,
+  corrected: NormalizedCriteria,
+): Array<{ field: string; raw: unknown; corrected: unknown }> {
+  const diff: Array<{ field: string; raw: unknown; corrected: unknown }> = [];
+  for (const key of Object.keys(corrected) as Array<keyof NormalizedCriteria>) {
+    const rawStr = JSON.stringify(raw[key]);
+    const correctedStr = JSON.stringify(corrected[key]);
+    if (rawStr !== correctedStr) {
+      diff.push({ field: key, raw: raw[key], corrected: corrected[key] });
+    }
+  }
+  return diff;
+}
+
 const DEFAULT_OPENAI_MODEL = 'gpt-4.1-mini';
-
-// 모델이 반드시 반환해야 하는 AnalysisCriteria JSON 형태를 고정한다.
-const REQUIRED_OUTPUT_SHAPE = {
-  analysis_type: 'comparison | ranking | null',
-  metric_id: 'string | null',
-  metric_type: 'string | null',
-  date_field: 'string | null',
-  period_standard: 'string | null',
-  period_compare: 'string | null',
-  sort_by: 'string | null',
-  sort_direction: 'asc | desc | null',
-  group_by: ['string'],
-  limit: 'number | null',
-  filters: [{ field: 'string', operator: 'string', value: 'unknown' }],
-  display_metrics: ['string'],
-  warnings: ['string'],
-  unsupported_reason: 'string | null',
-} as const;
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const rootDir = path.resolve(__dirname, '..');
 
-// 실행 시점에 .env를 읽어 API 키와 모델명을 주입한다.
 loadEnv({ path: path.join(rootDir, '.env') });
-
-type NormalizedCriteria = Required<AnalysisCriteria>;
-
-interface FieldAccuracyStat {
-  matched: number;
-  total: number;
-}
-
-interface ComparisonResult {
-  matchedFields: string[];
-  mismatchedFields: Array<{
-    field: string;
-    expected: unknown;
-    actual: unknown;
-  }>;
-}
 
 const fixturesPath = path.join(rootDir, 'fixtures', 'test-cases.json');
 const metricsPath = path.join(rootDir, 'fixtures', 'metrics.json');
@@ -64,418 +46,22 @@ const resultsDir = path.join(rootDir, 'public', 'results');
 const resultsJsonPath = path.join(resultsDir, 'latest-results.json');
 const consoleLogPath = path.join(resultsDir, 'latest-console.txt');
 
-// 콘솔 출력과 저장용 로그 배열을 항상 같은 내용으로 맞춘다.
 function emit(lines: string[], line = '') {
   lines.push(line);
   console.log(line);
 }
 
-// fixture와 결과 파일은 모두 JSON이므로 공용 로더를 사용한다.
 async function readJsonFile<T>(filePath: string): Promise<T> {
   const raw = await readFile(filePath, 'utf-8');
   return JSON.parse(raw) as T;
 }
 
-function asNullableString(value: unknown): string | null {
-  return typeof value === 'string' ? value : null;
-}
-
-// 모델이 한글/영문 기간 표현을 섞어서 반환해도 내부 비교 기준은 동일하게 맞춘다.
-function normalizePeriodValue(value: unknown): string | null {
-  if (typeof value !== 'string') {
-    return null;
-  }
-
-  const normalized = value.trim().toLowerCase();
-
-  if (['this_week', '이번 주', '금주'].includes(normalized)) {
-    return 'this_week';
-  }
-
-  if (['last_week', '지난주', '전주', 'previous_week'].includes(normalized)) {
-    return 'last_week';
-  }
-
-  return value;
-}
-
-// 배열 안에 문자열이 아닌 값이 섞여 있어도 비교 가능한 형태만 남긴다.
-function asStringArray(value: unknown): string[] {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-
-  return value.filter((item): item is string => typeof item === 'string');
-}
-
-// filter는 필드명과 연산자가 있어야만 유효한 값으로 인정한다.
-function normalizeFilters(value: unknown): AnalysisFilter[] {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-
-  return value.flatMap((item) => {
-    if (typeof item !== 'object' || item === null || Array.isArray(item)) {
-      return [];
-    }
-
-    const record = item as Record<string, unknown>;
-    if (typeof record.field !== 'string' || typeof record.operator !== 'string') {
-      return [];
-    }
-
-    return [
-      {
-        field: record.field,
-        operator: record.operator,
-        value: (record.value ?? null) as string | number | boolean,
-      },
-    ];
-  });
-}
-
-// 모델 응답을 테스트 비교용 표준 형태로 정리한다.
-function normalizeCriteria(value: unknown): NormalizedCriteria {
-  const record = typeof value === 'object' && value !== null && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : {};
-
-  return {
-    analysis_type:
-      record.analysis_type === 'comparison' || record.analysis_type === 'ranking'
-        ? record.analysis_type
-        : null,
-    metric_id: asNullableString(record.metric_id),
-    metric_type: asNullableString(record.metric_type),
-    date_field: asNullableString(record.date_field),
-    period_standard: normalizePeriodValue(record.period_standard),
-    period_compare: normalizePeriodValue(record.period_compare),
-    sort_by: asNullableString(record.sort_by),
-    sort_direction: record.sort_direction === 'asc' || record.sort_direction === 'desc' ? record.sort_direction : null,
-    group_by: asStringArray(record.group_by),
-    limit: typeof record.limit === 'number' && Number.isFinite(record.limit) ? record.limit : null,
-    filters: normalizeFilters(record.filters),
-    display_metrics: asStringArray(record.display_metrics),
-    warnings: asStringArray(record.warnings),
-    unsupported_reason: asNullableString(record.unsupported_reason),
-  };
-}
-
-// 객체 비교 시 키 순서 차이 때문에 오탐이 나지 않도록 정렬 후 비교한다.
-function sortObjectKeys(value: unknown): unknown {
-  if (Array.isArray(value)) {
-    return value.map(sortObjectKeys);
-  }
-
-  if (typeof value !== 'object' || value === null) {
-    return value;
-  }
-
-  return Object.keys(value as Record<string, unknown>)
-    .sort()
-    .reduce<Record<string, unknown>>((accumulator, key) => {
-      accumulator[key] = sortObjectKeys((value as Record<string, unknown>)[key]);
-      return accumulator;
-    }, {});
-}
-
-function isEqualValue(left: unknown, right: unknown): boolean {
-  return JSON.stringify(sortObjectKeys(left)) === JSON.stringify(sortObjectKeys(right));
-}
-
-// expected에는 일부 필드만 들어 있으므로 partial match 방식으로 비교한다.
-function compareExpected(expected: AnalysisCriteria, actual: NormalizedCriteria): ComparisonResult {
-  const matchedFields: string[] = [];
-  const mismatchedFields: ComparisonResult['mismatchedFields'] = [];
-
-  for (const [field, expectedValue] of Object.entries(expected)) {
-    const actualValue = actual[field as keyof NormalizedCriteria];
-
-    if (isEqualValue(expectedValue, actualValue)) {
-      matchedFields.push(field);
-      continue;
-    }
-
-    mismatchedFields.push({
-      field,
-      expected: expectedValue,
-      actual: actualValue,
-    });
-  }
-
-  return { matchedFields, mismatchedFields };
-}
-
-// 케이스별 데이터셋 스키마와 규칙을 프롬프트에 포함해 모델이 JSON으로만 답하게 한다.
-function buildPrompt(dataset: DatasetDefinition, metric: MetricDefinition, testCase: TestCase): string {
-  return JSON.stringify(
-    {
-      instructions: {
-        supported_analysis_types: ['comparison', 'ranking'],
-        preset_metric: {
-          id: metric.id,
-          formula: `${metric.id} = ${metric.numeratorField} / ${metric.denominatorField}`,
-          label: metric.businessLabel,
-          metric_type: metric.metricType,
-        },
-        semantic_roles: ['date', 'measure', 'dimension', 'status', 'flag', 'id'],
-        rules: [
-          'Return JSON only.',
-          'All keys in the required output shape must be present.',
-          'Use null for unavailable scalar values.',
-          'Use [] for empty arrays.',
-          'Use dataset field names exactly for date_field, group_by, and filters.field.',
-          'For ranking requests, sort_by should be metric_value.',
-          'For comparison requests about increase/decrease/drop versus a prior period, sort_by should be delta.',
-          'If the question asks where the value dropped the most, use sort_direction asc because the most negative delta should come first.',
-          'If the question mentions channel and device together, group_by should include both dimensions when both exist in the dataset.',
-          'If the dataset uses source instead of channel, map channel intent to source and add a warning saying 채널은 source로 매핑.',
-          'If the question asks top 5 or 5개, limit should be 5. If it asks for the single biggest drop, limit should be 1.',
-          'For comparison results about week-over-week drop, display_metrics should include conversion_rate and delta.',
-          'If a field required by the question does not exist in the dataset, set unsupported_reason to a concrete Korean explanation.',
-          'If date fields are ambiguous and one cannot be chosen safely, set unsupported_reason to a concrete Korean explanation.',
-          'unsupported_reason must be null when the request is supported.',
-          'When the dataset is ambiguous or lacks required fields, keep the best inferred intent but set unsupported_reason.',
-        ],
-        examples: [
-          {
-            question: '이번 주 가입 전환율이 가장 낮은 채널·디바이스 top 5를 보여줘',
-            result_hint: {
-              analysis_type: 'ranking',
-              sort_by: 'metric_value',
-              sort_direction: 'asc',
-              group_by: ['channel', 'device'],
-              limit: 5,
-            },
-          },
-          {
-            question: '이번 주 가입 전환율이 지난주 대비 어디에서 가장 많이 떨어졌어?',
-            result_hint: {
-              analysis_type: 'comparison',
-              sort_by: 'delta',
-              sort_direction: 'asc',
-              group_by: ['channel', 'device'],
-              limit: 1,
-              display_metrics: ['conversion_rate', 'delta'],
-            },
-          },
-          {
-            question: 'dataset C에서 이번 주 가입 전환율이 가장 낮은 채널 top 5를 보여줘',
-            result_hint: {
-              unsupported_reason: 'dataset C에는 기준 날짜 필드를 하나로 확정하기 어렵습니다.',
-            },
-          },
-          {
-            question: '신규/기존 유저별 가입 전환율 보여줘',
-            result_hint: {
-              unsupported_reason: '데이터셋에 신규/기존 유저를 구분하는 필드가 없습니다.',
-            },
-          },
-        ],
-      },
-      dataset_schema: {
-        id: dataset.id,
-        label: dataset.label,
-        description: dataset.description,
-        table_name: dataset.tableName,
-        date_fields: dataset.dateFields,
-        fields: dataset.fields,
-        sample_rows: dataset.sampleRows,
-      },
-      user_question: testCase.question,
-      required_output_shape: REQUIRED_OUTPUT_SHAPE,
-    },
-    null,
-    2,
-  );
-}
-
-function ensureUnique(values: string[]): string[] {
-  return [...new Set(values)];
-}
-
-function datasetHasField(dataset: DatasetDefinition, fieldName: string): boolean {
-  return dataset.fields.some((field) => field.name === fieldName);
-}
-
-// 테스트에서 반복적으로 틀리던 항목은 데모 안정성을 위해 최소한의 후처리로 보정한다.
-function applyDemoHeuristics(
-  criteria: NormalizedCriteria,
-  dataset: DatasetDefinition,
-  testCase: TestCase,
-): NormalizedCriteria {
-  const next: NormalizedCriteria = {
-    ...criteria,
-    group_by: [...criteria.group_by],
-    filters: [...criteria.filters],
-    display_metrics: [...criteria.display_metrics],
-    warnings: [...criteria.warnings],
-  };
-  const question = testCase.question;
-  const mentionsChannel = /채널/i.test(question);
-  const mentionsDevice = /디바이스/i.test(question);
-  const mentionsTop5 = /top\s*5|5개/i.test(question);
-  const mentionsBiggestDrop = /가장 많이 떨어|가장 많이 하락|크게 떨어진|하위/i.test(question);
-  const mentionsInternalTest = /internal_test/.test(question);
-  const isComparison = next.analysis_type === 'comparison';
-  const isRanking = next.analysis_type === 'ranking';
-
-  if (isRanking) {
-    next.sort_by = 'metric_value';
-  }
-
-  if (isComparison) {
-    next.sort_by = 'delta';
-    next.sort_direction = 'asc';
-    next.display_metrics = ensureUnique(['conversion_rate', 'delta']);
-    if (question.includes('가장')) {
-      next.limit = 1;
-    }
-  }
-
-  if (mentionsTop5) {
-    next.limit = 5;
-  }
-
-  if (mentionsChannel) {
-    if (datasetHasField(dataset, 'channel')) {
-      next.group_by.push('channel');
-    } else if (datasetHasField(dataset, 'source')) {
-      next.group_by.push('source');
-      next.warnings.push('채널은 source로 매핑');
-    }
-  }
-
-  if (mentionsDevice && datasetHasField(dataset, 'device')) {
-    next.group_by.push('device');
-  }
-
-  if (isComparison && mentionsBiggestDrop && next.group_by.length === 1) {
-    if (datasetHasField(dataset, 'device') && !next.group_by.includes('device')) {
-      next.group_by.push('device');
-    }
-  }
-
-  if (mentionsInternalTest && datasetHasField(dataset, 'account_flag')) {
-    next.filters = next.filters.filter((filter) => filter.field === 'account_flag');
-    next.filters = [
-      {
-        field: 'account_flag',
-        operator: '!=',
-        value: 'internal_test',
-      },
-    ];
-  }
-
-  if (/구간/.test(question) && isComparison) {
-    next.warnings.push('구간 표현이 다소 모호하지만 채널·디바이스 기준으로 해석');
-  }
-
-  if (dataset.id === 'dataset-c') {
-    next.warnings.push('날짜 필드가 모호함');
-    next.unsupported_reason = 'dataset C에는 기준 날짜 필드를 하나로 확정하기 어렵습니다.';
-  }
-
-  if (/신규\/기존 유저/.test(question) && !datasetHasField(dataset, 'user_type')) {
-    next.analysis_type = 'ranking';
-    next.metric_id = 'conversion_rate';
-    next.unsupported_reason = '데이터셋에 신규/기존 유저를 구분하는 필드가 없습니다.';
-    next.group_by = ['user_type'];
-  }
-
-  next.group_by = ensureUnique(next.group_by);
-  next.display_metrics = ensureUnique(next.display_metrics);
-  next.warnings = ensureUnique(next.warnings);
-
-  if (!next.unsupported_reason) {
-    next.unsupported_reason = null;
-  }
-
-  return next;
-}
-
-// OpenAI 호출은 로컬 스크립트 내부에서만 수행하며, 실패 시 각 케이스 단위로 기록한다.
-async function requestAnalysisCriteria(
-  client: OpenAI,
-  model: string,
-  dataset: DatasetDefinition,
-  metric: MetricDefinition,
-  testCase: TestCase,
-): Promise<NormalizedCriteria> {
-  const completion = await client.chat.completions.create({
-    model,
-    temperature: 0,
-    response_format: { type: 'json_object' },
-    messages: [
-      {
-        role: 'system',
-        content: [
-          'You convert a Korean analytics question into AnalysisCriteria JSON.',
-          'Supported analysis types are comparison and ranking only.',
-          'Return JSON only and do not wrap it in markdown.',
-        ].join(' '),
-      },
-      {
-        role: 'user',
-        content: buildPrompt(dataset, metric, testCase),
-      },
-    ],
-  });
-
-  const content = completion.choices[0]?.message?.content;
-  if (!content) {
-    throw new Error('OpenAI returned empty content.');
-  }
-
-  let parsed: unknown;
-
-  try {
-    parsed = JSON.parse(content);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unknown JSON parse error';
-    throw new Error(`Failed to parse JSON response: ${message}`);
-  }
-
-  return applyDemoHeuristics(normalizeCriteria(parsed), dataset, testCase);
-}
-
-
-// 필드별 정확도 표를 만들기 위해 기대 필드 목록을 먼저 수집한다.
-function createEmptyFieldAccuracy(expectedCases: TestCase[]): Record<string, FieldAccuracyStat> {
-  const stats: Record<string, FieldAccuracyStat> = {};
-
-  for (const testCase of expectedCases) {
-    for (const field of Object.keys(testCase.expected)) {
-      if (!stats[field]) {
-        stats[field] = { matched: 0, total: 0 };
-      }
-    }
-  }
-
-  return stats;
-}
-
-function finalizeFieldAccuracy(stats: Record<string, FieldAccuracyStat>) {
-  return Object.fromEntries(
-    Object.entries(stats).map(([field, value]) => [
-      field,
-      {
-        matched: value.matched,
-        total: value.total,
-        accuracy: value.total === 0 ? 0 : Number((value.matched / value.total).toFixed(4)),
-      },
-    ]),
-  );
-}
-
-// 프런트가 바로 읽을 수 있도록 JSON 결과와 텍스트 로그를 동시에 저장한다.
 async function writeArtifacts(results: SavedResults, lines: string[]) {
   await mkdir(resultsDir, { recursive: true });
   await writeFile(resultsJsonPath, JSON.stringify(results, null, 2), 'utf-8');
   await writeFile(consoleLogPath, `${lines.join('\n')}\n`, 'utf-8');
 }
 
-// 전체 실행 흐름: 환경 확인 -> fixture 로드 -> OpenAI 호출 -> 비교 -> 결과 저장
 async function main() {
   const generatedAt = new Date().toISOString();
   const lines: string[] = [];
@@ -483,18 +69,14 @@ async function main() {
   const model = process.env.OPENAI_MODEL || DEFAULT_OPENAI_MODEL;
 
   if (!apiKey) {
-    const message = 'Missing OPENAI_API_KEY. Create a .env file from .env.example and set OPENAI_API_KEY before running npm run ai:test.';
+    const message =
+      'Missing OPENAI_API_KEY. Create a .env file from .env.example and set OPENAI_API_KEY before running npm run ai:test.';
     const errorResults: SavedResults = {
       generatedAt,
       phase: 'phase-2-evaluation',
       status: 'configuration_error',
       model,
-      summary: {
-        total: 0,
-        passed: 0,
-        failed: 0,
-        field_accuracy: {},
-      },
+      summary: { total: 0, passed: 0, failed: 0, field_accuracy: {} },
       items: [],
     };
 
@@ -524,17 +106,20 @@ async function main() {
   ]);
 
   const client = new OpenAI({ apiKey });
+  const systemPrompt = buildSystemPrompt(metric);
   const fieldAccuracy = createEmptyFieldAccuracy(testCases);
   const items: SavedResultItem[] = [];
   let passed = 0;
   let failed = 0;
 
+  const totalUsage: TokenUsage = { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 };
+
   emit(lines, `[${generatedAt}] AI analysis test run started`);
   emit(lines, `Model: ${model}`);
   emit(lines, `Metric preset: ${metric.id} (${metric.businessLabel})`);
   emit(lines, `Loaded ${testCases.length} test cases.`);
+  emit(lines, `System prompt length: ${systemPrompt.length} chars`);
 
-  // 케이스별 실패가 있어도 전체 러너는 끝까지 진행해 집계 결과를 남긴다.
   for (const testCase of testCases) {
     const dataset = datasets.get(testCase.datasetId);
     if (!dataset) {
@@ -545,15 +130,11 @@ async function main() {
         question: testCase.question,
         status: 'failed',
         expected_partial: testCase.expected,
+        raw_criteria: null,
         actual_criteria: null,
         matched_fields: [],
-        mismatched_fields: [
-          {
-            field: 'datasetId',
-            expected: testCase.datasetId,
-            actual: null,
-          },
-        ],
+        mismatched_fields: [{ field: 'datasetId', expected: testCase.datasetId, actual: null }],
+        heuristics_diff: [],
         error: missingDatasetError,
       });
       failed += 1;
@@ -565,13 +146,20 @@ async function main() {
       continue;
     }
 
-    let actualCriteria: NormalizedCriteria | null = null;
+    let rawCriteria: NormalizedCriteria | null = null;
+    let correctedCriteria: NormalizedCriteria | null = null;
     let comparison: ComparisonResult = { matchedFields: [], mismatchedFields: [] };
+    let heuristicsDiff: Array<{ field: string; raw: unknown; corrected: unknown }> = [];
     let caseError: string | null = null;
+    let caseUsage: TokenUsage = { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 };
 
     try {
-      actualCriteria = await requestAnalysisCriteria(client, model, dataset, metric, testCase);
-      comparison = compareExpected(testCase.expected, actualCriteria);
+      const result: AnalysisResult = await requestAnalysisCriteria(client, model, systemPrompt, dataset, testCase);
+      rawCriteria = result.raw;
+      correctedCriteria = result.corrected;
+      caseUsage = result.usage;
+      heuristicsDiff = computeHeuristicsDiff(rawCriteria, correctedCriteria);
+      comparison = compareExpected(testCase.expected, correctedCriteria);
     } catch (error) {
       caseError = error instanceof Error ? error.message : 'Unknown error';
       comparison = {
@@ -583,6 +171,10 @@ async function main() {
         })),
       };
     }
+
+    totalUsage.prompt_tokens += caseUsage.prompt_tokens;
+    totalUsage.completion_tokens += caseUsage.completion_tokens;
+    totalUsage.total_tokens += caseUsage.total_tokens;
 
     for (const field of Object.keys(testCase.expected)) {
       fieldAccuracy[field] ??= { matched: 0, total: 0 };
@@ -607,9 +199,11 @@ async function main() {
       question: testCase.question,
       status,
       expected_partial: testCase.expected,
-      actual_criteria: actualCriteria,
+      raw_criteria: rawCriteria,
+      actual_criteria: correctedCriteria,
       matched_fields: comparison.matchedFields,
       mismatched_fields: comparison.mismatchedFields,
+      heuristics_diff: heuristicsDiff,
       error: caseError,
     });
 
@@ -617,11 +211,32 @@ async function main() {
     emit(lines, `=== ${testCase.id} | ${status.toUpperCase()} ===`);
     emit(lines, `Dataset: ${dataset.id} (${dataset.label})`);
     emit(lines, `Question: ${testCase.question}`);
+    emit(
+      lines,
+      `Tokens: prompt=${caseUsage.prompt_tokens} completion=${caseUsage.completion_tokens} total=${caseUsage.total_tokens}`,
+    );
     emit(lines, 'Expected partial criteria:');
     emit(lines, JSON.stringify(testCase.expected, null, 2));
-    emit(lines, 'Actual criteria:');
-    emit(lines, JSON.stringify(actualCriteria, null, 2));
-    emit(lines, `Matched fields: ${comparison.matchedFields.length > 0 ? comparison.matchedFields.join(', ') : '-'}`);
+    emit(lines, 'Raw criteria (model only):');
+    emit(lines, JSON.stringify(rawCriteria, null, 2));
+    emit(lines, 'Corrected criteria (after heuristics):');
+    emit(lines, JSON.stringify(correctedCriteria, null, 2));
+
+    if (heuristicsDiff.length > 0) {
+      emit(lines, `Heuristics corrections (${heuristicsDiff.length} field(s)):`);
+      for (const diff of heuristicsDiff) {
+        emit(lines, `- ${diff.field}`);
+        emit(lines, `  raw:       ${JSON.stringify(diff.raw)}`);
+        emit(lines, `  corrected: ${JSON.stringify(diff.corrected)}`);
+      }
+    } else {
+      emit(lines, 'Heuristics corrections: none');
+    }
+
+    emit(
+      lines,
+      `Matched fields: ${comparison.matchedFields.length > 0 ? comparison.matchedFields.join(', ') : '-'}`,
+    );
     emit(
       lines,
       `Mismatched fields: ${comparison.mismatchedFields.length > 0 ? comparison.mismatchedFields.map((item) => item.field).join(', ') : '-'}`,
@@ -662,6 +277,19 @@ async function main() {
   emit(lines, `Failed cases: ${results.summary.failed}`);
   emit(lines, 'Field-level accuracy:');
   emit(lines, JSON.stringify(results.summary.field_accuracy, null, 2));
+  emit(lines);
+  emit(lines, '=== TOKEN USAGE ===');
+  emit(lines, `Total prompt tokens:     ${totalUsage.prompt_tokens}`);
+  emit(lines, `Total completion tokens:  ${totalUsage.completion_tokens}`);
+  emit(lines, `Total tokens:            ${totalUsage.total_tokens}`);
+  emit(
+    lines,
+    `Avg prompt tokens/case:  ${testCases.length > 0 ? Math.round(totalUsage.prompt_tokens / testCases.length) : 0}`,
+  );
+  emit(
+    lines,
+    `Avg total tokens/case:   ${testCases.length > 0 ? Math.round(totalUsage.total_tokens / testCases.length) : 0}`,
+  );
 
   await writeArtifacts(results, lines);
 }

--- a/test/src/App.tsx
+++ b/test/src/App.tsx
@@ -142,10 +142,11 @@ export default function App() {
     // 프런트는 OpenAI를 직접 호출하지 않고 저장된 결과 파일만 읽는다.
     async function loadSavedArtifacts() {
       try {
+        const cacheBuster = `?t=${Date.now()}`;
         const [resultsJson, consoleOutput] = await Promise.all([
-          fetchJsonOrNull<SavedResults>(toBaseUrl('results/latest-results.json')),
+          fetchJsonOrNull<SavedResults>(toBaseUrl('results/latest-results.json') + cacheBuster),
           fetchTextOrFallback(
-            toBaseUrl('results/latest-console.txt'),
+            toBaseUrl('results/latest-console.txt') + cacheBuster,
             '아직 저장된 콘솔 로그가 없습니다. 먼저 npm run ai:test 를 실행하세요.',
           ),
         ]);
@@ -364,8 +365,8 @@ export default function App() {
                   </div>
                 </div>
 
-                {/* expected / actual JSON을 나란히 보여줘 모델 출력을 바로 비교할 수 있게 한다. */}
-                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 14 }}>
+                {/* expected / raw / corrected JSON을 나란히 보여줘 모델 출력과 후처리 효과를 분리 확인한다. */}
+                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 14 }}>
                   <div style={softBlockStyle}>
                     <strong>기대 partial criteria</strong>
                     <div style={{ marginTop: 12 }}>
@@ -373,12 +374,40 @@ export default function App() {
                     </div>
                   </div>
                   <div style={softBlockStyle}>
-                    <strong>실제 criteria</strong>
+                    <strong>Raw criteria <span style={{ ...pillStyle, fontSize: 11, background: '#e3e8de' }}>모델 원본</span></strong>
+                    <div style={{ marginTop: 12 }}>
+                      <JsonBlock value={selectedResult?.raw_criteria ?? null} emptyText="아직 실행 결과가 없습니다." />
+                    </div>
+                  </div>
+                  <div style={softBlockStyle}>
+                    <strong>Corrected criteria <span style={{ ...pillStyle, fontSize: 11, background: '#dcead2' }}>후처리 적용</span></strong>
                     <div style={{ marginTop: 12 }}>
                       <JsonBlock value={selectedResult?.actual_criteria ?? null} emptyText="아직 실행 결과가 없습니다." />
                     </div>
                   </div>
                 </div>
+
+                {selectedResult?.heuristics_diff && selectedResult.heuristics_diff.length > 0 ? (
+                  <div style={{ ...softBlockStyle, border: '1px solid #c9dbc1' }}>
+                    <strong>Heuristics 보정 내역 <span style={{ ...pillStyle, fontSize: 11, background: '#fef3cd', color: '#664d03' }}>{selectedResult.heuristics_diff.length}개 필드</span></strong>
+                    <div style={{ display: 'grid', gap: 10, marginTop: 12 }}>
+                      {selectedResult.heuristics_diff.map((diff) => (
+                        <div key={diff.field} style={{ background: '#ffffff', borderRadius: 12, padding: 12, border: '1px solid #d7dfd4' }}>
+                          <div style={{ fontWeight: 700, color: '#664d03' }}>{diff.field}</div>
+                          <div style={{ marginTop: 8, fontSize: 13, color: '#556b50' }}>raw (모델 원본)</div>
+                          <pre style={{ ...codeBlockStyle, marginTop: 6 }}>{JSON.stringify(diff.raw, null, 2)}</pre>
+                          <div style={{ marginTop: 8, fontSize: 13, color: '#556b50' }}>corrected (후처리)</div>
+                          <pre style={{ ...codeBlockStyle, marginTop: 6 }}>{JSON.stringify(diff.corrected, null, 2)}</pre>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                ) : selectedResult ? (
+                  <div style={{ ...softBlockStyle, border: '1px solid #d7dfd4', color: '#556b50' }}>
+                    <strong style={{ color: '#20331b' }}>Heuristics 보정 내역</strong>
+                    <p style={{ margin: '8px 0 0' }}>후처리로 변경된 필드가 없습니다. 모델 원본 출력이 그대로 사용되었습니다.</p>
+                  </div>
+                ) : null}
 
                 {/* 일치/불일치 필드는 발표 중 원인 설명이 쉽도록 별도 영역으로 분리한다. */}
                 <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 14 }}>

--- a/test/src/types.ts
+++ b/test/src/types.ts
@@ -75,12 +75,18 @@ export interface SavedResultItem {
   question: string;
   status: 'passed' | 'failed';
   expected_partial: AnalysisCriteria;
+  raw_criteria: AnalysisCriteria | null;
   actual_criteria: AnalysisCriteria | null;
   matched_fields: string[];
   mismatched_fields: Array<{
     field: string;
     expected: unknown;
     actual: unknown;
+  }>;
+  heuristics_diff: Array<{
+    field: string;
+    raw: unknown;
+    corrected: unknown;
   }>;
   error: string | null;
 }


### PR DESCRIPTION
## 요약
- AI 테스트 러너(`run-analysis-tests.ts`)를 6개 모듈로 분리하여 유지보수성과 가독성을 개선하고, 토큰 최적화(스키마 축약,샘플 제한,system/user 분리)을 적용하여 12케이스 1회 실행 비용 절감
- 
스크립트의 유지보수성과 가독성을 높이기 위해 기존 단일 파일(run-analysis-tests.ts)을 책임별로 6개 모듈(prompt.ts, client.ts, normalize.ts, heuristics.ts, compare.ts, types.ts)로 분리했습니다. 프롬프트 빌더, OpenAI API 호출, 응답 정규화, 데모 후처리, 기대값 비교, 타입 정의를 각각 독립된 파일로 나누어 역할이 명확하게 드러나도록 구조를 개선했습니다.

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [x] 리팩토링
- [x] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  yarn demo

## 스크린샷/로그 (선택)
- 필요한 경우 첨부

## 관련 이슈
Closes #15 
