### PR TITLE
feat: refresh token 구현

### DIFF
--- a/apps/be/build.gradle
+++ b/apps/be/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 	//DB (JPA+PostgreSQL)
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'org.postgresql:postgresql'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 	//DB Migration (Flyway)
 	implementation 'org.flywaydb:flyway-core'

--- a/apps/be/src/main/java/com/capstone/logue/auth/controller/AuthController.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/controller/AuthController.java
@@ -1,0 +1,32 @@
+package com.capstone.logue.auth.controller;
+
+import com.capstone.logue.auth.dto.ReIssueTokenResponse;
+import com.capstone.logue.auth.service.AuthService;
+import com.capstone.logue.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Auth", description = "인증 API")
+@RestController
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @Operation(summary = "토큰 재발급", description = "Refresh Token으로 Access Token과 Refresh Token을 재발급합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "재발급 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "유효하지 않은 토큰"),
+    })
+    @PostMapping("/api/auth/reissue")
+    public ResponseEntity<ApiResponse<ReIssueTokenResponse>> reIssueToken(@RequestHeader("Refresh-Token") String refreshToken) {
+        ReIssueTokenResponse response = authService.reIssueToken(refreshToken);
+        return ResponseEntity.ok(ApiResponse.success("토큰 재발급 성공", response));
+    }
+}

--- a/apps/be/src/main/java/com/capstone/logue/auth/dto/ReIssueTokenResponse.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/dto/ReIssueTokenResponse.java
@@ -1,0 +1,4 @@
+package com.capstone.logue.auth.dto;
+
+public record ReIssueTokenResponse(String accessToken, String refreshToken) {
+}

--- a/apps/be/src/main/java/com/capstone/logue/auth/filter/JWTFilter.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/filter/JWTFilter.java
@@ -90,6 +90,7 @@ public class JWTFilter extends OncePerRequestFilter {
                 || path.equals("/health") || path.equals("/error")
                 || path.startsWith("/oauth2") || path.startsWith("/login/oauth2/")
                 || path.startsWith("/swagger-ui/") || path.startsWith("/v3/api-docs")
+                || path.equals("/api/auth/reissue")
                 ;
     }
 

--- a/apps/be/src/main/java/com/capstone/logue/auth/filter/JWTFilter.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/filter/JWTFilter.java
@@ -75,26 +75,6 @@ public class JWTFilter extends OncePerRequestFilter {
     }
 
     /**
-     * JWT 인증 필터를 적용하지 않을 경로를 지정합니다.
-     *
-     * <p>루트, 헬스 체크, 에러 페이지, OAuth2 로그인 관련 경로,
-     * Swagger 문서 경로 등은 JWT 인증 없이 접근할 수 있도록 제외합니다.</p>
-     *
-     * @param request HTTP 요청
-     * @return 필터 적용 제외 여부
-     */
-    @Override
-    protected boolean shouldNotFilter(HttpServletRequest request) {
-        String path = request.getServletPath();
-        return path.equals("/")
-                || path.equals("/health") || path.equals("/error")
-                || path.startsWith("/oauth2") || path.startsWith("/login/oauth2/")
-                || path.startsWith("/swagger-ui/") || path.startsWith("/v3/api-docs")
-                || path.equals("/api/auth/reissue")
-                ;
-    }
-
-    /**
      * Authorization 헤더에서 Bearer access token을 추출합니다.
      *
      * <p>헤더가 없거나 Bearer 형식이 아니면 null을 반환합니다.</p>

--- a/apps/be/src/main/java/com/capstone/logue/auth/handler/OAuth2LoginSuccessHandler.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/handler/OAuth2LoginSuccessHandler.java
@@ -1,6 +1,8 @@
 package com.capstone.logue.auth.handler;
 
 import com.capstone.logue.auth.provider.JWTProvider;
+import com.capstone.logue.auth.service.AuthService;
+import com.capstone.logue.auth.service.RefreshTokenService;
 import com.capstone.logue.global.entity.User;
 import com.capstone.logue.auth.dto.GoogleUserInfo;
 import com.capstone.logue.auth.dto.OAuth2UserInfo;
@@ -65,6 +67,8 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
     /** 사용자 조회를 위한 repository */
     private final UserRepository userRepository;
 
