### PR TITLE
feat: @CurrentUser 어노테이션 구현

### DIFF
--- a/apps/be/src/main/java/com/capstone/logue/auth/annotation/CurrentUser.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/annotation/CurrentUser.java
@@ -1,0 +1,14 @@
+package com.capstone.logue.auth.annotation;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal
+public @interface CurrentUser {
+}

--- a/apps/be/src/main/java/com/capstone/logue/auth/filter/JWTFilter.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/filter/JWTFilter.java
@@ -2,6 +2,7 @@ package com.capstone.logue.auth.filter;
 
 import com.capstone.logue.auth.provider.JWTProvider;
 import com.capstone.logue.auth.security.UserAuthentication;
+import com.capstone.logue.auth.security.UserPrincipal;
 import com.capstone.logue.global.exception.LogueException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -63,8 +64,7 @@ public class JWTFilter extends OncePerRequestFilter {
             }
 
             jwtProvider.validateToken(accessToken);  // JWT 유효성 검증
-            Long userId = jwtProvider.getUserIdFromToken(accessToken);  // JWT에서 사용자 ID 추출
-            setAuthentication(userId);  // 인증 정보 설정
+            setAuthentication(accessToken);
             filterChain.doFilter(request, response);  // 필터 체인 통과
 
         } catch (LogueException e) {
@@ -111,10 +111,13 @@ public class JWTFilter extends OncePerRequestFilter {
     /**
      * 사용자 ID를 기반으로 인증 객체를 생성하고 SecurityContext에 저장합니다.
      *
-     * @param userId 인증된 사용자 ID
+     * @param accessToken 인증된 사용자 토큰
      */
-    private void setAuthentication(Long userId) {
-        UserAuthentication authentication = new UserAuthentication(userId, null, null);
+    private void setAuthentication(String accessToken) {
+        Long userId = jwtProvider.getUserIdFromToken(accessToken);
+        String email = jwtProvider.getEmailFromToken(accessToken);
+        UserPrincipal principal = new UserPrincipal(userId, email);
+        UserAuthentication authentication = new UserAuthentication(principal, null, null);
         SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 

--- a/apps/be/src/main/java/com/capstone/logue/auth/filter/JWTFilter.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/filter/JWTFilter.java
@@ -4,6 +4,7 @@ import com.capstone.logue.auth.provider.JWTProvider;
 import com.capstone.logue.auth.security.UserAuthentication;
 import com.capstone.logue.auth.security.UserPrincipal;
 import com.capstone.logue.global.exception.LogueException;
+import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -63,8 +64,9 @@ public class JWTFilter extends OncePerRequestFilter {
                 return;
             }
 
-            jwtProvider.validateToken(accessToken);  // JWT 유효성 검증
-            setAuthentication(accessToken);
+            // 파싱 1회 — validate + Claims 추출을 동시에
+            Claims claims = jwtProvider.validateToken(accessToken);
+            setAuthentication(claims);  // Claims 객체를 넘김
             filterChain.doFilter(request, response);  // 필터 체인 통과
 
         } catch (LogueException e) {
@@ -111,11 +113,11 @@ public class JWTFilter extends OncePerRequestFilter {
     /**
      * 사용자 ID를 기반으로 인증 객체를 생성하고 SecurityContext에 저장합니다.
      *
-     * @param accessToken 인증된 사용자 토큰
+     * @param claims 검증된 JWT에서 추출한 클레임 정보
      */
-    private void setAuthentication(String accessToken) {
-        Long userId = jwtProvider.getUserIdFromToken(accessToken);
-        String email = jwtProvider.getEmailFromToken(accessToken);
+    private void setAuthentication(Claims claims) {
+        Long userId = jwtProvider.getUserIdFromToken(claims);
+        String email = jwtProvider.getEmailFromToken(claims);
         UserPrincipal principal = new UserPrincipal(userId, email);
         UserAuthentication authentication = new UserAuthentication(principal, null, null);
         SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/apps/be/src/main/java/com/capstone/logue/auth/handler/OAuth2LoginSuccessHandler.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/handler/OAuth2LoginSuccessHandler.java
@@ -117,7 +117,7 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
             User existUser = optionalUser.get();
             log.info("기존 유저입니다. userId={}", existUser.getId());
 
-            String accessToken = jwtProvider.generateToken(existUser.getId(), ACCESS_TOKEN_EXPIRATION_TIME);
+            String accessToken = jwtProvider.generateToken(existUser.getId(), existUser.getEmail(), ACCESS_TOKEN_EXPIRATION_TIME);
 
             String redirectUrl = UriComponentsBuilder
                     .fromUriString(REDIRECT_URI_BASE)

--- a/apps/be/src/main/java/com/capstone/logue/auth/provider/JWTProvider.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/provider/JWTProvider.java
@@ -70,8 +70,8 @@ public class JWTProvider {
      * @param token 검증할 JWT 문자열
      * @throws LogueException 토큰이 만료되었거나 유효하지 않은 경우
      */
-    public void validateToken(String token) {
-        tokenParser(token);  // 토큰을 파싱하고, 유효하지 않으면 예외를 발생시킨다.
+    public Claims validateToken(String token) {
+        return tokenParser(token);  // 토큰을 파싱하고, 유효하지 않으면 예외를 발생시킨다.
     }
 
     /**
@@ -101,20 +101,20 @@ public class JWTProvider {
     /**
      * JWT 토큰에서 사용자 ID를 추출합니다.
      *
-     * @param token JWT 문자열
+     * @param claims 검증된 JWT에서 추출한 클레임 정보
      * @return 토큰에 포함된 userId
      */
-    public Long getUserIdFromToken(String token) {
-        return tokenParser(token).get("userId", Long.class);  // 토큰에서 userId를 추출하여 반환한다.
+    public Long getUserIdFromToken(Claims claims) {
+        return claims.get("userId", Long.class);  // 토큰에서 userId를 추출하여 반환한다.
     }
 
     /**
      * JWT 토큰에서 사용자 email을 추출합니다.
      *
-     * @param token JWT 문자열
+     * @param claims 검증된 JWT에서 추출한 클레임 정보
      * @return 토큰에 포함된 email
      */
-    public String getEmailFromToken(String token) {
-        return tokenParser(token).get("email", String.class);  // 토큰에서 email을 추출하여 반환한다.
+    public String getEmailFromToken(Claims claims) {
+        return claims.get("email", String.class);  // 토큰에서 email을 추출하여 반환한다.
     }
 }

--- a/apps/be/src/main/java/com/capstone/logue/auth/provider/JWTProvider.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/provider/JWTProvider.java
@@ -48,12 +48,14 @@ public class JWTProvider {
      * 발급 시간과 만료 시간이 함께 설정됩니다.</p>
      *
      * @param userId 토큰에 포함할 사용자 ID
+     * @param email 토큰에 포함할 사용자 email
      * @param expirationMillis 토큰 만료 시간 (millisecond 단위)
      * @return 생성된 JWT 문자열
      */
-    public String generateToken(Long userId, long expirationMillis) {
+    public String generateToken(Long userId, String email, long expirationMillis) {
         return Jwts.builder()
                 .claim("userId", userId)  // 사용자 ID를 claim에 담는다.
+                .claim("email", email)       // 사용자 email을 claim에 담는다.
                 .setIssuedAt(new Date(System.currentTimeMillis()))  // 토큰 발급 시간 설정
                 .setExpiration(new Date(System.currentTimeMillis() + expirationMillis))  // 토큰 만료 시간 설정
                 .signWith(secretKey, SignatureAlgorithm.HS256)  // 서명을 생성한다.
@@ -104,5 +106,15 @@ public class JWTProvider {
      */
     public Long getUserIdFromToken(String token) {
         return tokenParser(token).get("userId", Long.class);  // 토큰에서 userId를 추출하여 반환한다.
+    }
+
+    /**
+     * JWT 토큰에서 사용자 email을 추출합니다.
+     *
+     * @param token JWT 문자열
+     * @return 토큰에 포함된 email
+     */
+    public String getEmailFromToken(String token) {
+        return tokenParser(token).get("email", String.class);  // 토큰에서 email을 추출하여 반환한다.
     }
 }

--- a/apps/be/src/main/java/com/capstone/logue/auth/provider/SecurityContextProvider.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/provider/SecurityContextProvider.java
@@ -1,6 +1,7 @@
 package com.capstone.logue.auth.provider;
 
 import com.capstone.logue.auth.security.UserAuthentication;
+import com.capstone.logue.auth.security.UserPrincipal;
 import com.capstone.logue.global.exception.ErrorCode;
 import com.capstone.logue.global.exception.LogueException;
 import lombok.extern.slf4j.Slf4j;
@@ -33,12 +34,12 @@ public class SecurityContextProvider {
      * @return 현재 인증된 사용자 ID
      * @throws LogueException 인증되지 않은 요청인 경우
      */
-    public Long getAuthenticatedUserId() {
+    public UserPrincipal getAuthenticatedUser() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null || authentication.getPrincipal() == null) {
             throw new LogueException(ErrorCode.UNAUTHORIZED); // 인증되지 않은 경우 예외 발생
         }
-        return (Long) authentication.getPrincipal();  // 사용자 ID 반환
+        return (UserPrincipal) authentication.getPrincipal();
     }
 
     /**

--- a/apps/be/src/main/java/com/capstone/logue/auth/security/UserPrincipal.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/security/UserPrincipal.java
@@ -1,0 +1,13 @@
+package com.capstone.logue.auth.security;
+
+/**
+ * JWT 인증 후 SecurityContext에 저장되는 사용자 정보 객체입니다.
+ *
+ * <p>DB 조회 없이 JWT 클레임에서 파싱한 정보만을 담으며,
+ * {@code @CurrentUser} 어노테이션을 통해 컨트롤러 파라미터로 주입됩니다.</p>
+ *
+ * @param userId 사용자 ID
+ * @param email  사용자 이메일
+ */
+public record UserPrincipal(Long userId, String email) {
+}

--- a/apps/be/src/main/java/com/capstone/logue/auth/security/UserPrincipal.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/security/UserPrincipal.java
@@ -1,5 +1,7 @@
 package com.capstone.logue.auth.security;
 
+import lombok.Getter;
+
 /**
  * JWT 인증 후 SecurityContext에 저장되는 사용자 정보 객체입니다.
  *
@@ -9,5 +11,6 @@ package com.capstone.logue.auth.security;
  * @param userId 사용자 ID
  * @param email  사용자 이메일
  */
+
 public record UserPrincipal(Long userId, String email) {
 }

--- a/apps/be/src/main/java/com/capstone/logue/data/controller/DataSourceController.java
+++ b/apps/be/src/main/java/com/capstone/logue/data/controller/DataSourceController.java
@@ -1,6 +1,8 @@
 package com.capstone.logue.data.controller;
 
+import com.capstone.logue.auth.annotation.CurrentUser;
 import com.capstone.logue.auth.provider.SecurityContextProvider;
+import com.capstone.logue.auth.security.UserPrincipal;
 import com.capstone.logue.data.dto.GetDataSourceListResponse;
 import com.capstone.logue.data.dto.GetFileResponse;
 import com.capstone.logue.data.dto.SortType;
@@ -36,7 +38,6 @@ import org.springframework.web.multipart.MultipartFile;
 public class DataSourceController {
 
     private final DataSourceService dataSourceService;
-    private final SecurityContextProvider securityContextProvider;
 
     /**
      * CSV 파일을 업로드하여 DataSource 를 생성합니다.
@@ -50,10 +51,10 @@ public class DataSourceController {
     )
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<UploadFileResponse> upload(
+            @CurrentUser UserPrincipal userPrincipal,
             @RequestPart("file") MultipartFile file
     ) {
-        Long userId = securityContextProvider.getAuthenticatedUserId();
-        UploadFileResponse response = dataSourceService.upload(userId, file);
+        UploadFileResponse response = dataSourceService.upload(userPrincipal.userId(), file);
         return ApiResponse.success("CSV 파일이 업로드되었습니다.", response);
     }
 
@@ -74,6 +75,7 @@ public class DataSourceController {
     )
     @GetMapping
     public ApiResponse<GetDataSourceListResponse> getList(
+            @CurrentUser UserPrincipal userPrincipal,
             @Parameter(description = "정렬 기준. 생략 시 LATEST 로 처리", example = "LATEST")
             @RequestParam(value = "sort", required = false) SortType sort,
 
@@ -83,8 +85,7 @@ public class DataSourceController {
             @Parameter(description = "페이지당 항목 수", example = "20")
             @RequestParam("size") int size
     ) {
-        Long userId = securityContextProvider.getAuthenticatedUserId();
-        GetDataSourceListResponse response = dataSourceService.getList(userId, sort, page, size);
+        GetDataSourceListResponse response = dataSourceService.getList(userPrincipal.userId(), sort, page, size);
         return ApiResponse.success("데이터 소스 목록 조회 성공", response);
     }
 
@@ -97,11 +98,11 @@ public class DataSourceController {
     @Operation(summary = "데이터 소스 단건 조회", description = "DataSource 메타데이터와 CSV 미리보기(헤더+행)를 반환합니다.")
     @GetMapping("/{dataSourceId}")
     public ApiResponse<GetFileResponse> getOne(
+            @CurrentUser UserPrincipal userPrincipal,
             @Parameter(description = "조회할 DataSource id", example = "1")
             @PathVariable Long dataSourceId
     ) {
-        Long userId = securityContextProvider.getAuthenticatedUserId();
-        GetFileResponse response = dataSourceService.getOne(userId, dataSourceId);
+        GetFileResponse response = dataSourceService.getOne(userPrincipal.userId(), dataSourceId);
         return ApiResponse.success("데이터 소스 조회에 성공했습니다.", response);
     }
 
@@ -111,11 +112,11 @@ public class DataSourceController {
     @Operation(summary = "데이터 소스 단건 삭제")
     @DeleteMapping("/{dataSourceId}")
     public ApiResponse<Void> deleteOne(
+            @CurrentUser UserPrincipal userPrincipal,
             @Parameter(description = "삭제할 DataSource id", example = "1")
             @PathVariable Long dataSourceId
     ) {
-        Long userId = securityContextProvider.getAuthenticatedUserId();
-        dataSourceService.deleteOne(userId, dataSourceId);
+        dataSourceService.deleteOne(userPrincipal.userId(), dataSourceId);
         return ApiResponse.success("데이터 소스를 삭제했습니다.");
     }
 
@@ -128,11 +129,11 @@ public class DataSourceController {
     @Operation(summary = "데이터 소스 다건 삭제")
     @DeleteMapping
     public ApiResponse<Void> deleteMany(
+            @CurrentUser UserPrincipal userPrincipal,
             @Parameter(description = "삭제할 DataSource id 리스트", example = "1,2,3")
             @RequestParam("id") List<Long> ids
     ) {
-        Long userId = securityContextProvider.getAuthenticatedUserId();
-        dataSourceService.deleteMany(userId, ids);
+        dataSourceService.deleteMany(userPrincipal.userId(), ids);
         return ApiResponse.success("선택한 데이터 소스들을 삭제했습니다.");
     }
 }

--- a/apps/be/src/main/java/com/capstone/logue/user/controller/UserController.java
+++ b/apps/be/src/main/java/com/capstone/logue/user/controller/UserController.java
@@ -1,6 +1,8 @@
 package com.capstone.logue.user.controller;
 
+import com.capstone.logue.auth.annotation.CurrentUser;
 import com.capstone.logue.auth.provider.SecurityContextProvider;
+import com.capstone.logue.auth.security.UserPrincipal;
 import com.capstone.logue.global.entity.User;
 import com.capstone.logue.global.exception.ErrorCode;
 import com.capstone.logue.global.exception.LogueException;
@@ -24,9 +26,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 public class UserController {
-    /** 현재 인증된 사용자 정보를 조회하기 위한 provider */
-    private final SecurityContextProvider securityContextProvider;
-
     /** 사용자 조회를 위한 repository */
     private final UserRepository userRepository;
 
@@ -50,10 +49,9 @@ public class UserController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음"),
     })
     @GetMapping("/api/user/me")
-    public ResponseEntity<ApiResponse<GetUserInfoResponse>> getMyInfo() {
-        Long userId = securityContextProvider.getAuthenticatedUserId();
+    public ResponseEntity<ApiResponse<GetUserInfoResponse>> getMyInfo(@CurrentUser UserPrincipal currentUser) {
 
-        User user = userRepository.findById(userId)
+        User user = userRepository.findById(currentUser.userId())
                 .orElseThrow(() -> new LogueException(ErrorCode.USER_NOT_FOUND));
 
         GetUserInfoResponse response = GetUserInfoResponse.from(user);

--- a/apps/be/src/main/resources/application.properties
+++ b/apps/be/src/main/resources/application.properties
@@ -19,3 +19,10 @@ DISCORD_WEBHOOK_URL=
 # OAuth2
 # ================================
 spring.security.oauth2.client.registration.google.scope=profile,email
+
+# ================================
+# Test
+# ===============================
+spring.security.oauth2.client.registration.google.client-id=test
+spring.security.oauth2.client.registration.google.client-secret=test
+spring.jwt.secret=test-secret-key-that-is-long-enough-for-hs256

--- a/apps/be/src/main/resources/application.properties
+++ b/apps/be/src/main/resources/application.properties
@@ -20,9 +20,3 @@ DISCORD_WEBHOOK_URL=
 # ================================
 spring.security.oauth2.client.registration.google.scope=profile,email
 
-# ================================
-# Test
-# ===============================
-spring.security.oauth2.client.registration.google.client-id=test
-spring.security.oauth2.client.registration.google.client-secret=test
-spring.jwt.secret=test-secret-key-that-is-long-enough-for-hs256

--- a/apps/be/src/test/java/com/capstone/logue/UserControllerTest.java
+++ b/apps/be/src/test/java/com/capstone/logue/UserControllerTest.java
@@ -1,0 +1,156 @@
+package com.capstone.logue;
+
+import com.capstone.logue.auth.provider.JWTProvider;
+import com.capstone.logue.global.config.SecurityConfig;
+import com.capstone.logue.global.entity.User;
+import com.capstone.logue.global.exception.ErrorCode;
+import com.capstone.logue.global.exception.LogueException;
+import com.capstone.logue.user.controller.UserController;
+import com.capstone.logue.user.dto.GetUserInfoResponse;
+import com.capstone.logue.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+/**
+ * {@link UserController}의 GET /api/user/me API에 대한 슬라이스 테스트입니다.
+ *
+ * <p>{@link WebMvcTest}를 사용하여 DB 연결 없이 웹 레이어만 로드하며,
+ * {@link JWTProvider}와 {@link UserRepository}는 Mockito로 대체합니다.</p>
+ *
+ * <p>검증 대상:</p>
+ * <ul>
+ *   <li>JWT 필터 → {@code @CurrentUser} 주입 → 컨트롤러 실행까지의 전체 인증 흐름</li>
+ *   <li>토큰 유효성에 따른 HTTP 상태 코드 분기</li>
+ *   <li>사용자 조회 성공/실패에 따른 응답 처리</li>
+ * </ul>
+ */
+@WebMvcTest(UserController.class)
+@Import(SecurityConfig.class)
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private UserRepository userRepository;
+
+    @MockitoBean
+    private JWTProvider jwtProvider;
+
+    // SecurityConfig가 OAuth2 핸들러를 주입받으므로 MockBean 필요
+    @MockitoBean
+    private com.capstone.logue.auth.handler.OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+
+    @MockitoBean
+    private com.capstone.logue.auth.handler.OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
+
+    @MockitoBean
+    private com.capstone.logue.global.discord.DiscordWebhookService discordWebhookService;
+
+    private static final Long USER_ID = 1L;
+    private static final String VALID_TOKEN = "valid-token";
+
+
+    /**
+     * 유효한 JWT 토큰으로 요청 시 사용자 정보를 정상 반환하는지 검증합니다.
+     *
+     * <p>JWTFilter가 토큰을 파싱하여 userId를 추출하고,
+     * {@code @CurrentUser}를 통해 컨트롤러 파라미터에 주입된 뒤
+     * DB에서 사용자를 조회하여 200 응답을 반환하는 전체 흐름을 검증합니다.</p>
+     */
+    @Test
+    @DisplayName("유효한 토큰으로 요청 시 사용자 정보를 반환한다")
+    void getMyInfo_validToken_returns200() throws Exception {
+        // given
+        User user = User.builder()
+                .id(USER_ID)
+                .email("test@test.com")
+                .name("테스터")
+                .provider("GOOGLE")         // ← 추가
+                .profileImageUrl(null)      // ← null이면 생략해도 되지만 명시하는 게 안전
+                .build();
+
+        doNothing().when(jwtProvider).validateToken(VALID_TOKEN);
+        when(jwtProvider.getUserIdFromToken(VALID_TOKEN)).thenReturn(USER_ID);
+        when(jwtProvider.getEmailFromToken(VALID_TOKEN)).thenReturn("test@test.com");
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+
+        // when & then
+        mockMvc.perform(get("/api/user/me")
+                        .header("Authorization", "Bearer " + VALID_TOKEN))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.email").value("test@test.com"));
+    }
+
+
+    /**
+     * JWT 토큰은 유효하지만 해당 userId를 가진 사용자가 DB에 없을 때 404를 반환하는지 검증합니다.
+     *
+     * <p>토큰 탈취 후 계정이 삭제된 경우 등 인증은 통과했으나
+     * 사용자를 찾을 수 없는 예외 상황을 커버합니다.</p>
+     */
+    @Test
+    @DisplayName("유효한 토큰이지만 DB에 유저가 없으면 404를 반환한다")
+    void getMyInfo_userNotFound_returns404() throws Exception {
+        // given
+        doNothing().when(jwtProvider).validateToken(VALID_TOKEN);
+        when(jwtProvider.getUserIdFromToken(VALID_TOKEN)).thenReturn(USER_ID);
+        when(jwtProvider.getEmailFromToken(VALID_TOKEN)).thenReturn("test@test.com");
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.empty());
+
+        // when & then
+        mockMvc.perform(get("/api/user/me")
+                        .header("Authorization", "Bearer " + VALID_TOKEN))
+                .andExpect(status().isNotFound());
+    }
+
+
+    /**
+     * 토큰 없이 요청 시 OAuth2 로그인 페이지로 리다이렉트(302)되는지 검증합니다.
+     *
+     * <p>미인증 요청에 대해 Spring Security가 OAuth2 인증 흐름으로
+     * 리다이렉트하는 기본 동작을 검증합니다.</p>
+     */
+    @Test
+    @DisplayName("토큰 없이 요청 시 OAuth2 로그인 페이지로 리다이렉트된다")
+    @WithAnonymousUser
+    void getMyInfo_noToken_returns302() throws Exception {
+        mockMvc.perform(get("/api/user/me"))
+                .andExpect(status().is3xxRedirection());
+    }
+
+
+    /**
+     * 만료된 JWT 토큰으로 요청 시 401을 반환하는지 검증합니다.
+     *
+     * <p>JWTFilter가 토큰 검증 중 {@link LogueException}(EXPIRED_TOKEN)을 발생시키면
+     * 필터 내부에서 직접 JSON 에러 응답을 작성하여 401을 반환하는 흐름을 검증합니다.</p>
+     */
+    @Test
+    @DisplayName("만료된 토큰으로 요청 시 401을 반환한다")
+    void getMyInfo_expiredToken_returns401() throws Exception {
+        // given
+        doThrow(new LogueException(ErrorCode.EXPIRED_TOKEN))
+                .when(jwtProvider).validateToken("expired-token");
+
+        // when & then
+        mockMvc.perform(get("/api/user/me")
+                        .header("Authorization", "Bearer expired-token"))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/apps/be/src/test/java/com/capstone/logue/user/controller/UserControllerTest.java
+++ b/apps/be/src/test/java/com/capstone/logue/user/controller/UserControllerTest.java
@@ -22,6 +22,8 @@ import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
 
 
 /**
@@ -63,6 +65,13 @@ class UserControllerTest {
     private static final Long USER_ID = 1L;
     private static final String VALID_TOKEN = "valid-token";
 
+    // 성공 케이스 공통으로 쓸 Claims mock 생성 헬퍼
+    private Claims mockClaims(Long userId, String email) {
+        Claims claims = mock(Claims.class);
+        when(claims.get("userId", Long.class)).thenReturn(userId);
+        when(claims.get("email", String.class)).thenReturn(email);
+        return claims;
+    }
 
     /**
      * 유효한 JWT 토큰으로 요청 시 사용자 정보를 정상 반환하는지 검증합니다.
@@ -75,6 +84,8 @@ class UserControllerTest {
     @DisplayName("유효한 토큰으로 요청 시 사용자 정보를 반환한다")
     void getMyInfo_validToken_returns200() throws Exception {
         // given
+        Claims claims = mockClaims(USER_ID, "test@test.com");
+
         User user = User.builder()
                 .id(USER_ID)
                 .email("test@test.com")
@@ -83,9 +94,9 @@ class UserControllerTest {
                 .profileImageUrl(null)      // ← null이면 생략해도 되지만 명시하는 게 안전
                 .build();
 
-        doNothing().when(jwtProvider).validateToken(VALID_TOKEN);
-        when(jwtProvider.getUserIdFromToken(VALID_TOKEN)).thenReturn(USER_ID);
-        when(jwtProvider.getEmailFromToken(VALID_TOKEN)).thenReturn("test@test.com");
+        when(jwtProvider.validateToken(VALID_TOKEN)).thenReturn(claims); // ✅ Claims 반환
+        when(jwtProvider.getUserIdFromToken(claims)).thenReturn(USER_ID);
+        when(jwtProvider.getEmailFromToken(claims)).thenReturn("test@test.com");
         when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
 
         // when & then
@@ -106,9 +117,9 @@ class UserControllerTest {
     @DisplayName("유효한 토큰이지만 DB에 유저가 없으면 404를 반환한다")
     void getMyInfo_userNotFound_returns404() throws Exception {
         // given
-        doNothing().when(jwtProvider).validateToken(VALID_TOKEN);
-        when(jwtProvider.getUserIdFromToken(VALID_TOKEN)).thenReturn(USER_ID);
-        when(jwtProvider.getEmailFromToken(VALID_TOKEN)).thenReturn("test@test.com");
+        Claims claims = mockClaims(USER_ID, "test@test.com");
+
+        when(jwtProvider.validateToken(VALID_TOKEN)).thenReturn(claims);
         when(userRepository.findById(USER_ID)).thenReturn(Optional.empty());
 
         // when & then
@@ -143,8 +154,8 @@ class UserControllerTest {
     @DisplayName("만료된 토큰으로 요청 시 401을 반환한다")
     void getMyInfo_expiredToken_returns401() throws Exception {
         // given
-        doThrow(new LogueException(ErrorCode.EXPIRED_TOKEN))
-                .when(jwtProvider).validateToken("expired-token");
+        when(jwtProvider.validateToken("expired-token"))
+                .thenThrow(new LogueException(ErrorCode.EXPIRED_TOKEN));
 
         // when & then
         mockMvc.perform(get("/api/user/me")

--- a/apps/be/src/test/java/com/capstone/logue/user/controller/UserControllerTest.java
+++ b/apps/be/src/test/java/com/capstone/logue/user/controller/UserControllerTest.java
@@ -1,12 +1,10 @@
-package com.capstone.logue;
+package com.capstone.logue.user.controller;
 
 import com.capstone.logue.auth.provider.JWTProvider;
 import com.capstone.logue.global.config.SecurityConfig;
 import com.capstone.logue.global.entity.User;
 import com.capstone.logue.global.exception.ErrorCode;
 import com.capstone.logue.global.exception.LogueException;
-import com.capstone.logue.user.controller.UserController;
-import com.capstone.logue.user.dto.GetUserInfoResponse;
 import com.capstone.logue.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/apps/be/src/test/resources/application.properties
+++ b/apps/be/src/test/resources/application.properties
@@ -1,0 +1,6 @@
+# ================================
+# Test
+# ===============================
+spring.security.oauth2.client.registration.google.client-id=test
+spring.security.oauth2.client.registration.google.client-secret=test
+spring.jwt.secret=test-secret-key-that-is-long-enough-for-hs256


### PR DESCRIPTION
## 요약
- `@CurrentUser` 어노테이션 구현하며 기존 userId만 저장하던 토큰을 email 포함한 UserPrincipal을 저장하도록 수정.

## 변경 사항
- [x] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - .\gradlew test --tests com.capstone.logue.user.controller.UserControllerTest (4/4 성공)

## 스크린샷/로그 (선택)
X

## 롤백/리스크
- 리스크 포인트:
  - `UserPrincipal`이 null인 경우 컨트롤러에서 NPE 발생 가능 (`@PreAuthorize("isAuthenticated()"`) 없이 `@CurrentUser` 단독 사용 시)
  - 기존에 발급된 JWT 토큰에는 `email` 클레임이 없어서, 이미 로그인된 사용자가 토큰 만료 전까지 `getEmailFromToken()` 호출 시 `null` 반환
  - `SecurityContextProvider.getAuthenticatedUser()`로 메서드명이 변경되어 호출부 누락 시 컴파일 에러 발생 (`DataSourceController` 등)
- 롤백 방법:
  - `UserPrincipal` 삭제, `JWTFilter.setAuthentication()`을 `userId`만 받던 원래 방식으로 되돌리기
  - `JWTProvider.generateToken()` 시그니처를 `(Long userId, long expirationMillis)`로 복구
  - `SecurityContextProvider.getAuthenticatedUser()` → `getAuthenticatedUserId()` 로 복구, 반환 타입 `Long`으로 복구
  - `@CurrentUser UserPrincipal` → `@CurrentUser Long userId`로 복구

## 관련 이슈
Closes #42
