### PR TITLE
feat: add login API

### DIFF
--- a/apps/be/build.gradle
+++ b/apps/be/build.gradle
@@ -24,20 +24,38 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
+	//Web
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
+
+	//DB (JPA+PostgreSQL)
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	runtimeOnly 'org.postgresql:postgresql'
+
+	//DB Migration (Flyway)
 	implementation 'org.flywaydb:flyway-core'
 	implementation 'org.flywaydb:flyway-database-postgresql'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
+
+	//redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	//actuator
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	
+	//Lombok
 	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
+	
+	//test runtime
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	//OAuth 2.0
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+	//Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/apps/be/build.gradle
+++ b/apps/be/build.gradle
@@ -56,6 +56,11 @@ dependencies {
 	//Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	testImplementation 'org.springframework.security:spring-security-test'
+
+	//JWT (토큰 생성 및 검증)
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/apps/be/src/main/java/com/capstone/logue/auth/dto/GoogleUserInfo.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/dto/GoogleUserInfo.java
@@ -4,6 +4,21 @@ import lombok.AllArgsConstructor;
 
 import java.util.Map;
 
+/**
+ * Google OAuth2 인증을 통해 전달받은 사용자 정보를 추상화한 구현체입니다.
+ *
+ * <p>Spring Security OAuth2 로그인 과정에서 제공되는 attribute(Map)를 기반으로
+ * Google 사용자 정보(provider, id, email, name, profile image)를 추출합니다.</p>
+ *
+ * <p>각 필드는 Google의 표준 OpenID Connect(OIDC) 클레임을 따릅니다:
+ * <ul>
+ *     <li>sub: 사용자 고유 식별자</li>
+ *     <li>email: 사용자 이메일</li>
+ *     <li>name: 사용자 이름</li>
+ *     <li>picture: 프로필 이미지 URL</li>
+ * </ul>
+ * </p>
+ */
 @AllArgsConstructor
 public class GoogleUserInfo implements OAuth2UserInfo {
 

--- a/apps/be/src/main/java/com/capstone/logue/auth/dto/GoogleUserInfo.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/dto/GoogleUserInfo.java
@@ -30,7 +30,7 @@ public class GoogleUserInfo implements OAuth2UserInfo {
     }
 
     @Override
-    public String getProviderId() {
+    public String getProviderUserId() {
         return attribute.get("sub").toString();
     }
 

--- a/apps/be/src/main/java/com/capstone/logue/auth/dto/GoogleUserInfo.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/dto/GoogleUserInfo.java
@@ -1,0 +1,36 @@
+package com.capstone.logue.auth.dto;
+
+import lombok.AllArgsConstructor;
+
+import java.util.Map;
+
+@AllArgsConstructor
+public class GoogleUserInfo implements OAuth2UserInfo {
+
+    private final Map<String, Object> attribute;
+
+    @Override
+    public String getProvider() {
+        return "google";
+    }
+
+    @Override
+    public String getProviderId() {
+        return attribute.get("sub").toString();
+    }
+
+    @Override
+    public String getEmail() {
+        return attribute.get("email").toString();
+    }
+
+    @Override
+    public String getName() {
+        return attribute.get("name").toString();
+    }
+
+    @Override
+    public String getProfileImageUrl() {
+        return attribute.get("picture").toString();
+    }
+}

--- a/apps/be/src/main/java/com/capstone/logue/auth/dto/OAuth2UserInfo.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/dto/OAuth2UserInfo.java
@@ -1,0 +1,14 @@
+package com.capstone.logue.auth.dto;
+
+public interface OAuth2UserInfo {
+    //provider
+    String getProvider();
+    //provider가 발급해주는 고유 아이디
+    String getProviderId();
+    //email
+    String getEmail();
+    //name
+    String getName();
+    //profile image
+    String getProfileImageUrl();
+}

--- a/apps/be/src/main/java/com/capstone/logue/auth/dto/OAuth2UserInfo.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/dto/OAuth2UserInfo.java
@@ -26,7 +26,7 @@ public interface OAuth2UserInfo {
      *
      * @return provider 고유 사용자 ID
      */
-    String getProviderId();
+    String getProviderUserId();
 
     /**
      * 사용자 이메일을 반환합니다.

--- a/apps/be/src/main/java/com/capstone/logue/auth/dto/OAuth2UserInfo.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/dto/OAuth2UserInfo.java
@@ -1,14 +1,51 @@
 package com.capstone.logue.auth.dto;
 
+/**
+ * OAuth2 제공자별 사용자 정보를 공통 인터페이스로 추상화합니다.
+ *
+ * <p>Google, Kakao, Naver 등 다양한 OAuth2 제공자마다 응답 구조가 다르기 때문에,
+ * 이를 통일된 방식으로 처리하기 위해 사용됩니다.</p>
+ *
+ * <p>각 구현체는 provider별 attribute 구조에 맞게 데이터를 파싱하여,
+ * 아래 메서드들을 통해 표준화된 사용자 정보를 반환해야 합니다.</p>
+ */
 public interface OAuth2UserInfo {
-    //provider
+
+    /**
+     * OAuth 제공자 이름을 반환합니다.
+     *
+     * @return 예: "google", "kakao", "naver"
+     */
     String getProvider();
-    //provider가 발급해주는 고유 아이디
+
+    /**
+     * OAuth 제공자가 발급한 사용자 고유 식별자를 반환합니다.
+     *
+     * <p>provider 내부에서 유일한 값으로,
+     * 서비스 내부 사용자 식별 키로 활용됩니다.</p>
+     *
+     * @return provider 고유 사용자 ID
+     */
     String getProviderId();
-    //email
+
+    /**
+     * 사용자 이메일을 반환합니다.
+     *
+     * @return 이메일 주소
+     */
     String getEmail();
-    //name
+
+    /**
+     * 사용자 이름을 반환합니다.
+     *
+     * @return 사용자 이름
+     */
     String getName();
-    //profile image
+
+    /**
+     * 사용자 프로필 이미지 URL을 반환합니다.
+     *
+     * @return 프로필 이미지 URL
+     */
     String getProfileImageUrl();
 }

--- a/apps/be/src/main/java/com/capstone/logue/auth/filter/JWTFilter.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/filter/JWTFilter.java
@@ -14,19 +14,47 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+/**
+ * JWT 기반 인증을 처리하는 Spring Security 필터입니다.
+ *
+ * <p>요청 헤더의 Authorization 값에서 Bearer 토큰을 추출한 뒤,
+ * 토큰 유효성을 검증하고 사용자 ID를 파싱하여
+ * {@link SecurityContextHolder}에 인증 정보를 설정합니다.</p>
+ *
+ * <p>토큰이 없으면 인증 없이 다음 필터로 넘기며,
+ * 토큰 검증 중 {@link LogueException}이 발생하면 JSON 형식의 에러 응답을 반환합니다.</p>
+ */
 @Slf4j
 @RequiredArgsConstructor
 public class JWTFilter extends OncePerRequestFilter {
 
+    /** Authorization 헤더 이름 */
     private static final String AUTHORIZATION_HEADER = "Authorization";
+
+    /** Bearer 토큰 접두사 */
     private static final String BEARER_PREFIX = "Bearer ";
 
+    /** JWT 생성, 검증, 파싱을 담당하는 provider */
     private final JWTProvider jwtProvider;
 
+
+    /**
+     * JWT 인증 필터의 핵심 로직입니다.
+     *
+     * <p>요청 헤더에서 access token을 추출하고,
+     * 토큰이 존재하면 유효성 검증 후 사용자 인증 정보를 SecurityContext에 저장합니다.
+     * 토큰이 없으면 인증 없이 다음 필터로 넘깁니다.</p>
+     *
+     * @param request HTTP 요청
+     * @param response HTTP 응답
+     * @param filterChain 다음 필터 체인
+     * @throws ServletException 서블릿 처리 중 예외 발생 시
+     * @throws IOException 입출력 예외 발생 시
+     */
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         try {
-            String accessToken = resolveAccessToken(request);  // 쿠키에서 JWT를 가져온다.
+            String accessToken = resolveAccessToken(request);  // Authorization 헤더에서 JWT를 가져온다.
 
             //토큰이 없으면 인증 없이 다음 필터로 넘김
             if (accessToken == null) {
@@ -44,7 +72,16 @@ public class JWTFilter extends OncePerRequestFilter {
         }
     }
 
-    @Override // 필터에 걸리지 않기 위한 경로들 추가
+    /**
+     * JWT 인증 필터를 적용하지 않을 경로를 지정합니다.
+     *
+     * <p>루트, 헬스 체크, 에러 페이지, OAuth2 로그인 관련 경로,
+     * Swagger 문서 경로 등은 JWT 인증 없이 접근할 수 있도록 제외합니다.</p>
+     *
+     * @param request HTTP 요청
+     * @return 필터 적용 제외 여부
+     */
+    @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String path = request.getServletPath();
         return path.equals("/")
@@ -54,6 +91,14 @@ public class JWTFilter extends OncePerRequestFilter {
                 ;
     }
 
+    /**
+     * Authorization 헤더에서 Bearer access token을 추출합니다.
+     *
+     * <p>헤더가 없거나 Bearer 형식이 아니면 null을 반환합니다.</p>
+     *
+     * @param request HTTP 요청
+     * @return 추출된 access token, 없으면 null
+     */
     private String resolveAccessToken(HttpServletRequest request) {
         String authorizationHeader  = request.getHeader(AUTHORIZATION_HEADER);
 
@@ -63,19 +108,32 @@ public class JWTFilter extends OncePerRequestFilter {
         return authorizationHeader.substring(BEARER_PREFIX.length());
     }
 
-    // 인증 정보 설정 메서드
+    /**
+     * 사용자 ID를 기반으로 인증 객체를 생성하고 SecurityContext에 저장합니다.
+     *
+     * @param userId 인증된 사용자 ID
+     */
     private void setAuthentication(Long userId) {
-        UserAuthentication authentication = new UserAuthentication(userId, null, null);  // 인증 객체 생성
-        SecurityContextHolder.getContext().setAuthentication(authentication);  // SecurityContext에 인증 정보 저장
+        UserAuthentication authentication = new UserAuthentication(userId, null, null);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 
-    // 예외 처리 메서드
+    /**
+     * JWT 인증 과정에서 발생한 커스텀 예외를 JSON 응답으로 변환합니다.
+     *
+     * <p>에러 코드와 메시지를 포함한 응답 본문을 작성하며,
+     * HTTP 상태 코드는 {@link LogueException}의 ErrorCode를 따릅니다.</p>
+     *
+     * @param response HTTP 응답
+     * @param e 발생한 커스텀 예외
+     * @throws IOException 응답 작성 중 예외 발생 시
+     */
     private void handleCustomException(HttpServletResponse response, LogueException e) throws IOException {
         log.warn("JWT 인증 실패: {}", e.getMessage());
-        response.setStatus(e.getErrorCode().getHttpStatus().value());  // 상태 코드 설정
+        response.setStatus(e.getErrorCode().getHttpStatus().value());
         response.setContentType("application/json");
         String jsonResponse = String.format("{\"code\": \"%s\", \"message\": \"%s\",\"data\":null}", e.getErrorCode().getCode(), e.getErrorCode().getMessage());
-        response.getWriter().write(jsonResponse);  // JSON 형식으로 예외 응답
+        response.getWriter().write(jsonResponse);
     }
 
 }

--- a/apps/be/src/main/java/com/capstone/logue/auth/filter/JWTFilter.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/filter/JWTFilter.java
@@ -1,0 +1,81 @@
+package com.capstone.logue.auth.filter;
+
+import com.capstone.logue.auth.provider.JWTProvider;
+import com.capstone.logue.auth.security.UserAuthentication;
+import com.capstone.logue.global.exception.LogueException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JWTFilter extends OncePerRequestFilter {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JWTProvider jwtProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            String accessToken = resolveAccessToken(request);  // 쿠키에서 JWT를 가져온다.
+
+            //토큰이 없으면 인증 없이 다음 필터로 넘김
+            if (accessToken == null) {
+                filterChain.doFilter(request,response);
+                return;
+            }
+
+            jwtProvider.validateToken(accessToken);  // JWT 유효성 검증
+            Long userId = jwtProvider.getUserIdFromToken(accessToken);  // JWT에서 사용자 ID 추출
+            setAuthentication(userId);  // 인증 정보 설정
+            filterChain.doFilter(request, response);  // 필터 체인 통과
+
+        } catch (LogueException e) {
+            handleCustomException(response, e);
+        }
+    }
+
+    @Override // 필터에 걸리지 않기 위한 경로들 추가
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getServletPath();
+        return path.equals("/")
+                || path.equals("/health") || path.equals("/error")
+                || path.startsWith("/oauth2") || path.startsWith("/login/oauth2/")
+                || path.startsWith("/swagger-ui/") || path.startsWith("/v3/api-docs")
+                ;
+    }
+
+    private String resolveAccessToken(HttpServletRequest request) {
+        String authorizationHeader  = request.getHeader(AUTHORIZATION_HEADER);
+
+        if (authorizationHeader == null || !authorizationHeader.startsWith(BEARER_PREFIX))
+            return null;
+
+        return authorizationHeader.substring(BEARER_PREFIX.length());
+    }
+
+    // 인증 정보 설정 메서드
+    private void setAuthentication(Long userId) {
+        UserAuthentication authentication = new UserAuthentication(userId, null, null);  // 인증 객체 생성
+        SecurityContextHolder.getContext().setAuthentication(authentication);  // SecurityContext에 인증 정보 저장
+    }
+
+    // 예외 처리 메서드
+    private void handleCustomException(HttpServletResponse response, LogueException e) throws IOException {
+        log.warn("JWT 인증 실패: {}", e.getMessage());
+        response.setStatus(e.getErrorCode().getHttpStatus().value());  // 상태 코드 설정
+        response.setContentType("application/json");
+        String jsonResponse = String.format("{\"code\": \"%s\", \"message\": \"%s\",\"data\":null}", e.getErrorCode().getCode(), e.getErrorCode().getMessage());
+        response.getWriter().write(jsonResponse);  // JSON 형식으로 예외 응답
+    }
+
+}

--- a/apps/be/src/main/java/com/capstone/logue/auth/handler/OAuth2LoginFailureHandler.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/handler/OAuth2LoginFailureHandler.java
@@ -1,0 +1,23 @@
+package com.capstone.logue.auth.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws ServletException, IOException {
+        log.error("LOGIN FAILED : {}", exception.getMessage());
+        super.onAuthenticationFailure(request, response, exception);
+    }
+}

--- a/apps/be/src/main/java/com/capstone/logue/auth/handler/OAuth2LoginFailureHandler.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/handler/OAuth2LoginFailureHandler.java
@@ -11,10 +11,33 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
+/**
+ * OAuth2 로그인 실패 시 동작을 정의하는 핸들러입니다.
+ *
+ * <p>Spring Security의 OAuth2 로그인 과정에서 인증에 실패하면 호출되며,
+ * 실패 원인을 로그로 기록한 후 기본 실패 처리 로직을 수행합니다.</p>
+ *
+ * <p>기본적으로 {@link SimpleUrlAuthenticationFailureHandler}를 상속하여
+ * redirect 또는 에러 응답 처리를 그대로 유지하면서,
+ * 추가적인 로깅을 수행하기 위해 사용됩니다.</p>
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class OAuth2LoginFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    /**
+     * OAuth2 인증 실패 시 호출되는 메서드입니다.
+     *
+     * <p>실패 원인을 로그로 남기고,
+     * 부모 클래스의 기본 실패 처리 로직을 수행합니다.</p>
+     *
+     * @param request HTTP 요청
+     * @param response HTTP 응답
+     * @param exception 인증 실패 예외
+     * @throws ServletException 서블릿 처리 중 예외 발생 시
+     * @throws IOException 입출력 예외 발생 시
+     */
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws ServletException, IOException {
         log.error("LOGIN FAILED : {}", exception.getMessage());

--- a/apps/be/src/main/java/com/capstone/logue/auth/handler/OAuth2LoginSuccessHandler.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/handler/OAuth2LoginSuccessHandler.java
@@ -20,26 +20,66 @@ import org.springframework.web.util.UriComponentsBuilder;
 import java.io.IOException;
 import java.util.Map;
 
+/**
+ * OAuth2 로그인 성공 시 후속 처리를 담당하는 핸들러입니다.
+ *
+ * <p>인증된 OAuth2 사용자 정보를 provider별 DTO로 변환한 뒤,
+ * 기존 회원 여부를 조회하여 다음과 같이 분기 처리합니다.</p>
+ *
+ * <ul>
+ *     <li>신규 사용자: 온보딩 페이지로 리다이렉트</li>
+ *     <li>기존 사용자: access token 발급 후 메인 페이지로 리다이렉트</li>
+ * </ul>
+ *
+ * <p>현재는 Google OAuth2 로그인을 지원하며,
+ * provider별 사용자 정보 파싱은 {@link OAuth2UserInfo} 구현체를 통해 수행합니다.</p>
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
+    /** 신규 사용자 온보딩 페이지 리다이렉트 URI */
     @Value("${spring.jwt.redirect.onboarding}")
     private String REDIRECT_URI_ONBOARDING;
+
+    /** 기존 사용자 로그인 성공 후 리다이렉트할 기본 URI */
     @Value("${spring.jwt.redirect.base}")
     private String REDIRECT_URI_BASE;
 
-//    @Value("${spring.jwt.register-token.expiration-time}")
-//    private long REGISTER_TOKEN_EXPIRATION_TIME;
+    /** access token 만료 시간 */
     @Value("${spring.jwt.access-token.expiration-time}")
     private long ACCESS_TOKEN_EXPIRATION_TIME;
+
+//    @Value("${spring.jwt.register-token.expiration-time}")
+//    private long REGISTER_TOKEN_EXPIRATION_TIME;
 //    @Value("${spring.jwt.refresh-token.expiration-time}")
 //    private long REFRESH_TOKEN_EXPIRATION_TIME;
 
+    /** JWT 생성 및 파싱을 담당하는 provider */
     private final JWTProvider jwtProvider;
+
+    /** 사용자 조회를 위한 repository */
     private final UserRepository userRepository;
 
+
+    /**
+     * OAuth2 로그인 성공 시 호출되는 메서드입니다.
+     *
+     * <p>OAuth2 인증 객체에서 provider와 사용자 속성을 추출한 뒤,
+     * provider에 맞는 {@link OAuth2UserInfo} 구현체로 변환합니다.
+     * 이후 providerId를 기준으로 기존 회원 여부를 조회하여 다음과 같이 처리합니다.</p>
+     *
+     * <ul>
+     *     <li>신규 사용자이면 온보딩 페이지로 리다이렉트</li>
+     *     <li>기존 사용자이면 access token을 발급하여 메인 페이지로 리다이렉트</li>
+     * </ul>
+     *
+     * @param request HTTP 요청
+     * @param response HTTP 응답
+     * @param authentication Spring Security 인증 객체
+     * @throws IOException 리다이렉트 처리 중 입출력 예외 발생 시
+     */
     @Override
     @Transactional
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {

--- a/apps/be/src/main/java/com/capstone/logue/auth/handler/OAuth2LoginSuccessHandler.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/handler/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,92 @@
+package com.capstone.logue.auth.handler;
+
+import com.capstone.logue.auth.provider.JWTProvider;
+import com.capstone.logue.global.entity.User;
+import com.capstone.logue.auth.dto.GoogleUserInfo;
+import com.capstone.logue.auth.dto.OAuth2UserInfo;
+import com.capstone.logue.user.repository.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    @Value("${spring.jwt.redirect.onboarding}")
+    private String REDIRECT_URI_ONBOARDING;
+    @Value("${spring.jwt.redirect.base}")
+    private String REDIRECT_URI_BASE;
+
+//    @Value("${spring.jwt.register-token.expiration-time}")
+//    private long REGISTER_TOKEN_EXPIRATION_TIME;
+    @Value("${spring.jwt.access-token.expiration-time}")
+    private long ACCESS_TOKEN_EXPIRATION_TIME;
+//    @Value("${spring.jwt.refresh-token.expiration-time}")
+//    private long REFRESH_TOKEN_EXPIRATION_TIME;
+
+    private final JWTProvider jwtProvider;
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
+        OAuth2AuthenticationToken token = (OAuth2AuthenticationToken) authentication;
+        final String provider = token.getAuthorizedClientRegistrationId();
+        final Map<String, Object> attributes = token.getPrincipal().getAttributes();
+
+        OAuth2UserInfo oAuth2UserInfo;
+        switch (provider) {
+            case "google" -> oAuth2UserInfo = new GoogleUserInfo(attributes);
+            default ->  throw new IllegalArgumentException("지원하지 않는 OAuth provider입니다: " + provider);
+        }
+
+        String providerId = oAuth2UserInfo.getProviderId();
+        String email = oAuth2UserInfo.getEmail();
+        String profileImageUrl = oAuth2UserInfo.getProfileImageUrl();
+
+        log.info("OAuth 로그인 성공. providerId = {}", providerId);
+        log.info("email = {}", email);
+
+        User existUser = userRepository.findByProviderId(providerId);
+        if (existUser == null) {
+            log.info("신규 유저입니다. provider={}, providerId={}", provider, providerId);
+
+            String redirectUrl = UriComponentsBuilder
+                    .fromUriString(REDIRECT_URI_ONBOARDING)
+                    .queryParam("provider", provider)
+                    .queryParam("providerId", providerId)
+                    .queryParam("email", email)
+                    .queryParam("profileImageUrl", profileImageUrl)
+                    .build()
+                    .toUriString();
+
+            getRedirectStrategy().sendRedirect(request, response, redirectUrl);
+        } else {
+            log.info("기존 유저입니다. userId={}", existUser.getId());
+
+            String accessToken = jwtProvider.generateToken(existUser.getId(), ACCESS_TOKEN_EXPIRATION_TIME);
+
+            String redirectUrl = UriComponentsBuilder
+                    .fromUriString(REDIRECT_URI_BASE)
+                    .queryParam("accessToken", accessToken)
+                    .build()
+                    .toUriString();
+
+            getRedirectStrategy().sendRedirect(request, response, redirectUrl);
+        }
+
+    }
+}

--- a/apps/be/src/main/java/com/capstone/logue/auth/handler/OAuth2LoginSuccessHandler.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/handler/OAuth2LoginSuccessHandler.java
@@ -4,6 +4,8 @@ import com.capstone.logue.auth.provider.JWTProvider;
 import com.capstone.logue.global.entity.User;
 import com.capstone.logue.auth.dto.GoogleUserInfo;
 import com.capstone.logue.auth.dto.OAuth2UserInfo;
+import com.capstone.logue.global.exception.ErrorCode;
+import com.capstone.logue.global.exception.LogueException;
 import com.capstone.logue.user.repository.UserRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -19,6 +21,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * OAuth2 로그인 성공 시 후속 처리를 담당하는 핸들러입니다.
@@ -51,10 +54,6 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
     @Value("${spring.jwt.access-token.expiration-time}")
     private long ACCESS_TOKEN_EXPIRATION_TIME;
 
-//    @Value("${spring.jwt.register-token.expiration-time}")
-//    private long REGISTER_TOKEN_EXPIRATION_TIME;
-//    @Value("${spring.jwt.refresh-token.expiration-time}")
-//    private long REFRESH_TOKEN_EXPIRATION_TIME;
 
     /** JWT 생성 및 파싱을 담당하는 provider */
     private final JWTProvider jwtProvider;
@@ -68,7 +67,7 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
      *
      * <p>OAuth2 인증 객체에서 provider와 사용자 속성을 추출한 뒤,
      * provider에 맞는 {@link OAuth2UserInfo} 구현체로 변환합니다.
-     * 이후 providerId를 기준으로 기존 회원 여부를 조회하여 다음과 같이 처리합니다.</p>
+     * 이후 pproviderUserId를 기준으로 기존 회원 여부를 조회하여 다음과 같이 처리합니다.</p>
      *
      * <ul>
      *     <li>신규 사용자이면 온보딩 페이지로 리다이렉트</li>
@@ -90,24 +89,24 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         OAuth2UserInfo oAuth2UserInfo;
         switch (provider) {
             case "google" -> oAuth2UserInfo = new GoogleUserInfo(attributes);
-            default ->  throw new IllegalArgumentException("지원하지 않는 OAuth provider입니다: " + provider);
+            default -> throw new LogueException(ErrorCode.UNSUPPORTED_OAUTH_PROVIDER);
         }
 
-        String providerId = oAuth2UserInfo.getProviderId();
+        String providerUserId = oAuth2UserInfo.getProviderUserId();
         String email = oAuth2UserInfo.getEmail();
         String profileImageUrl = oAuth2UserInfo.getProfileImageUrl();
 
-        log.info("OAuth 로그인 성공. providerId = {}", providerId);
+        log.info("OAuth 로그인 성공. providerUserId = {}", providerUserId);
         log.info("email = {}", email);
 
-        User existUser = userRepository.findByProviderId(providerId);
-        if (existUser == null) {
-            log.info("신규 유저입니다. provider={}, providerId={}", provider, providerId);
+        Optional<User> optionalUser = userRepository.findByProviderUserId(providerUserId);
+        if (optionalUser.isEmpty()) {
+            log.info("신규 유저입니다. provider={}, providerUserId={}", provider, providerUserId);
 
             String redirectUrl = UriComponentsBuilder
                     .fromUriString(REDIRECT_URI_ONBOARDING)
                     .queryParam("provider", provider)
-                    .queryParam("providerId", providerId)
+                    .queryParam("providerUserId", providerUserId)
                     .queryParam("email", email)
                     .queryParam("profileImageUrl", profileImageUrl)
                     .build()
@@ -115,6 +114,7 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
 
             getRedirectStrategy().sendRedirect(request, response, redirectUrl);
         } else {
+            User existUser = optionalUser.get();
             log.info("기존 유저입니다. userId={}", existUser.getId());
 
             String accessToken = jwtProvider.generateToken(existUser.getId(), ACCESS_TOKEN_EXPIRATION_TIME);

--- a/apps/be/src/main/java/com/capstone/logue/auth/provider/JWTProvider.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/provider/JWTProvider.java
@@ -33,7 +33,7 @@ public class JWTProvider {
     private final SecretKey secretKey;
 
     /**
-     * application.yml에 설정된 secret 값을 기반으로 SecretKey를 생성합니다.
+     * SSM에 저장된 파라미터 `/logue/~/JWT_SECRET` 값을 기반으로 SecretKey를 생성합니다.
      *
      * @param secret JWT 서명용 비밀 문자열
      */

--- a/apps/be/src/main/java/com/capstone/logue/auth/provider/JWTProvider.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/provider/JWTProvider.java
@@ -1,0 +1,62 @@
+package com.capstone.logue.auth.provider;
+
+import com.capstone.logue.global.exception.ErrorCode;
+import com.capstone.logue.global.exception.LogueException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.ExpiredJwtException;
+
+@Slf4j
+@Component
+public class JWTProvider {
+    private final SecretKey secretKey;
+
+    public JWTProvider(@Value("${spring.jwt.secret}") String secret) {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    // 토큰 생성 메서드
+    public String generateToken(Long userId, long expirationMillis) {
+        return Jwts.builder()
+                .claim("userId", userId)  // 사용자 ID를 claim에 담는다.
+                .setIssuedAt(new Date(System.currentTimeMillis()))  // 토큰 발급 시간 설정
+                .setExpiration(new Date(System.currentTimeMillis() + expirationMillis))  // 토큰 만료 시간 설정
+                .signWith(secretKey, SignatureAlgorithm.HS256)  // 서명을 생성한다.
+                .compact();  // 최종적으로 JWT 문자열을 생성하여 반환한다.
+    }
+
+    // 토큰 유효성 검증 메서드
+    public void validateToken(String token) {
+        tokenParser(token);  // 토큰을 파싱하고, 유효하지 않으면 예외를 발생시킨다.
+    }
+
+    // 토큰 파싱 메서드
+    private Claims tokenParser(String token) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(secretKey)  // 서명을 검증할 비밀 키를 설정한다.
+                    .build()
+                    .parseClaimsJws(token)  // JWT를 파싱하고, 서명을 검증한다.
+                    .getBody();  // 파싱 결과로 Claims(토큰의 내용)를 반환한다.
+        } catch (ExpiredJwtException e) {
+            throw new LogueException(ErrorCode.EXPIRED_TOKEN);  // 만료된 토큰에 대한 예외 처리
+        } catch (Exception e) {
+            throw new LogueException(ErrorCode.INVALID_TOKEN);  // 잘못된 토큰에 대한 예외 처리
+        }
+    }
+
+    // 토큰에서 사용자 ID를 추출하는 메서드
+    public Long getUserIdFromToken(String token) {
+        return tokenParser(token).get("userId", Long.class);  // 토큰에서 userId를 추출하여 반환한다.
+    }
+}

--- a/apps/be/src/main/java/com/capstone/logue/auth/provider/JWTProvider.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/provider/JWTProvider.java
@@ -16,16 +16,41 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import io.jsonwebtoken.ExpiredJwtException;
 
+/**
+ * JWT(Json Web Token)의 생성, 검증, 파싱을 담당하는 컴포넌트입니다.
+ *
+ * <p>사용자 인증을 위해 userId를 claim으로 포함한 토큰을 생성하며,
+ * 요청 시 전달된 토큰의 유효성을 검증하고 사용자 정보를 추출합니다.</p>
+ *
+ * <p>토큰은 HS256 알고리즘을 사용하여 서명되며,
+ * secret key는 application 설정값을 기반으로 생성됩니다.</p>
+ */
 @Slf4j
 @Component
 public class JWTProvider {
+
+    /** JWT 서명 및 검증에 사용되는 비밀 키 */
     private final SecretKey secretKey;
 
+    /**
+     * application.yml에 설정된 secret 값을 기반으로 SecretKey를 생성합니다.
+     *
+     * @param secret JWT 서명용 비밀 문자열
+     */
     public JWTProvider(@Value("${spring.jwt.secret}") String secret) {
         this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
     }
 
-    // 토큰 생성 메서드
+    /**
+     * 사용자 ID를 기반으로 JWT access token을 생성합니다.
+     *
+     * <p>토큰에는 userId가 claim으로 포함되며,
+     * 발급 시간과 만료 시간이 함께 설정됩니다.</p>
+     *
+     * @param userId 토큰에 포함할 사용자 ID
+     * @param expirationMillis 토큰 만료 시간 (millisecond 단위)
+     * @return 생성된 JWT 문자열
+     */
     public String generateToken(Long userId, long expirationMillis) {
         return Jwts.builder()
                 .claim("userId", userId)  // 사용자 ID를 claim에 담는다.
@@ -35,12 +60,28 @@ public class JWTProvider {
                 .compact();  // 최종적으로 JWT 문자열을 생성하여 반환한다.
     }
 
-    // 토큰 유효성 검증 메서드
+    /**
+     * JWT 토큰의 유효성을 검증합니다.
+     *
+     * <p>토큰이 유효하지 않거나 만료된 경우 예외를 발생시킵니다.</p>
+     *
+     * @param token 검증할 JWT 문자열
+     * @throws LogueException 토큰이 만료되었거나 유효하지 않은 경우
+     */
     public void validateToken(String token) {
         tokenParser(token);  // 토큰을 파싱하고, 유효하지 않으면 예외를 발생시킨다.
     }
 
-    // 토큰 파싱 메서드
+    /**
+     * JWT 토큰을 파싱하여 Claims를 반환합니다.
+     *
+     * <p>서명을 검증하고 토큰의 payload를 해석합니다.
+     * 만료되었거나 잘못된 토큰일 경우 {@link LogueException}을 발생시킵니다.</p>
+     *
+     * @param token 파싱할 JWT 문자열
+     * @return 토큰의 Claims(payload)
+     * @throws LogueException EXPIRED_TOKEN 또는 INVALID_TOKEN
+     */
     private Claims tokenParser(String token) {
         try {
             return Jwts.parserBuilder()
@@ -55,7 +96,12 @@ public class JWTProvider {
         }
     }
 
-    // 토큰에서 사용자 ID를 추출하는 메서드
+    /**
+     * JWT 토큰에서 사용자 ID를 추출합니다.
+     *
+     * @param token JWT 문자열
+     * @return 토큰에 포함된 userId
+     */
     public Long getUserIdFromToken(String token) {
         return tokenParser(token).get("userId", Long.class);  // 토큰에서 userId를 추출하여 반환한다.
     }

--- a/apps/be/src/main/java/com/capstone/logue/auth/provider/SecurityContextProvider.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/provider/SecurityContextProvider.java
@@ -10,9 +10,29 @@ import org.springframework.stereotype.Component;
 
 import java.util.Objects;
 
+/**
+ * Spring Security의 {@link SecurityContextHolder}로부터
+ * 현재 인증된 사용자 정보를 조회하는 컴포넌트입니다.
+ *
+ * <p>주로 서비스 계층이나 비즈니스 로직에서
+ * "현재 로그인한 사용자의 ID"가 필요할 때 사용됩니다.</p>
+ *
+ * <p>또한 테스트 환경에서 인증 정보를 직접 주입할 수 있도록
+ * SecurityContext 설정 메서드를 함께 제공합니다.</p>
+ */
 @Slf4j
 @Component
 public class SecurityContextProvider {
+
+    /**
+     * 현재 SecurityContext에 저장된 인증 사용자 ID를 반환합니다.
+     *
+     * <p>인증 정보가 없거나 principal이 비어 있으면
+     * {@link LogueException}을 발생시킵니다.</p>
+     *
+     * @return 현재 인증된 사용자 ID
+     * @throws LogueException 인증되지 않은 요청인 경우
+     */
     public Long getAuthenticatedUserId() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         Object principal = authentication.getPrincipal();
@@ -22,7 +42,15 @@ public class SecurityContextProvider {
         return (Long) principal;  // 사용자 ID 반환
     }
 
-    // 테스트를 위한 SecurityContext 설정 메서드
+    /**
+     * 테스트 환경에서 사용할 SecurityContext를 직접 설정합니다.
+     *
+     * <p>지정한 userId를 principal로 가지는
+     * {@link UserAuthentication} 객체를 생성하여
+     * SecurityContext에 저장합니다.</p>
+     *
+     * @param userId 테스트용으로 주입할 사용자 ID
+     */
     public void setupSecurityContextForTest(Long userId) {
         UserAuthentication authentication = new UserAuthentication(userId, null, null);
         SecurityContextHolder.getContext().setAuthentication(authentication);  // 테스트 환경에서 사용자 인증 설정

--- a/apps/be/src/main/java/com/capstone/logue/auth/provider/SecurityContextProvider.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/provider/SecurityContextProvider.java
@@ -1,0 +1,30 @@
+package com.capstone.logue.auth.provider;
+
+import com.capstone.logue.auth.security.UserAuthentication;
+import com.capstone.logue.global.exception.ErrorCode;
+import com.capstone.logue.global.exception.LogueException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+
+@Slf4j
+@Component
+public class SecurityContextProvider {
+    public Long getAuthenticatedUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Object principal = authentication.getPrincipal();
+        if (Objects.isNull(principal)) {
+            throw new LogueException(ErrorCode.UNAUTHORIZED);  // 인증되지 않은 경우 예외 발생
+        }
+        return (Long) principal;  // 사용자 ID 반환
+    }
+
+    // 테스트를 위한 SecurityContext 설정 메서드
+    public void setupSecurityContextForTest(Long userId) {
+        UserAuthentication authentication = new UserAuthentication(userId, null, null);
+        SecurityContextHolder.getContext().setAuthentication(authentication);  // 테스트 환경에서 사용자 인증 설정
+    }
+}

--- a/apps/be/src/main/java/com/capstone/logue/auth/provider/SecurityContextProvider.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/provider/SecurityContextProvider.java
@@ -35,11 +35,10 @@ public class SecurityContextProvider {
      */
     public Long getAuthenticatedUserId() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Object principal = authentication.getPrincipal();
-        if (Objects.isNull(principal)) {
-            throw new LogueException(ErrorCode.UNAUTHORIZED);  // 인증되지 않은 경우 예외 발생
+        if (authentication == null || authentication.getPrincipal() == null) {
+            throw new LogueException(ErrorCode.UNAUTHORIZED); // 인증되지 않은 경우 예외 발생
         }
-        return (Long) principal;  // 사용자 ID 반환
+        return (Long) authentication.getPrincipal();  // 사용자 ID 반환
     }
 
     /**

--- a/apps/be/src/main/java/com/capstone/logue/auth/security/UserAuthentication.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/security/UserAuthentication.java
@@ -5,7 +5,28 @@ import org.springframework.security.core.GrantedAuthority;
 
 import java.util.Collection;
 
+/**
+ * 사용자 인증 정보를 표현하는 커스텀 Authentication 객체입니다.
+ *
+ * <p>{@link UsernamePasswordAuthenticationToken}을 상속하여 구현되며,
+ * principal에 사용자 ID를 저장하는 방식으로 인증을 처리합니다.</p>
+ *
+ * <p>JWT 인증 과정에서 토큰으로부터 추출한 userId를 기반으로 생성되며,
+ * {@link org.springframework.security.core.context.SecurityContextHolder}에 저장되어
+ * 이후 요청 처리 과정에서 인증된 사용자 정보를 참조할 수 있도록 합니다.</p>
+ *
+ * <p>현재 구현에서는 권한(Authority)을 별도로 사용하지 않으며,
+ * 필요 시 roles/permissions 확장을 고려할 수 있습니다.</p>
+ */
 public class UserAuthentication extends UsernamePasswordAuthenticationToken {
+
+    /**
+     * 사용자 인증 객체를 생성합니다.
+     *
+     * @param principal 사용자 식별 정보 (현재는 userId)
+     * @param credentials 인증 자격 정보 (사용하지 않음, 일반적으로 null)
+     * @param authorities 사용자 권한 목록 (현재는 null 또는 비어 있음)
+     */
     public UserAuthentication(Object principal, Object credentials, Collection<? extends GrantedAuthority> authorities) {
         super(principal, credentials, authorities);
     }

--- a/apps/be/src/main/java/com/capstone/logue/auth/security/UserAuthentication.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/security/UserAuthentication.java
@@ -1,0 +1,12 @@
+package com.capstone.logue.auth.security;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+public class UserAuthentication extends UsernamePasswordAuthenticationToken {
+    public UserAuthentication(Object principal, Object credentials, Collection<? extends GrantedAuthority> authorities) {
+        super(principal, credentials, authorities);
+    }
+}

--- a/apps/be/src/main/java/com/capstone/logue/global/config/SecurityConfig.java
+++ b/apps/be/src/main/java/com/capstone/logue/global/config/SecurityConfig.java
@@ -2,6 +2,9 @@ package com.capstone.logue.global.config;
 
 import java.util.List;
 
+import com.capstone.logue.auth.handler.OAuth2LoginFailureHandler;
+import com.capstone.logue.auth.handler.OAuth2LoginSuccessHandler;
+import com.capstone.logue.auth.provider.JWTProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -12,6 +15,7 @@ import org.springframework.security.config.annotation.authentication.configurati
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -29,6 +33,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+    private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
+    private final JWTProvider jwtProvider;
+
     @Bean
     public CorsFilter corsFilter() {
         CorsConfiguration config = new CorsConfiguration();
@@ -41,7 +49,7 @@ public class SecurityConfig {
         config.setAllowCredentials(true);
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
-        config.setExposedHeaders(List.of("Set-Cookie"));
+        config.setExposedHeaders(List.of("Set-Cookie", "Authorization"));
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);
@@ -53,10 +61,18 @@ public class SecurityConfig {
         return http
                 .cors(cors -> {})
                 .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(HttpBasicConfigurer::disable)
+                .oauth2Login((oauth2) -> oauth2
+                        .successHandler(oAuth2LoginSuccessHandler)
+                        .failureHandler(oAuth2LoginFailureHandler))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers(
+                                "/",
+                                "/login",
+                                "/login/google",
                                 "/health",
                                 "/v3/api-docs/**",
                                 "/swagger-ui/**",

--- a/apps/be/src/main/java/com/capstone/logue/global/config/SecurityConfig.java
+++ b/apps/be/src/main/java/com/capstone/logue/global/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.capstone.logue.global.config;
 
 import java.util.List;
 
+import com.capstone.logue.auth.filter.JWTFilter;
 import com.capstone.logue.auth.handler.OAuth2LoginFailureHandler;
 import com.capstone.logue.auth.handler.OAuth2LoginSuccessHandler;
 import com.capstone.logue.auth.provider.JWTProvider;
@@ -71,8 +72,8 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers(
                                 "/",
-                                "/login",
-                                "/login/google",
+                                "/oauth2/**",
+                                "/login/oauth2/**",
                                 "/health",
                                 "/v3/api-docs/**",
                                 "/swagger-ui/**",
@@ -81,6 +82,7 @@ public class SecurityConfig {
                         ).permitAll()
                         .anyRequest().authenticated()
                 )
+                .addFilterBefore(new JWTFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)
                 .build();
     }
 

--- a/apps/be/src/main/java/com/capstone/logue/global/config/SecurityConfig.java
+++ b/apps/be/src/main/java/com/capstone/logue/global/config/SecurityConfig.java
@@ -36,7 +36,7 @@ public class SecurityConfig {
         config.setAllowedOriginPatterns(List.of(
                 "http://localhost:5173",
                 "http://localhost:3000",
-                "https://www.logue-kr.site/"
+                "https://www.logue-kr.site"
         ));
         config.setAllowCredentials(true);
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));

--- a/apps/be/src/main/java/com/capstone/logue/global/exception/ErrorCode.java
+++ b/apps/be/src/main/java/com/capstone/logue/global/exception/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     FORBIDDEN(HttpStatus.FORBIDDEN, "A002", "접근 권한이 없습니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "A003", "만료된 토큰입니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A004", "유효하지 않은 토큰입니다."),
+    UNSUPPORTED_OAUTH_PROVIDER(HttpStatus.BAD_REQUEST, "A005", "지원하지 않는 OAuth Provider입니다."),
 
     // User
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "사용자를 찾을 수 없습니다."),

--- a/apps/be/src/main/java/com/capstone/logue/global/exception/ErrorCode.java
+++ b/apps/be/src/main/java/com/capstone/logue/global/exception/ErrorCode.java
@@ -17,6 +17,11 @@ public enum ErrorCode {
     // Auth
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "A001", "인증이 필요합니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "A002", "접근 권한이 없습니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "A003", "만료된 토큰입니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A004", "유효하지 않은 토큰입니다."),
+
+    // User
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "사용자를 찾을 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/apps/be/src/main/java/com/capstone/logue/user/controller/UserController.java
+++ b/apps/be/src/main/java/com/capstone/logue/user/controller/UserController.java
@@ -11,12 +11,33 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 사용자 관련 API를 제공하는 컨트롤러입니다.
+ *
+ * <p>현재 로그인한 사용자의 정보를 조회하는 기능을 제공합니다.</p>
+ */
 @RestController
 @RequiredArgsConstructor
 public class UserController {
+    /** 현재 인증된 사용자 정보를 조회하기 위한 provider */
     private final SecurityContextProvider securityContextProvider;
+
+    /** 사용자 조회를 위한 repository */
     private final UserRepository userRepository;
 
+
+    /**
+     * 현재 로그인한 사용자의 정보를 조회합니다.
+     *
+     * <p>JWT 인증을 통해 {@link SecurityContextProvider}에서 userId를 가져온 후,
+     * 해당 ID로 사용자를 조회하여 응답 DTO로 변환합니다.</p>
+     *
+     * <p>요청에는 별도의 Request Body가 필요하지 않으며,
+     * Authorization 헤더에 포함된 JWT 토큰을 기반으로 인증이 수행됩니다.</p>
+     *
+     * @return 사용자 정보 조회 결과
+     * @throws LogueException 사용자를 찾을 수 없는 경우 (USER_NOT_FOUND)
+     */
     @GetMapping("/api/user/me")
     public ApiResponse<GetUserInfoResponse> getMyInfo() {
         Long userId = securityContextProvider.getAuthenticatedUserId();

--- a/apps/be/src/main/java/com/capstone/logue/user/controller/UserController.java
+++ b/apps/be/src/main/java/com/capstone/logue/user/controller/UserController.java
@@ -1,0 +1,31 @@
+package com.capstone.logue.user.controller;
+
+import com.capstone.logue.auth.provider.SecurityContextProvider;
+import com.capstone.logue.global.entity.User;
+import com.capstone.logue.global.exception.ErrorCode;
+import com.capstone.logue.global.exception.LogueException;
+import com.capstone.logue.global.response.ApiResponse;
+import com.capstone.logue.user.dto.GetUserInfoResponse;
+import com.capstone.logue.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class UserController {
+    private final SecurityContextProvider securityContextProvider;
+    private final UserRepository userRepository;
+
+    @GetMapping("/api/user/me")
+    public ApiResponse<GetUserInfoResponse> getMyInfo() {
+        Long userId = securityContextProvider.getAuthenticatedUserId();
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new LogueException(ErrorCode.USER_NOT_FOUND));
+
+        GetUserInfoResponse response = GetUserInfoResponse.from(user);
+        return ApiResponse.success("사용자 정보 조회 성공", response);
+
+    }
+}

--- a/apps/be/src/main/java/com/capstone/logue/user/controller/UserController.java
+++ b/apps/be/src/main/java/com/capstone/logue/user/controller/UserController.java
@@ -7,7 +7,11 @@ import com.capstone.logue.global.exception.LogueException;
 import com.capstone.logue.global.response.ApiResponse;
 import com.capstone.logue.user.dto.GetUserInfoResponse;
 import com.capstone.logue.user.repository.UserRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -16,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
  *
  * <p>현재 로그인한 사용자의 정보를 조회하는 기능을 제공합니다.</p>
  */
+@Tag(name = "User", description = "사용자 API")
 @RestController
 @RequiredArgsConstructor
 public class UserController {
@@ -38,15 +43,20 @@ public class UserController {
      * @return 사용자 정보 조회 결과
      * @throws LogueException 사용자를 찾을 수 없는 경우 (USER_NOT_FOUND)
      */
+    @Operation(summary = "내 정보 조회", description = "JWT 토큰 기반으로 현재 로그인한 사용자 정보를 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패 (토큰 없음 또는 만료)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음"),
+    })
     @GetMapping("/api/user/me")
-    public ApiResponse<GetUserInfoResponse> getMyInfo() {
+    public ResponseEntity<ApiResponse<GetUserInfoResponse>> getMyInfo() {
         Long userId = securityContextProvider.getAuthenticatedUserId();
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new LogueException(ErrorCode.USER_NOT_FOUND));
 
         GetUserInfoResponse response = GetUserInfoResponse.from(user);
-        return ApiResponse.success("사용자 정보 조회 성공", response);
-
+        return ResponseEntity.ok(ApiResponse.success("사용자 정보 조회 성공", response));
     }
 }

--- a/apps/be/src/main/java/com/capstone/logue/user/dto/GetUserInfoResponse.java
+++ b/apps/be/src/main/java/com/capstone/logue/user/dto/GetUserInfoResponse.java
@@ -46,7 +46,7 @@ public class GetUserInfoResponse {
                 .email(user.getEmail())
                 .name(user.getName())
                 .provider(user.getProvider().toLowerCase())
-                .profileImageUrl(null)
+                .profileImageUrl(user.getProfileImageUrl())
                 .build();
     }
 }

--- a/apps/be/src/main/java/com/capstone/logue/user/dto/GetUserInfoResponse.java
+++ b/apps/be/src/main/java/com/capstone/logue/user/dto/GetUserInfoResponse.java
@@ -4,16 +4,42 @@ import com.capstone.logue.global.entity.User;
 import lombok.Builder;
 import lombok.Getter;
 
+/**
+ * 현재 로그인한 사용자 정보를 반환하기 위한 응답 DTO입니다.
+ *
+ * <p>{@link com.capstone.logue.user.controller.UserController}의
+ * /api/user/me API에서 사용되며,
+ * 내부 User 엔티티를 클라이언트에 전달할 형태로 변환합니다.</p>
+ */
 @Getter
 @Builder
 public class GetUserInfoResponse {
 
+    /** 사용자 ID */
     private Long id;
+
+    /** 사용자 이메일 */
     private String email;
+
+    /** 사용자 이름 */
     private String name;
+
+    /** OAuth 제공자 (google) */
     private String provider;
+
+    /** 사용자 프로필 이미지 URL */
     private String profileImageUrl;
 
+
+    /**
+     * {@link User} 엔티티를 {@link GetUserInfoResponse} DTO로 변환합니다.
+     *
+     * <p>엔티티 내부 정보를 클라이언트 응답 형태로 매핑하며,
+     * provider는 소문자로 변환하여 반환합니다.</p>
+     *
+     * @param user 변환할 사용자 엔티티
+     * @return 사용자 정보 응답 DTO
+     */
     public static GetUserInfoResponse from(User user) {
         return GetUserInfoResponse.builder()
                 .id(user.getId())

--- a/apps/be/src/main/java/com/capstone/logue/user/dto/GetUserInfoResponse.java
+++ b/apps/be/src/main/java/com/capstone/logue/user/dto/GetUserInfoResponse.java
@@ -1,0 +1,26 @@
+package com.capstone.logue.user.dto;
+
+import com.capstone.logue.global.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GetUserInfoResponse {
+
+    private Long id;
+    private String email;
+    private String name;
+    private String provider;
+    private String profileImageUrl;
+
+    public static GetUserInfoResponse from(User user) {
+        return GetUserInfoResponse.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .name(user.getName())
+                .provider(user.getProvider().toLowerCase())
+                .profileImageUrl(null)
+                .build();
+    }
+}

--- a/apps/be/src/main/java/com/capstone/logue/user/repository/UserRepository.java
+++ b/apps/be/src/main/java/com/capstone/logue/user/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package com.capstone.logue.user.repository;
+
+import com.capstone.logue.global.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Logue 서비스를 사용하는 사용자 정보에 접근하는 레포지토리입니다.
+ *
+ * <p>소셜 로그인(Google OAuth2)을 통해 인증되며,
+ * {소셜 서버에서 받은 providerId로 유저의 존재 여부를 체크 할 수 있도록 한다.</p>
+ */
+public interface UserRepository extends JpaRepository<User, Long> {
+    User findByProviderId(String providerId);
+}

--- a/apps/be/src/main/java/com/capstone/logue/user/repository/UserRepository.java
+++ b/apps/be/src/main/java/com/capstone/logue/user/repository/UserRepository.java
@@ -3,12 +3,14 @@ package com.capstone.logue.user.repository;
 import com.capstone.logue.global.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 /**
  * Logue 서비스를 사용하는 사용자 정보에 접근하는 레포지토리입니다.
  *
  * <p>소셜 로그인(Google OAuth2)을 통해 인증되며,
- * {소셜 서버에서 받은 providerId로 유저의 존재 여부를 체크 할 수 있도록 한다.</p>
+ * {소셜 서버에서 받은 providerUserId로 유저의 존재 여부를 체크 할 수 있도록 한다.</p>
  */
 public interface UserRepository extends JpaRepository<User, Long> {
-    User findByProviderId(String providerId);
+    Optional<User> findByProviderUserId(String providerUserId);
 }

--- a/apps/be/src/main/resources/application-prod.properties
+++ b/apps/be/src/main/resources/application-prod.properties
@@ -35,9 +35,9 @@ spring.flyway.locations=classpath:db/migration
 # ================================
 # JWT
 # ================================
-#jwt.secret=${JWT_SECRET}
-#jwt.access-token.expiration-time=3600000
-#jwt.refresh-token.expiration-time=604800000
+jwt.secret=${JWT_SECRET}
+jwt.access-token.expiration-time=3600000
+jwt.refresh-token.expiration-time=604800000
 
 # ================================
 # OAuth2 - Google (Prod)

--- a/apps/be/src/main/resources/application-prod.properties
+++ b/apps/be/src/main/resources/application-prod.properties
@@ -40,9 +40,10 @@ spring.flyway.locations=classpath:db/migration
 #jwt.refresh-token.expiration-time=604800000
 
 # ================================
-# OAuth2
+# OAuth2 - Google (Prod)
 # ================================
-
+spring.security.oauth2.client.registration.google.client-id=${GOOGLE_CLIENT_ID}
+spring.security.oauth2.client.registration.google.client-secret=${GOOGLE_CLIENT_SECRET}
 
 # ================================
 # Frontend Redirect / Cookie

--- a/apps/be/src/main/resources/application.properties
+++ b/apps/be/src/main/resources/application.properties
@@ -14,3 +14,8 @@ spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSou
 # Discord Webhook (set via SSM: DISCORD_WEBHOOK_URL)
 # ================================
 DISCORD_WEBHOOK_URL=
+
+# ================================
+# OAuth2
+# ================================
+spring.security.oauth2.client.registration.google.scope=profile,email


### PR DESCRIPTION
## 요약
- OAuth2 로그인 + JWT 기반 인증 및 사용자 조회 API를 포함한 Auth/User 기능을 구현

## 변경 사항
- [x] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - DB 연결 없이 로컬 환경에서 테스트 진행 (DB 관련 로직은 임시 주석 처리)
  - BE: `./gradlew test` / FE: `yarn dev` 실행
  - `http://localhost:8080/oauth2/authorization/google` 접속 후 Google 로그인 수행
  - 로그인 성공 시 `http://localhost:3000/?provider=...` 형태로 리다이렉트되는 것 확인
- 테스트 한계:
  - DB 미연결 상태로 인해 기존 사용자 분기 및 `/api/user/me` API 호출은 검증하지 못함

## 스크린샷/로그 (선택)
- 필요한 경우 첨부

## 롤백/리스크
- 리스크 포인트:
 - JWT 토큰 만료 시간 및 예외 처리 로직에 따라 인증 실패 케이스 발생 가능
 - OAuth provider 확장 시 providerId 기준 조회 로직 충돌 가능성 있음
- 롤백 방법:
 - 인증 관련 기능 전체 비활성화 (로그인/인가 기능 제거)

## 관련 이슈
Closes #16