+    private final RefreshTokenService refreshTokenService;
+
 
     /**
      * OAuth2 로그인 성공 시 호출되는 메서드입니다.
@@ -124,9 +128,12 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
             String accessToken = jwtProvider.generateToken(existUser.getId(), existUser.getEmail(), ACCESS_TOKEN_EXPIRATION_TIME);
             String refreshToken = jwtProvider.generateToken(existUser.getId(), existUser.getEmail(), REFRESH_TOKEN_EXPIRATION_TIME);
 
+            refreshTokenService.saveRefreshToken(existUser.getId(), refreshToken);
+
             String redirectUrl = UriComponentsBuilder
                     .fromUriString(REDIRECT_URI_BASE)
                     .queryParam("accessToken", accessToken)
+                    .queryParam("refreshToken", refreshToken)
                     .build()
                     .toUriString();
 

--- a/apps/be/src/main/java/com/capstone/logue/auth/handler/OAuth2LoginSuccessHandler.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/handler/OAuth2LoginSuccessHandler.java
@@ -54,6 +54,10 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
     @Value("${spring.jwt.access-token.expiration-time}")
     private long ACCESS_TOKEN_EXPIRATION_TIME;
 
+    /** refresh token 만료 시간 */
+    @Value("${spring.jwt.refresh-token.expiration-time}")
+    private long REFRESH_TOKEN_EXPIRATION_TIME;
+
 
     /** JWT 생성 및 파싱을 담당하는 provider */
     private final JWTProvider jwtProvider;
@@ -118,6 +122,7 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
             log.info("기존 유저입니다. userId={}", existUser.getId());
 
             String accessToken = jwtProvider.generateToken(existUser.getId(), existUser.getEmail(), ACCESS_TOKEN_EXPIRATION_TIME);
+            String refreshToken = jwtProvider.generateToken(existUser.getId(), existUser.getEmail(), REFRESH_TOKEN_EXPIRATION_TIME);
 
             String redirectUrl = UriComponentsBuilder
                     .fromUriString(REDIRECT_URI_BASE)

--- a/apps/be/src/main/java/com/capstone/logue/auth/handler/OAuth2LoginSuccessHandler.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/handler/OAuth2LoginSuccessHandler.java
@@ -120,10 +120,14 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
 
         log.info("OAuth 로그인 성공. providerUserId = {}", providerUserId);
         String accessToken = jwtProvider.generateToken(user.getId(), user.getEmail(), ACCESS_TOKEN_EXPIRATION_TIME);
+        String refreshToken = jwtProvider.generateToken(user.getId(), user.getEmail(), REFRESH_TOKEN_EXPIRATION_TIME);
+
+        refreshTokenService.saveRefreshToken(user.getId(), refreshToken);
 
         String redirectUrl = UriComponentsBuilder
                 .fromUriString(REDIRECT_URI_BASE)
                 .queryParam("accessToken", accessToken)
+                .queryParam("refreshToken", refreshToken)
                 .build()
                 .toUriString();
 

--- a/apps/be/src/main/java/com/capstone/logue/auth/repository/RefreshTokenRepository.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/repository/RefreshTokenRepository.java
@@ -1,11 +1,70 @@
 package com.capstone.logue.auth.repository;
 
-import com.capstone.logue.global.entity.RefreshToken;
-import org.springframework.data.jpa.repository.JpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.util.HexFormat;
+import java.util.List;
 
