### PR TITLE
feat: 회원가입 API 구현

### DIFF
--- a/apps/be/src/main/java/com/capstone/logue/auth/handler/OAuth2LoginSuccessHandler.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/handler/OAuth2LoginSuccessHandler.java
@@ -93,6 +93,7 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         }
 
         String providerUserId = oAuth2UserInfo.getProviderUserId();
+        String name = oAuth2UserInfo.getName();
         String email = oAuth2UserInfo.getEmail();
         String profileImageUrl = oAuth2UserInfo.getProfileImageUrl();
 
@@ -107,6 +108,7 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
                     .fromUriString(REDIRECT_URI_ONBOARDING)
                     .queryParam("provider", provider)
                     .queryParam("providerUserId", providerUserId)
+                    .queryParam("name", name)
                     .queryParam("email", email)
                     .queryParam("profileImageUrl", profileImageUrl)
                     .build()

--- a/apps/be/src/main/java/com/capstone/logue/global/exception/ErrorCode.java
+++ b/apps/be/src/main/java/com/capstone/logue/global/exception/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
 
     // User
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "사용자를 찾을 수 없습니다."),
+    ALREADY_EXISTS_USER(HttpStatus.CONFLICT, "U002", "이미 존재하는 사용자입니다."),
 
     // DataSource
     DATASOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "D001", "데이터 소스를 찾을 수 없습니다."),

--- a/apps/be/src/main/java/com/capstone/logue/user/controller/UserController.java
+++ b/apps/be/src/main/java/com/capstone/logue/user/controller/UserController.java
@@ -8,13 +8,18 @@ import com.capstone.logue.global.exception.ErrorCode;
 import com.capstone.logue.global.exception.LogueException;
 import com.capstone.logue.global.response.ApiResponse;
 import com.capstone.logue.user.dto.GetUserInfoResponse;
+import com.capstone.logue.user.dto.SignUpRequest;
+import com.capstone.logue.user.dto.SignUpResponse;
 import com.capstone.logue.user.repository.UserRepository;
+import com.capstone.logue.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -26,9 +31,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 public class UserController {
-    /** 사용자 조회를 위한 repository */
-    private final UserRepository userRepository;
-
+    private final UserService userService;
 
     /**
      * 현재 로그인한 사용자의 정보를 조회합니다.
@@ -51,10 +54,20 @@ public class UserController {
     @GetMapping("/api/user/me")
     public ResponseEntity<ApiResponse<GetUserInfoResponse>> getMyInfo(@CurrentUser UserPrincipal currentUser) {
 
-        User user = userRepository.findById(currentUser.userId())
-                .orElseThrow(() -> new LogueException(ErrorCode.USER_NOT_FOUND));
+        User user = userService.findById(currentUser.userId());
 
         GetUserInfoResponse response = GetUserInfoResponse.from(user);
         return ResponseEntity.ok(ApiResponse.success("사용자 정보 조회 성공", response));
+    }
+
+    /**
+     * 유저 회원가입 진행
+     * @return X
+     */
+    @Operation(summary = "사용자 회원가입")
+    @PostMapping("/api/user/signup")
+    public ResponseEntity<ApiResponse<SignUpResponse>> signupUser(@RequestBody SignUpRequest request) {
+        SignUpResponse response = userService.signupUser(request);
+        return ResponseEntity.ok(ApiResponse.success("사용자 회원가입 성공", response));
     }
 }

--- a/apps/be/src/main/java/com/capstone/logue/user/dto/SignUpRequest.java
+++ b/apps/be/src/main/java/com/capstone/logue/user/dto/SignUpRequest.java
@@ -1,0 +1,30 @@
+package com.capstone.logue.user.dto;
+
+import com.capstone.logue.global.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 사용자 회원가입 요청을 위한 DTO입니다.
+ *
+ * <p>{@link com.capstone.logue.user.controller.UserController}의
+ * /api/user/signup API에서 사용됩니다.</p>
+ */
+public record SignUpRequest(
+        String email,
+        String name,
+        String provider,
+        String providerUserId,
+        String profileImageUrl
+) {
+
+    public static User toEntity(String provider, String providerUserId, String email, String name, String profileImageUrl) {
+        return User.builder()
+                .provider(provider)
+                .providerUserId(providerUserId)
+                .email(email)
+                .name(name)
+                .profileImageUrl(profileImageUrl)
+                .build();
+    }
+}