-public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
-    Optional<RefreshToken> findByUserId(Long userId);
-    void deleteByUserId(Long userId);
+@Repository
+@RequiredArgsConstructor
+public class RefreshTokenRepository {
+
+    private static final DefaultRedisScript<Long> COMPARE_AND_SET_SCRIPT =
+            new DefaultRedisScript<>(
+                    "if redis.call('GET', KEYS[1]) == ARGV[1] then " +
+                            "  redis.call('SET', KEYS[1], ARGV[2], 'EX', ARGV[3]) " +
+                            "  return 1 " +
+                            "else return 0 end",
+                    Long.class);
+
+    private final StringRedisTemplate redisTemplate;
+
+    @Value("${spring.jwt.refresh-token.expiration-time}")
+    private long REFRESH_TOKEN_EXPIRATION_TIME;
+
+    public void save(Long userId, String refreshToken) {
+        redisTemplate.opsForValue().set(
+                buildKey(userId),
+                hash(refreshToken),
+                Duration.ofMillis(REFRESH_TOKEN_EXPIRATION_TIME)
+        );
+    }
+
+    public void deleteByUserId(Long userId) {
+        redisTemplate.delete(buildKey(userId));
+    }
+
+    public boolean rotate(Long userId, String expectedOld, String newToken) {
+        long ttlSeconds = REFRESH_TOKEN_EXPIRATION_TIME / 1000;
+        Long result = redisTemplate.execute(
+                COMPARE_AND_SET_SCRIPT,
+                List.of(buildKey(userId)),
+                hash(expectedOld),
+                hash(newToken),
+                String.valueOf(ttlSeconds)
+        );
+        return Long.valueOf(1L).equals(result);
+    }
+
+    private String buildKey(Long userId) {
+        return "refresh:" + userId;
+    }
+
+    private String hash(String token) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] bytes = digest.digest(token.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(bytes);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 알고리즘을 사용할 수 없습니다", e);
+        }
+    }
 }

--- a/apps/be/src/main/java/com/capstone/logue/auth/repository/RefreshTokenRepository.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,11 @@
+package com.capstone.logue.auth.repository;
+
+import com.capstone.logue.global.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByUserId(Long userId);
+    void deleteByUserId(Long userId);
+}

--- a/apps/be/src/main/java/com/capstone/logue/auth/service/AuthService.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/service/AuthService.java
@@ -35,23 +35,14 @@ public class AuthService {
         Long userId = jwtProvider.getUserIdFromToken(claims);
         String email = jwtProvider.getEmailFromToken(claims);
 
-        // 2. DB에서 저장된 토큰 조회 및 검증
-        RefreshToken storedToken = refreshTokenService.getRefreshToken(userId);
-
-        if (!storedToken.getToken().equals(refreshToken)) {
-            throw new LogueException(ErrorCode.INVALID_TOKEN);
-        }
-
-        if (storedToken.getExpiresAt().isBefore(LocalDateTime.now())) {
-            refreshTokenService.deleteByUserId(userId);
-            throw new LogueException(ErrorCode.EXPIRED_TOKEN);
-        }
-
-        // 3. 새 토큰 발급 및 저장
+        // 2. CAS로 rotate (이전 토큰 일치 확인 + 새 토큰 저장 원자 실행)
         String newAccessToken = jwtProvider.generateToken(userId, email, ACCESS_TOKEN_EXPIRATION_TIME);
         String newRefreshToken = jwtProvider.generateToken(userId, email, REFRESH_TOKEN_EXPIRATION_TIME);
 
-        refreshTokenService.saveRefreshToken(userId, newRefreshToken);
+        boolean rotated = refreshTokenService.rotate(userId, refreshToken, newRefreshToken);
+        if (!rotated) {
+            throw new LogueException(ErrorCode.INVALID_TOKEN);
+        }
 
         return new ReIssueTokenResponse(newAccessToken, newRefreshToken);
     }

--- a/apps/be/src/main/java/com/capstone/logue/auth/service/AuthService.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/service/AuthService.java
@@ -1,0 +1,58 @@
+package com.capstone.logue.auth.service;
+
+import com.capstone.logue.auth.dto.ReIssueTokenResponse;
+import com.capstone.logue.auth.provider.JWTProvider;
+import com.capstone.logue.auth.repository.RefreshTokenRepository;
+import com.capstone.logue.global.entity.RefreshToken;
+import com.capstone.logue.global.exception.ErrorCode;
+import com.capstone.logue.global.exception.LogueException;
+import io.jsonwebtoken.Claims;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+    private final JWTProvider jwtProvider;
+    private final RefreshTokenService refreshTokenService;
+
+    @Value("${spring.jwt.access-token.expiration-time}")
+    private long ACCESS_TOKEN_EXPIRATION_TIME;
+
+    @Value("${spring.jwt.refresh-token.expiration-time}")
+    private long REFRESH_TOKEN_EXPIRATION_TIME;
+
+    @Transactional
+    public ReIssueTokenResponse reIssueToken(String refreshToken) {
+        // 1. 토큰에서 userId 추출
+        Claims claims = jwtProvider.validateToken(refreshToken);
+        Long userId = jwtProvider.getUserIdFromToken(claims);
+        String email = jwtProvider.getEmailFromToken(claims);
+
+        // 2. DB에서 저장된 토큰 조회 및 검증
+        RefreshToken storedToken = refreshTokenService.getRefreshToken(userId);
+
+        if (!storedToken.getToken().equals(refreshToken)) {
+            throw new LogueException(ErrorCode.INVALID_TOKEN);
+        }
+
+        if (storedToken.getExpiresAt().isBefore(LocalDateTime.now())) {
+            refreshTokenService.deleteByUserId(userId);
+            throw new LogueException(ErrorCode.EXPIRED_TOKEN);
+        }
+
+        // 3. 새 토큰 발급 및 저장
+        String newAccessToken = jwtProvider.generateToken(userId, email, ACCESS_TOKEN_EXPIRATION_TIME);
+        String newRefreshToken = jwtProvider.generateToken(userId, email, REFRESH_TOKEN_EXPIRATION_TIME);
+
+        refreshTokenService.saveRefreshToken(userId, newRefreshToken);
+
+        return new ReIssueTokenResponse(newAccessToken, newRefreshToken);
+    }
+}

--- a/apps/be/src/main/java/com/capstone/logue/auth/service/RefreshTokenService.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/service/RefreshTokenService.java
@@ -1,0 +1,44 @@
+package com.capstone.logue.auth.service;
+
+import com.capstone.logue.auth.repository.RefreshTokenRepository;
+import com.capstone.logue.global.entity.RefreshToken;
+import com.capstone.logue.global.exception.ErrorCode;
+import com.capstone.logue.global.exception.LogueException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Value("${spring.jwt.refresh-token.expiration-time}")
+    private long REFRESH_TOKEN_EXPIRATION_TIME;
+
+    // 저장 (기존 토큰 있으면 덮어쓰기)
+    @Transactional
+    public void saveRefreshToken(Long userId, String token) {
+        refreshTokenRepository.deleteByUserId(userId);
+        refreshTokenRepository.save(RefreshToken.builder()
+                .userId(userId)
+                .token(token)
+                .expiresAt(LocalDateTime.now().plusSeconds(REFRESH_TOKEN_EXPIRATION_TIME / 1000))
+                .build());
+    }
+
+    // 조회
+    public RefreshToken getRefreshToken(Long userId) {
+        return refreshTokenRepository.findByUserId(userId)
+                .orElseThrow(() -> new LogueException(ErrorCode.EXPIRED_TOKEN));
+    }
+
+    // 삭제
+    @Transactional
+    public void deleteByUserId(Long userId) {
+        refreshTokenRepository.deleteByUserId(userId);
+    }
+}

--- a/apps/be/src/main/java/com/capstone/logue/auth/service/RefreshTokenService.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/service/RefreshTokenService.java
@@ -20,25 +20,17 @@ public class RefreshTokenService {
     private long REFRESH_TOKEN_EXPIRATION_TIME;
 
     // 저장 (기존 토큰 있으면 덮어쓰기)
-    @Transactional
-    public void saveRefreshToken(Long userId, String token) {
-        refreshTokenRepository.deleteByUserId(userId);
-        refreshTokenRepository.save(RefreshToken.builder()
-                .userId(userId)
-                .token(token)
-                .expiresAt(LocalDateTime.now().plusSeconds(REFRESH_TOKEN_EXPIRATION_TIME / 1000))
-                .build());
-    }
-
-    // 조회
-    public RefreshToken getRefreshToken(Long userId) {
-        return refreshTokenRepository.findByUserId(userId)
-                .orElseThrow(() -> new LogueException(ErrorCode.EXPIRED_TOKEN));
+    public void saveRefreshToken(Long userId, String refreshToken) {
+        refreshTokenRepository.save(userId, refreshToken);
     }
 
     // 삭제
-    @Transactional
     public void deleteByUserId(Long userId) {
         refreshTokenRepository.deleteByUserId(userId);
+    }
+
+    // Refresh Token 재발급할 때 동시 요청 방어
+    public boolean rotate(Long userId, String expectedOld, String newToken) {
+        return refreshTokenRepository.rotate(userId, expectedOld, newToken);
     }
 }

--- a/apps/be/src/main/java/com/capstone/logue/global/config/SecurityConfig.java
+++ b/apps/be/src/main/java/com/capstone/logue/global/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import com.capstone.logue.auth.filter.JWTFilter;
 import com.capstone.logue.auth.handler.OAuth2LoginFailureHandler;
 import com.capstone.logue.auth.handler.OAuth2LoginSuccessHandler;
 import com.capstone.logue.auth.provider.JWTProvider;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -82,6 +83,13 @@ public class SecurityConfig {
                                 "/swagger-resources/**"
                         ).permitAll()
                         .anyRequest().authenticated()
+                )
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint((request, response, authException) -> {
+                            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                            response.setContentType("application/json");
+                            response.getWriter().write("{\"code\": \"A001\", \"message\": \"인증이 필요합니다.\", \"data\": null}");
+                        })
                 )
                 .addFilterBefore(new JWTFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)
                 .build();