--- a/apps/be/src/main/java/com/capstone/logue/user/dto/SignUpResponse.java
+++ b/apps/be/src/main/java/com/capstone/logue/user/dto/SignUpResponse.java
@@ -1,0 +1,4 @@
+package com.capstone.logue.user.dto;
+
+public record SignUpResponse(String accessToken) {
+}

--- a/apps/be/src/main/java/com/capstone/logue/user/service/UserService.java
+++ b/apps/be/src/main/java/com/capstone/logue/user/service/UserService.java
@@ -34,6 +34,9 @@ public class UserService {
 
     @Transactional
     public SignUpResponse signupUser(SignUpRequest request){
+        if (userRepository.findByProviderUserId(request.providerUserId()).isPresent())
+            throw new LogueException(ErrorCode.ALREADY_EXISTS_USER);
+
         User user = userRepository.save(
                 SignUpRequest.toEntity(
                         request.provider(),

--- a/apps/be/src/main/java/com/capstone/logue/user/service/UserService.java
+++ b/apps/be/src/main/java/com/capstone/logue/user/service/UserService.java
@@ -1,0 +1,50 @@
+package com.capstone.logue.user.service;
+
+import com.capstone.logue.auth.provider.JWTProvider;
+import com.capstone.logue.global.entity.User;
+import com.capstone.logue.global.exception.ErrorCode;
+import com.capstone.logue.global.exception.LogueException;
+import com.capstone.logue.user.dto.SignUpRequest;
+import com.capstone.logue.user.dto.SignUpResponse;
+import com.capstone.logue.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    /** access token 만료 시간 */
+    @Value("${spring.jwt.access-token.expiration-time}")
+    private long ACCESS_TOKEN_EXPIRATION_TIME;
+
+    private final JWTProvider jwtProvider;
+    private final UserRepository userRepository;
+
+
+    public User findById(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new LogueException(ErrorCode.USER_NOT_FOUND));
+
+        return user;
+    }
+
+    @Transactional
+    public SignUpResponse signupUser(SignUpRequest request){
+        User user = userRepository.save(
+                SignUpRequest.toEntity(
+                        request.provider(),
+                        request.providerUserId(),
+                        request.email(),
+                        request.name(),
+                        request.profileImageUrl()
+                )
+        );
+
+        String accessToken = jwtProvider.generateToken(user.getId(), user.getEmail(), ACCESS_TOKEN_EXPIRATION_TIME);
+        return new SignUpResponse(accessToken);
+    }
+}

--- a/apps/be/src/main/resources/db/migration/V1__init.sql
+++ b/apps/be/src/main/resources/db/migration/V1__init.sql
@@ -214,7 +214,7 @@ CREATE TABLE ai_tagging_jobs
     status          VARCHAR(20) NOT NULL,
     error_message   TEXT,
     request_payload JSONB,
-    started_at      TIMESTAMPTZ
+    started_at      TIMESTAMPTZ,
     finished_at     TIMESTAMPTZ
 );
 


### PR DESCRIPTION
## 요약
- 새로운 계정으로 구글 로그인 시 DB에 저장하는 회원가입 API 구현

## 변경 사항
- [x] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - swagger에서 `api/user/signup` 후 DB에 정상 저장 확인

## 스크린샷/로그 (선택)
- 필요한 경우 첨부

## 롤백/리스크
- 리스크 포인트: 
- 롤백 방법: git revert로 이전 커밋으로 복구

## 관련 이슈
Closes #16 