--- a/apps/be/src/main/java/com/capstone/logue/global/config/SecurityConfig.java
+++ b/apps/be/src/main/java/com/capstone/logue/global/config/SecurityConfig.java
@@ -74,6 +74,7 @@ public class SecurityConfig {
                                 "/",
                                 "/oauth2/**",
                                 "/login/oauth2/**",
+                                "/api/auth/reissue",
                                 "/health",
                                 "/v3/api-docs/**",
                                 "/swagger-ui/**",

--- a/apps/be/src/main/java/com/capstone/logue/global/entity/RefreshToken.java
+++ b/apps/be/src/main/java/com/capstone/logue/global/entity/RefreshToken.java
@@ -1,0 +1,29 @@
+package com.capstone.logue.global.entity;
+
+import com.capstone.logue.global.entity.base.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "refresh_tokens")
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class RefreshToken extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private String token;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+}

--- a/apps/be/src/main/java/com/capstone/logue/user/controller/UserController.java
+++ b/apps/be/src/main/java/com/capstone/logue/user/controller/UserController.java
@@ -1,8 +1,10 @@
 package com.capstone.logue.user.controller;
 
 import com.capstone.logue.auth.annotation.CurrentUser;
+import com.capstone.logue.auth.dto.ReIssueTokenResponse;
 import com.capstone.logue.auth.provider.SecurityContextProvider;
 import com.capstone.logue.auth.security.UserPrincipal;
+import com.capstone.logue.auth.service.AuthService;
 import com.capstone.logue.global.entity.User;
 import com.capstone.logue.global.exception.ErrorCode;
 import com.capstone.logue.global.exception.LogueException;
@@ -15,6 +17,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -57,4 +61,20 @@ public class UserController {
         GetUserInfoResponse response = GetUserInfoResponse.from(user);
         return ResponseEntity.ok(ApiResponse.success("사용자 정보 조회 성공", response));
     }
+
+    @Tag(name = "Auth", description = "인증 API")
+    @RestController
+    @RequiredArgsConstructor
+    public class AuthController {
+
+        private final AuthService authService;
+
+        @Operation(summary = "토큰 재발급")
+        @PostMapping("/api/auth/reissue")
+        public ResponseEntity<ApiResponse<ReIssueTokenResponse>> reIssueToken(@RequestHeader("Refresh-Token") String refreshToken) {
+            ReIssueTokenResponse response = authService.reIssueToken(refreshToken);
+            return ResponseEntity.ok(ApiResponse.success("토큰 재발급 성공", response));
+        }
+    }
+
 }

--- a/apps/be/src/main/java/com/capstone/logue/user/controller/UserController.java
+++ b/apps/be/src/main/java/com/capstone/logue/user/controller/UserController.java
@@ -1,10 +1,8 @@
 package com.capstone.logue.user.controller;
 
 import com.capstone.logue.auth.annotation.CurrentUser;
-import com.capstone.logue.auth.dto.ReIssueTokenResponse;
 import com.capstone.logue.auth.provider.SecurityContextProvider;
 import com.capstone.logue.auth.security.UserPrincipal;
-import com.capstone.logue.auth.service.AuthService;
 import com.capstone.logue.global.entity.User;
 import com.capstone.logue.global.exception.ErrorCode;
 import com.capstone.logue.global.exception.LogueException;
@@ -17,10 +15,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -34,7 +28,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
     /** 사용자 조회를 위한 repository */
     private final UserRepository userRepository;
-
 
     /**
      * 현재 로그인한 사용자의 정보를 조회합니다.
@@ -62,21 +55,6 @@ public class UserController {
 
         GetUserInfoResponse response = GetUserInfoResponse.from(user);
         return ResponseEntity.ok(ApiResponse.success("사용자 정보 조회 성공", response));
-    }
-
-    @Tag(name = "Auth", description = "인증 API")
-    @RestController
-    @RequiredArgsConstructor
-    public class AuthController {
-
-        private final AuthService authService;
-
-        @Operation(summary = "토큰 재발급")
-        @PostMapping("/api/auth/reissue")
-        public ResponseEntity<ApiResponse<ReIssueTokenResponse>> reIssueToken(@RequestHeader("Refresh-Token") String refreshToken) {
-            ReIssueTokenResponse response = authService.reIssueToken(refreshToken);
-            return ResponseEntity.ok(ApiResponse.success("토큰 재발급 성공", response));
-        }
     }
 
 }

--- a/apps/be/src/main/resources/db/migration/V1__init.sql
+++ b/apps/be/src/main/resources/db/migration/V1__init.sql
@@ -230,3 +230,15 @@ CREATE INDEX idx_ai_tagging_jobs_conversation_id_stage_status
     ON ai_tagging_jobs (conversation_id, stage, status);
 CREATE INDEX idx_ai_tagging_jobs_conversation_id_created_at
     ON ai_tagging_jobs (conversation_id, created_at);
+
+CREATE TABLE refresh_tokens
+(
+    id         BIGSERIAL PRIMARY KEY,
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL,
+    user_id    BIGINT      NOT NULL REFERENCES users (id),
+    token      TEXT        NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX idx_refresh_tokens_user_id ON refresh_tokens (user_id);

--- a/apps/be/src/main/resources/db/migration/V1__init.sql
+++ b/apps/be/src/main/resources/db/migration/V1__init.sql
@@ -230,15 +230,3 @@ CREATE INDEX idx_ai_tagging_jobs_conversation_id_stage_status
     ON ai_tagging_jobs (conversation_id, stage, status);
 CREATE INDEX idx_ai_tagging_jobs_conversation_id_created_at
     ON ai_tagging_jobs (conversation_id, created_at);
-
-CREATE TABLE refresh_tokens
-(
-    id         BIGSERIAL PRIMARY KEY,
-    created_at TIMESTAMPTZ NOT NULL,
-    updated_at TIMESTAMPTZ NOT NULL,
-    user_id    BIGINT      NOT NULL REFERENCES users (id),
-    token      TEXT        NOT NULL,
-    expires_at TIMESTAMPTZ NOT NULL
-);
-
-CREATE INDEX idx_refresh_tokens_user_id ON refresh_tokens (user_id);

--- a/apps/be/src/main/resources/db/migration/V2__add_refresh_token_table.sql
+++ b/apps/be/src/main/resources/db/migration/V2__add_refresh_token_table.sql
@@ -1,0 +1,11 @@
+CREATE TABLE refresh_tokens
+(
+    id         BIGSERIAL PRIMARY KEY,
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL,
+    user_id    BIGINT      NOT NULL REFERENCES users (id),
+    token      TEXT        NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX idx_refresh_tokens_user_id ON refresh_tokens (user_id);


### PR DESCRIPTION
## 요약
- JWT Refresh Token 발급 및 Redis 기반 Refresh Token 관리 구현

## 변경 사항
- [x] 기능
  - OAuth2 로그인 성공 시 Access Token + Refresh Token 동시 발급
  - Refresh Token Redis 저장 (SHA-256 해시, CAS rotate로 동시 요청 방어)
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `./gradlew bootrun --args='--spring.profiles.active=local'`
  - Google OAuth2 로그인 후 accessToken, refreshToken 쿼리파라미터 수신 확인
  - refresh token Redis 저장 확인
  - Swagger `/api/auth/reissue` 호출 → 새 토큰 발급 확인

## 스크린샷/로그 (선택)

## 롤백/리스크
- 리스크 포인트:
 - Redis 장애 시 토큰 재발급 불가 (로그인은 가능)
 - EC2 Redis 재시작 시 저장된 토큰 전부 소멸 → 사용자 재로그인 필요
- 롤백 방법:
  - git revert로 이전 커밋 복구
  - Redis 데이터는 redis-cli flushall로 초기화 가능

## 관련 이슈
Closes #46 
