### PR TITLE
feat: 질문 분석 플로우 - 분석 기준 도출/조회/수정/취소/상태폴링 API 및 FastAPI 연동 (#82)

### DIFF
--- a/apps/be/src/main/java/com/capstone/logue/anal/client/FastApiClient.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/client/FastApiClient.java
@@ -2,6 +2,8 @@ package com.capstone.logue.anal.client;
 
 import com.capstone.logue.anal.dto.fastapi.response.FileAnalysisResponse;
 import com.capstone.logue.anal.dto.fastapi.request.FileAnalysisRequest;
+import com.capstone.logue.anal.dto.fastapi.request.QuestionAnalysisRequest;
+import com.capstone.logue.anal.dto.fastapi.response.QuestionAnalysisResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -49,6 +51,32 @@ public class FastApiClient {
                 HttpMethod.POST,
                 new HttpEntity<>(request, headers),
                 FileAnalysisResponse.class
+        );
+
+        if (response.getBody() == null) {
+            throw new IllegalStateException("FastAPI 응답 body가 null입니다.");
+        }
+        return response;
+    }
+
+    /**
+     * FastAPI 서버에 질문 → 분석 기준 도출을 요청합니다.
+     *
+     * <p>응답 body 가 null 인 경우 예외가 발생합니다.</p>
+     *
+     * @param request 질문 분석 요청 DTO
+     * @return FastAPI 응답 (HTTP 상태 코드 + body 포함)
+     * @throws IllegalStateException 응답 body 가 null 인 경우
+     */
+    public ResponseEntity<QuestionAnalysisResponse> resolveAnalysisCriteria(QuestionAnalysisRequest request) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        ResponseEntity<QuestionAnalysisResponse> response = fastApiRestTemplate.exchange(
+                fastApiBaseUrl + "/v1/llm/analysis-criteria/resolve",
+                HttpMethod.POST,
+                new HttpEntity<>(request, headers),
+                QuestionAnalysisResponse.class
         );
 
         if (response.getBody() == null) {

--- a/apps/be/src/main/java/com/capstone/logue/anal/client/FastApiClient.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/client/FastApiClient.java
@@ -79,7 +79,7 @@ public class FastApiClient {
                 QuestionAnalysisResponse.class
         );
 
-        if (response.getBody() == null) {
+        if (response.getStatusCode().is2xxSuccessful() && response.getBody() == null) {
             throw new IllegalStateException("FastAPI 응답 body가 null입니다.");
         }
         return response;

--- a/apps/be/src/main/java/com/capstone/logue/anal/controller/AnalController.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/controller/AnalController.java
@@ -13,6 +13,7 @@ import com.capstone.logue.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -179,7 +180,7 @@ public class AnalController {
     public ResponseEntity<ApiResponse<CreateQuestionResponse>> createQuestion(
             @PathVariable Long conversationId,
             @PathVariable Long analysisFlowId,
-            @RequestBody CreateQuestionRequest request) {
+            @Valid @RequestBody CreateQuestionRequest request) {
         return ResponseEntity.ok(ApiResponse.success(
                 "질문 분석 성공",
                 questionCriteriaService.createQuestion(conversationId, analysisFlowId, request)));

--- a/apps/be/src/main/java/com/capstone/logue/anal/controller/AnalController.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/controller/AnalController.java
@@ -1,9 +1,12 @@
 package com.capstone.logue.anal.controller;
 
 import com.capstone.logue.anal.dto.spring.request.CreateAnalysisFlowRequest;
+import com.capstone.logue.anal.dto.spring.request.CreateQuestionRequest;
+import com.capstone.logue.anal.dto.spring.request.UpdateQuestionCriteriaRequest;
 import com.capstone.logue.anal.dto.spring.response.*;
 import com.capstone.logue.anal.service.AnalService;
 import com.capstone.logue.anal.service.JobRetryService;
+import com.capstone.logue.anal.service.QuestionCriteriaService;
 import com.capstone.logue.auth.annotation.CurrentUser;
 import com.capstone.logue.auth.security.UserPrincipal;
 import com.capstone.logue.global.response.ApiResponse;
@@ -28,6 +31,7 @@ public class AnalController {
 
     private final AnalService analService;
     private final JobRetryService jobRetryService;
+    private final QuestionCriteriaService questionCriteriaService;
 
     /**
      * 새로운 분석 대화를 시작합니다.
@@ -155,5 +159,127 @@ public class AnalController {
     public ResponseEntity<ApiResponse<Void>> retryJob(@PathVariable Long jobId) {
         jobRetryService.retryJob(jobId);
         return ResponseEntity.accepted().build();
+    }
+
+    /**
+     * 사용자 질문을 전송하고 분석 기준 도출 작업을 시작합니다.
+     *
+     * @param conversationId 대화 ID
+     * @param analysisFlowId 분석 흐름 ID
+     * @param request        질문 본문
+     * @return 생성된 메시지 정보
+     */
+    @Operation(summary = "사용자 질문 전송", description = "사용자 질문 메시지를 저장하고 분석 기준 도출 비동기 작업을 트리거합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "질문 분석 시작"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "데이터 상태 요약 미완료 (AN106)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "대화/플로우/데이터 소스 없음"),
+    })
+    @PostMapping("/conversations/{conversationId}/analysisFlows/{analysisFlowId}/messages")
+    public ResponseEntity<ApiResponse<CreateQuestionResponse>> createQuestion(
+            @PathVariable Long conversationId,
+            @PathVariable Long analysisFlowId,
+            @RequestBody CreateQuestionRequest request) {
+        return ResponseEntity.ok(ApiResponse.success(
+                "질문 분석 성공",
+                questionCriteriaService.createQuestion(conversationId, analysisFlowId, request)));
+    }
+
+    /**
+     * 분석 기준 도출 결과를 조회합니다.
+     *
+     * @param conversationId 대화 ID
+     * @param analysisFlowId 분석 흐름 ID
+     * @param messageId      사용자 메시지 ID
+     * @return 분석 기준 + 데이터 경고
+     */
+    @Operation(summary = "분석 기준 조회", description = "도출이 완료된 분석 기준과 데이터 경고를 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "분석 기준 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "분석 기준 도출 미완료 (AN102)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "분석 기준/메시지 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "502", description = "LLM 호출 실패 (L001)"),
+    })
+    @GetMapping("/conversations/{conversationId}/analysisFlows/{analysisFlowId}/messages/{messageId}/analysisCriterias")
+    public ResponseEntity<ApiResponse<GetQuestionCriteriaResponse>> getCriteria(
+            @PathVariable Long conversationId,
+            @PathVariable Long analysisFlowId,
+            @PathVariable Long messageId) {
+        return ResponseEntity.ok(ApiResponse.success(
+                "질문 분석 완료",
+                questionCriteriaService.getCriteria(conversationId, analysisFlowId, messageId)));
+    }
+
+    /**
+     * 분석 기준을 수정하거나 확정합니다.
+     *
+     * @param conversationId 대화 ID
+     * @param analysisFlowId 분석 흐름 ID
+     * @param messageId      사용자 메시지 ID
+     * @param request        수정 요청
+     * @return 분석 기준 ID + 확정 시각
+     */
+    @Operation(summary = "분석 기준 수정/확정", description = "분석 기준을 수정하거나 confirmed=true 로 확정합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "분석 기준 확정"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "분석 기준 없음 (AN101)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "이미 확정된 분석 기준 (AN104)"),
+    })
+    @PutMapping("/conversations/{conversationId}/analysisFlows/{analysisFlowId}/messages/{messageId}/analysisCriterias")
+    public ResponseEntity<ApiResponse<UpdateQuestionCriteriaResponse>> updateCriteria(
+            @PathVariable Long conversationId,
+            @PathVariable Long analysisFlowId,
+            @PathVariable Long messageId,
+            @RequestBody UpdateQuestionCriteriaRequest request) {
+        return ResponseEntity.ok(ApiResponse.success(
+                "분석 기준 확정",
+                questionCriteriaService.updateCriteria(conversationId, analysisFlowId, messageId, request)));
+    }
+
+    /**
+     * 진행 중인 분석 기준 도출 작업을 취소합니다.
+     *
+     * @param conversationId 대화 ID
+     * @param analysisFlowId 분석 흐름 ID
+     * @param messageId      사용자 메시지 ID
+     * @return 취소 결과 (status: CANCELLED)
+     */
+    @Operation(summary = "분석 기준 도출 취소", description = "QUEUED/RUNNING/RETRYING 상태의 분석 기준 도출 작업을 취소합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "분석 기준 조회 취소"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "분석 기준 도출 미시작 (AN103)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "분석 기준 없음 (AN101)"),
+    })
+    @PostMapping("/conversations/{conversationId}/analysisFlows/{analysisFlowId}/messages/{messageId}/analysisCriterias/cancel")
+    public ResponseEntity<ApiResponse<CancelQuestionCriteriaResponse>> cancelCriteria(
+            @PathVariable Long conversationId,
+            @PathVariable Long analysisFlowId,
+            @PathVariable Long messageId) {
+        return ResponseEntity.ok(ApiResponse.success(
+                "분석 기준 조회 취소",
+                questionCriteriaService.cancelCriteria(conversationId, analysisFlowId, messageId)));
+    }
+
+    /**
+     * 분석 기준 도출 작업 상태를 조회합니다.
+     *
+     * @param conversationId 대화 ID
+     * @param analysisFlowId 분석 흐름 ID
+     * @param messageId      사용자 메시지 ID
+     * @return 현재 작업 상태
+     */
+    @Operation(summary = "분석 기준 도출 상태 폴링", description = "분석 기준 도출 비동기 작업의 현재 상태를 반환합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "상태 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "분석 기준 없음 (AN101)"),
+    })
+    @GetMapping("/conversations/{conversationId}/analysisFlows/{analysisFlowId}/messages/{messageId}/analysisCriterias/status")
+    public ResponseEntity<ApiResponse<GetQuestionCriteriaStatusResponse>> getCriteriaStatus(
+            @PathVariable Long conversationId,
+            @PathVariable Long analysisFlowId,
+            @PathVariable Long messageId) {
+        return ResponseEntity.ok(ApiResponse.success(
+                "분석 기준 생성 상태 조회",
+                questionCriteriaService.getCriteriaStatus(conversationId, analysisFlowId, messageId)));
     }
 }

--- a/apps/be/src/main/java/com/capstone/logue/anal/dto/fastapi/request/FlowWarningKeyInfo.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/dto/fastapi/request/FlowWarningKeyInfo.java
@@ -1,0 +1,13 @@
+package com.capstone.logue.anal.dto.fastapi.request;
+
+/**
+ * FastAPI 카탈로그에 포함되는 플로우 경고 정의입니다.
+ *
+ * <p>{@link com.capstone.logue.global.entity.enums.FlowWarningKey} 에 대응됩니다.</p>
+ */
+public record FlowWarningKeyInfo(
+        String code,
+        String name,
+        String comment
+) {
+}

--- a/apps/be/src/main/java/com/capstone/logue/anal/dto/fastapi/request/PredefinedMetricInfo.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/dto/fastapi/request/PredefinedMetricInfo.java
@@ -1,0 +1,15 @@
+package com.capstone.logue.anal.dto.fastapi.request;
+
+/**
+ * 사전 정의된 지표 정보입니다.
+ *
+ * <p>{@code metricType} 이 RATIO 인 경우 분자/분모 컬럼이 사용됩니다.</p>
+ */
+public record PredefinedMetricInfo(
+        String metricName,
+        String displayName,
+        String metricType,
+        String formulaNumerator,
+        String formulaDenominator
+) {
+}

--- a/apps/be/src/main/java/com/capstone/logue/anal/dto/fastapi/request/PreviousMessageInfo.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/dto/fastapi/request/PreviousMessageInfo.java
@@ -1,0 +1,11 @@
+package com.capstone.logue.anal.dto.fastapi.request;
+
+/**
+ * 같은 플로우의 이전 메시지를 표현하는 record입니다.
+ * role 은 USER / LOGUE 문자열입니다.
+ */
+public record PreviousMessageInfo(
+        String role,
+        String content
+) {
+}

--- a/apps/be/src/main/java/com/capstone/logue/anal/dto/fastapi/request/QuestionAnalysisRequest.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/dto/fastapi/request/QuestionAnalysisRequest.java
@@ -1,0 +1,16 @@
+package com.capstone.logue.anal.dto.fastapi.request;
+
+/**
+ * FastAPI {@code POST /v1/llm/analysis-criteria/resolve} 요청 DTO입니다.
+ *
+ * <p>Spring → FastAPI 로 전송되는 질문 분석 페이로드를 표현합니다.
+ * 직렬화 시 snake_case 로 변환됩니다 (AppConfig.fastApiRestTemplate).</p>
+ */
+public record QuestionAnalysisRequest(
+        String requestId,
+        Long conversationId,
+        QuestionContextInfo question,
+        QuestionDataSourceInfo dataSource,
+        QuestionCatalogInfo catalog
+) {
+}

--- a/apps/be/src/main/java/com/capstone/logue/anal/dto/fastapi/request/QuestionCatalogInfo.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/dto/fastapi/request/QuestionCatalogInfo.java
@@ -1,0 +1,17 @@
+package com.capstone.logue.anal.dto.fastapi.request;
+
+import java.util.List;
+
+/**
+ * FastAPI 질문 분석 요청에 포함되는 카탈로그 정보입니다.
+ *
+ * <p>지원하는 ENUM 값 목록 + Pre-defined 지표 + flow warning 정의를 한 번에 전달합니다.</p>
+ */
+public record QuestionCatalogInfo(
+        List<String> analysisTypes,
+        List<String> metricTypes,
+        List<PredefinedMetricInfo> predefinedMetrics,
+        List<String> supportedPeriods,
+        List<FlowWarningKeyInfo> flowWarningKeys
+) {
+}

--- a/apps/be/src/main/java/com/capstone/logue/anal/dto/fastapi/request/QuestionContextInfo.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/dto/fastapi/request/QuestionContextInfo.java
@@ -1,0 +1,12 @@
+package com.capstone.logue.anal.dto.fastapi.request;
+
+import java.util.List;
+
+/**
+ * 질문 원문과 이전 메시지 맥락을 묶은 컨텍스트 정보입니다.
+ */
+public record QuestionContextInfo(
+        String content,
+        List<PreviousMessageInfo> previousMessages
+) {
+}

--- a/apps/be/src/main/java/com/capstone/logue/anal/dto/fastapi/request/QuestionDataSourceColumnInfo.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/dto/fastapi/request/QuestionDataSourceColumnInfo.java
@@ -1,0 +1,17 @@
+package com.capstone.logue.anal.dto.fastapi.request;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * FastAPI 질문 분석 요청에 포함되는 컬럼 메타데이터입니다.
+ *
+ * <p>sample_values 는 실제 값을 그대로 직렬화하기 위해 {@link JsonNode} 로 다룹니다.</p>
+ */
+public record QuestionDataSourceColumnInfo(
+        String columnName,
+        String dataType,
+        String semanticRole,
+        Double nullRatio,
+        JsonNode sampleValues
+) {
+}

--- a/apps/be/src/main/java/com/capstone/logue/anal/dto/fastapi/request/QuestionDataSourceInfo.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/dto/fastapi/request/QuestionDataSourceInfo.java
@@ -1,0 +1,12 @@
+package com.capstone.logue.anal.dto.fastapi.request;
+
+import java.util.List;
+
+/**
+ * FastAPI 질문 분석 요청에 포함되는 데이터 소스 메타데이터입니다.
+ */
+public record QuestionDataSourceInfo(
+        Long id,
+        List<QuestionDataSourceColumnInfo> columns
+) {
+}

--- a/apps/be/src/main/java/com/capstone/logue/anal/dto/fastapi/response/AnalysisCriteriaInfo.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/dto/fastapi/response/AnalysisCriteriaInfo.java
@@ -1,0 +1,25 @@
+package com.capstone.logue.anal.dto.fastapi.response;
+
+import java.util.List;
+
+/**
+ * FastAPI 가 도출한 구조화된 분석 기준입니다.
+ *
+ * <p>비교 분석(COMPARISON)일 때 {@code comparePeriod} 가, 순위 분석(RANKING)일 때 {@code limitNum} 이 채워집니다.</p>
+ */
+public record AnalysisCriteriaInfo(
+        String analysisType,
+        String metricName,
+        String metricType,
+        String formulaNumerator,
+        String formulaDenominator,
+        String baseDateColumn,
+        String standardPeriod,
+        String comparePeriod,
+        String sortBy,
+        String sortDirection,
+        List<String> groupBy,
+        Long limitNum,
+        List<CriteriaFilterInfo> filters
+) {
+}

--- a/apps/be/src/main/java/com/capstone/logue/anal/dto/fastapi/response/CriteriaFilterInfo.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/dto/fastapi/response/CriteriaFilterInfo.java
@@ -1,0 +1,15 @@
+package com.capstone.logue.anal.dto.fastapi.response;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * 분석 기준에 적용되는 필터 조건입니다.
+ *
+ * <p>{@code value} 는 문자열/숫자/배열 등 임의 타입이므로 {@link JsonNode} 로 다룹니다.</p>
+ */
+public record CriteriaFilterInfo(
+        String field,
+        String operator,
+        JsonNode value
+) {
+}

--- a/apps/be/src/main/java/com/capstone/logue/anal/dto/fastapi/response/FlowColumnInfo.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/dto/fastapi/response/FlowColumnInfo.java
@@ -1,0 +1,10 @@
+package com.capstone.logue.anal.dto.fastapi.response;
+
+/**
+ * 분석 기준에 사용되는 컬럼과 시맨틱 역할 매핑입니다.
+ */
+public record FlowColumnInfo(
+        String columnName,
+        String semanticRole
+) {
+}

--- a/apps/be/src/main/java/com/capstone/logue/anal/dto/fastapi/response/FlowWarningInfo.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/dto/fastapi/response/FlowWarningInfo.java
@@ -1,0 +1,15 @@
+package com.capstone.logue.anal.dto.fastapi.response;
+
+import java.util.List;
+
+/**
+ * 분석 기준 도출 과정에서 발생한 플로우 수준 경고입니다.
+ *
+ * <p>{@code code} 는 {@link com.capstone.logue.global.entity.enums.FlowWarningKey} 와 매핑됩니다.</p>
+ */
+public record FlowWarningInfo(
+        String code,
+        List<String> relatedFields,
+        String detail
+) {
+}

--- a/apps/be/src/main/java/com/capstone/logue/anal/dto/fastapi/response/QuestionAnalysisResponse.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/dto/fastapi/response/QuestionAnalysisResponse.java
@@ -1,0 +1,17 @@
+package com.capstone.logue.anal.dto.fastapi.response;
+
+import java.util.List;
+
+/**
+ * FastAPI {@code POST /v1/llm/analysis-criteria/resolve} 응답 DTO입니다.
+ *
+ * <p>{@code unsupportedQuestion} 이 null 이 아닌 경우 {@code analysisCriteria} 는 null 입니다.</p>
+ */
+public record QuestionAnalysisResponse(
+        String requestId,
+        AnalysisCriteriaInfo analysisCriteria,
+        List<FlowColumnInfo> flowColumns,
+        List<FlowWarningInfo> warnings,
+        UnsupportedQuestionInfo unsupportedQuestion
+) {
+}

--- a/apps/be/src/main/java/com/capstone/logue/anal/dto/fastapi/response/UnsupportedQuestionInfo.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/dto/fastapi/response/UnsupportedQuestionInfo.java
@@ -1,0 +1,12 @@
+package com.capstone.logue.anal.dto.fastapi.response;
+
+/**
+ * 지원하지 않는 질문 유형인 경우 FastAPI 가 반환하는 사유입니다.
+ *
+ * <p>이 필드가 null 이 아니면 {@link QuestionAnalysisResponse#analysisCriteria()} 는 null 입니다.</p>
+ */
+public record UnsupportedQuestionInfo(
+        String reason,
+        String detectedIntent
+) {
+}

--- a/apps/be/src/main/java/com/capstone/logue/anal/dto/spring/request/CreateQuestionRequest.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/dto/spring/request/CreateQuestionRequest.java
@@ -1,0 +1,9 @@
+package com.capstone.logue.anal.dto.spring.request;
+
+/**
+ * 사용자 질문 전송 API 요청 DTO입니다.
+ */
+public record CreateQuestionRequest(
+        String question
+) {
+}

--- a/apps/be/src/main/java/com/capstone/logue/anal/dto/spring/request/CreateQuestionRequest.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/dto/spring/request/CreateQuestionRequest.java
@@ -1,9 +1,12 @@
 package com.capstone.logue.anal.dto.spring.request;
 
+import jakarta.validation.constraints.NotBlank;
+
 /**
  * 사용자 질문 전송 API 요청 DTO입니다.
  */
 public record CreateQuestionRequest(
+        @NotBlank(message = "question must not be blank")
         String question
 ) {
 }

--- a/apps/be/src/main/java/com/capstone/logue/anal/dto/spring/request/UpdateQuestionCriteriaRequest.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/dto/spring/request/UpdateQuestionCriteriaRequest.java
@@ -1,0 +1,35 @@
+package com.capstone.logue.anal.dto.spring.request;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.List;
+
+/**
+ * 분석 기준 수정/확정 API 요청 DTO입니다.
+ *
+ * <p>{@code confirmed=true} 인 경우 서버에서 확정 처리(isConfirmed=true, confirmedAt=now)를 수행합니다.</p>
+ *
+ * <p>{@code filters} 의 value 는 임의 타입이므로 {@link JsonNode} 로 받습니다.</p>
+ */
+public record UpdateQuestionCriteriaRequest(
+        String baseDateColumn,
+        String standardPeriod,
+        String comparePeriod,
+        List<String> groupBy,
+        String sortBy,
+        String sortDirection,
+        Long limitNum,
+        List<FilterInfo> filters,
+        boolean confirmed
+) {
+
+    /**
+     * 분석 기준에 적용할 필터 조건입니다.
+     */
+    public record FilterInfo(
+            String field,
+            String operator,
+            JsonNode value
+    ) {
+    }
+}

--- a/apps/be/src/main/java/com/capstone/logue/anal/dto/spring/response/CancelQuestionCriteriaResponse.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/dto/spring/response/CancelQuestionCriteriaResponse.java
@@ -1,0 +1,11 @@
+package com.capstone.logue.anal.dto.spring.response;
+
+/**
+ * 분석 기준 도출 취소 응답 DTO입니다.
+ *
+ * <p>{@code status} 는 항상 "CANCELLED" 입니다.</p>
+ */
+public record CancelQuestionCriteriaResponse(
+        String status
+) {
+}

--- a/apps/be/src/main/java/com/capstone/logue/anal/dto/spring/response/CreateQuestionResponse.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/dto/spring/response/CreateQuestionResponse.java
@@ -1,0 +1,13 @@
+package com.capstone.logue.anal.dto.spring.response;
+
+import java.time.OffsetDateTime;
+
+/**
+ * 사용자 질문 전송 응답 DTO입니다.
+ */
+public record CreateQuestionResponse(
+        Long messageId,
+        String question,
+        OffsetDateTime createdAt
+) {
+}

--- a/apps/be/src/main/java/com/capstone/logue/anal/dto/spring/response/GetQuestionCriteriaResponse.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/dto/spring/response/GetQuestionCriteriaResponse.java
@@ -1,0 +1,62 @@
+package com.capstone.logue.anal.dto.spring.response;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+/**
+ * 분석 기준 조회 응답 DTO입니다.
+ *
+ * <p>분석 기준 도출이 완료된 시점에 호출되며, 분석 기준 본문과 함께
+ * 사용자 확인이 필요한 필드 목록({@code needConfirm}) 및 데이터 경고를 반환합니다.</p>
+ */
+public record GetQuestionCriteriaResponse(
+        Long messageId,
+        String question,
+        String message,
+        CriteriaInfo criteria,
+        OffsetDateTime createdAt
+) {
+
+    /**
+     * 분석 기준 본문입니다.
+     *
+     * <p>{@code dataWarning} 은 사용자에게 노출되는 경고 메시지 리스트이며,
+     * {@code needConfirm} 은 색상 강조 등 FE 처리가 필요한 필드명 리스트입니다.</p>
+     */
+    public record CriteriaInfo(
+            String analysisType,
+            String metricName,
+            String baseDateColumn,
+            String standardPeriod,
+            String comparePeriod,
+            List<String> groupBy,
+            String sortBy,
+            String sortDirection,
+            Long limitNum,
+            List<FilterInfo> filters,
+            List<DataWarningItem> dataWarning,
+            List<String> needConfirm
+    ) {
+    }
+
+    /**
+     * 분석 기준에 적용된 필터 조건입니다.
+     */
+    public record FilterInfo(
+            String field,
+            String operator,
+            JsonNode value
+    ) {
+    }
+
+    /**
+     * 사용자에게 노출되는 데이터 경고 항목입니다.
+     */
+    public record DataWarningItem(
+            int order,
+            String content
+    ) {
+    }
+}

--- a/apps/be/src/main/java/com/capstone/logue/anal/dto/spring/response/GetQuestionCriteriaStatusResponse.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/dto/spring/response/GetQuestionCriteriaStatusResponse.java
@@ -1,0 +1,11 @@
+package com.capstone.logue.anal.dto.spring.response;
+
+/**
+ * 분석 기준 도출 작업 상태 응답 DTO입니다.
+ *
+ * <p>{@code status} 값: QUEUED / RUNNING / RETRYING / SUCCESS / FAILED / CANCELED</p>
+ */
+public record GetQuestionCriteriaStatusResponse(
+        String status
+) {
+}

--- a/apps/be/src/main/java/com/capstone/logue/anal/dto/spring/response/UpdateQuestionCriteriaResponse.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/dto/spring/response/UpdateQuestionCriteriaResponse.java
@@ -1,0 +1,14 @@
+package com.capstone.logue.anal.dto.spring.response;
+
+import java.time.OffsetDateTime;
+
+/**
+ * 분석 기준 수정/확정 응답 DTO입니다.
+ *
+ * <p>{@code confirmedAt} 은 confirmed=false 로 저장된 경우 null 입니다.</p>
+ */
+public record UpdateQuestionCriteriaResponse(
+        Long analysisCriteriaId,
+        OffsetDateTime confirmedAt
+) {
+}

--- a/apps/be/src/main/java/com/capstone/logue/anal/repository/AiTaggingJobRepository.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/repository/AiTaggingJobRepository.java
@@ -11,7 +11,7 @@ public interface AiTaggingJobRepository extends JpaRepository<AiTaggingJob, Long
 
     Optional<AiTaggingJob> findTopByConversationIdAndStageOrderByCreatedAtDesc(Long conversationId, JobStage stage);
 
-    Optional<AiTaggingJob> findTopByAnalysisFlowIdAndStageOrderByCreatedAtDesc(Long analysisFlowId, JobStage stage);
+    Optional<AiTaggingJob> findTopByAnalysisFlowIdAndStageOrderByCreatedAtDescIdDesc(Long analysisFlowId, JobStage stage);
 
-    Optional<AiTaggingJob> findTopByMessageIdAndStageOrderByCreatedAtDesc(Long messageId, JobStage stage);
+    Optional<AiTaggingJob> findTopByMessageIdAndStageOrderByCreatedAtDescIdDesc(Long messageId, JobStage stage);
 }

--- a/apps/be/src/main/java/com/capstone/logue/anal/repository/AiTaggingJobRepository.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/repository/AiTaggingJobRepository.java
@@ -10,4 +10,8 @@ public interface AiTaggingJobRepository extends JpaRepository<AiTaggingJob, Long
     Optional<AiTaggingJob> findByConversationIdAndStage(Long conversationId, JobStage stage);
 
     Optional<AiTaggingJob> findTopByConversationIdAndStageOrderByCreatedAtDesc(Long conversationId, JobStage stage);
+
+    Optional<AiTaggingJob> findTopByAnalysisFlowIdAndStageOrderByCreatedAtDesc(Long analysisFlowId, JobStage stage);
+
+    Optional<AiTaggingJob> findTopByMessageIdAndStageOrderByCreatedAtDesc(Long messageId, JobStage stage);
 }

--- a/apps/be/src/main/java/com/capstone/logue/anal/repository/AnalysisCriteriaRepository.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/repository/AnalysisCriteriaRepository.java
@@ -1,0 +1,14 @@
+package com.capstone.logue.anal.repository;
+
+import com.capstone.logue.global.entity.AnalysisCriteria;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface AnalysisCriteriaRepository extends JpaRepository<AnalysisCriteria, Long> {
+
+    Optional<AnalysisCriteria> findTopByAnalysisFlowIdOrderByCreatedAtDesc(Long analysisFlowId);
+
+    List<AnalysisCriteria> findByAnalysisFlowIdOrderByCreatedAtDesc(Long analysisFlowId);
+}

--- a/apps/be/src/main/java/com/capstone/logue/anal/repository/AnalysisCriteriaRepository.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/repository/AnalysisCriteriaRepository.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 public interface AnalysisCriteriaRepository extends JpaRepository<AnalysisCriteria, Long> {
 
-    Optional<AnalysisCriteria> findTopByAnalysisFlowIdOrderByCreatedAtDesc(Long analysisFlowId);
+    Optional<AnalysisCriteria> findTopByAnalysisFlowIdOrderByCreatedAtDescIdDesc(Long analysisFlowId);
 
     List<AnalysisCriteria> findByAnalysisFlowIdOrderByCreatedAtDesc(Long analysisFlowId);
 }

--- a/apps/be/src/main/java/com/capstone/logue/anal/repository/AnalysisFlowColumnRepository.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/repository/AnalysisFlowColumnRepository.java
@@ -1,0 +1,11 @@
+package com.capstone.logue.anal.repository;
+
+import com.capstone.logue.global.entity.AnalysisFlowColumn;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AnalysisFlowColumnRepository extends JpaRepository<AnalysisFlowColumn, Long> {
+
+    List<AnalysisFlowColumn> findByAnalysisFlowId(Long analysisFlowId);
+}

--- a/apps/be/src/main/java/com/capstone/logue/anal/repository/AnalysisFlowColumnRepository.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/repository/AnalysisFlowColumnRepository.java
@@ -7,5 +7,5 @@ import java.util.List;
 
 public interface AnalysisFlowColumnRepository extends JpaRepository<AnalysisFlowColumn, Long> {
 
-    List<AnalysisFlowColumn> findByAnalysisFlowId(Long analysisFlowId);
+    List<AnalysisFlowColumn> findByAnalysisFlowIdOrderByIdAsc(Long analysisFlowId);
 }

--- a/apps/be/src/main/java/com/capstone/logue/anal/repository/FlowDataWarningRepository.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/repository/FlowDataWarningRepository.java
@@ -1,0 +1,11 @@
+package com.capstone.logue.anal.repository;
+
+import com.capstone.logue.global.entity.FlowDataWarning;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface FlowDataWarningRepository extends JpaRepository<FlowDataWarning, Long> {
+
+    List<FlowDataWarning> findByAnalysisCriteriaId(Long analysisCriteriaId);
+}

--- a/apps/be/src/main/java/com/capstone/logue/anal/repository/MessageRepository.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/repository/MessageRepository.java
@@ -7,5 +7,5 @@ import java.util.List;
 
 public interface MessageRepository extends JpaRepository<Message, Long> {
 
-    List<Message> findByAnalysisFlowIdOrderByCreatedAtAsc(Long analysisFlowId);
+    List<Message> findByAnalysisFlowIdOrderByCreatedAtAscIdAsc(Long analysisFlowId);
 }

--- a/apps/be/src/main/java/com/capstone/logue/anal/repository/MessageRepository.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/repository/MessageRepository.java
@@ -1,0 +1,11 @@
+package com.capstone.logue.anal.repository;
+
+import com.capstone.logue.global.entity.Message;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MessageRepository extends JpaRepository<Message, Long> {
+
+    List<Message> findByAnalysisFlowIdOrderByCreatedAtAsc(Long analysisFlowId);
+}

--- a/apps/be/src/main/java/com/capstone/logue/anal/service/CriteriaJobContext.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/service/CriteriaJobContext.java
@@ -1,0 +1,25 @@
+package com.capstone.logue.anal.service;
+
+import com.capstone.logue.global.entity.AnalysisFlow;
+import com.capstone.logue.global.entity.AnalysisFlowColumn;
+import com.capstone.logue.global.entity.DataSource;
+import com.capstone.logue.global.entity.DataSourceColumn;
+import com.capstone.logue.global.entity.Message;
+
+import java.util.List;
+
+/**
+ * 분석 기준 도출 비동기 작업이 RUNNING 으로 전이될 때 함께 로드되는 컨텍스트입니다.
+ *
+ * <p>{@link QuestionAnalysisRequestBuilder} 가 FastAPI 요청을 빌드하는 데 필요한 모든 영속 객체를
+ * 트랜잭션 안에서 한 번에 모아 전달하기 위한 컨테이너입니다.</p>
+ */
+public record CriteriaJobContext(
+        Message currentMessage,
+        AnalysisFlow analysisFlow,
+        DataSource dataSource,
+        List<DataSourceColumn> dataSourceColumns,
+        List<AnalysisFlowColumn> analysisFlowColumns,
+        List<Message> previousMessages
+) {
+}

--- a/apps/be/src/main/java/com/capstone/logue/anal/service/JobStateService.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/service/JobStateService.java
@@ -214,16 +214,19 @@ public class JobStateService {
         job.markRunning();
 
         Message currentMessage = job.getMessage();
+        if (currentMessage == null) {
+            throw new LogueException(ErrorCode.MESSAGE_NOT_FOUND);
+        }
         AnalysisFlow flow = job.getAnalysisFlow();
         DataSource dataSource = flow.getDataSource();
 
         List<DataSourceColumn> columns = dataSourceColumnRepository.findByDataSourceId(dataSource.getId());
-        List<AnalysisFlowColumn> flowColumns = analysisFlowColumnRepository.findByAnalysisFlowId(flow.getId());
+        List<AnalysisFlowColumn> flowColumns = analysisFlowColumnRepository.findByAnalysisFlowIdOrderByIdAsc(flow.getId());
 
         List<Message> previousMessages = messageRepository
-                .findByAnalysisFlowIdOrderByCreatedAtAsc(flow.getId())
+                .findByAnalysisFlowIdOrderByCreatedAtAscIdAsc(flow.getId())
                 .stream()
-                .filter(m -> currentMessage == null || !m.getId().equals(currentMessage.getId()))
+                .filter(m -> !m.getId().equals(currentMessage.getId()))
                 .collect(Collectors.toList());
 
         return new CriteriaJobContext(currentMessage, flow, dataSource, columns, flowColumns, previousMessages);

--- a/apps/be/src/main/java/com/capstone/logue/anal/service/JobStateService.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/service/JobStateService.java
@@ -1,18 +1,35 @@
 package com.capstone.logue.anal.service;
 
+import com.capstone.logue.anal.dto.fastapi.response.AnalysisCriteriaInfo;
 import com.capstone.logue.anal.dto.fastapi.response.ColumnRoleInfo;
+import com.capstone.logue.anal.dto.fastapi.response.FlowColumnInfo;
+import com.capstone.logue.anal.dto.fastapi.response.FlowWarningInfo;
+import com.capstone.logue.anal.dto.fastapi.response.QuestionAnalysisResponse;
 import com.capstone.logue.anal.dto.fastapi.response.WarningInfo;
 import com.capstone.logue.anal.dto.fastapi.request.ColumnMetaInfo;
 import com.capstone.logue.anal.dto.fastapi.request.FileAnalysisRequest;
 import com.capstone.logue.anal.repository.AiTaggingJobRepository;
+import com.capstone.logue.anal.repository.AnalysisCriteriaRepository;
+import com.capstone.logue.anal.repository.AnalysisFlowColumnRepository;
 import com.capstone.logue.anal.repository.DataSourceColumnRepository;
+import com.capstone.logue.anal.repository.FlowDataWarningRepository;
+import com.capstone.logue.anal.repository.MessageRepository;
 import com.capstone.logue.anal.repository.SourceDataWarningRepository;
 import com.capstone.logue.data.repository.DataSourceRepository;
 import com.capstone.logue.global.entity.AiTaggingJob;
+import com.capstone.logue.global.entity.AnalysisCriteria;
+import com.capstone.logue.global.entity.AnalysisFlow;
+import com.capstone.logue.global.entity.AnalysisFlowColumn;
 import com.capstone.logue.global.entity.DataSource;
 import com.capstone.logue.global.entity.DataSourceColumn;
+import com.capstone.logue.global.entity.FlowDataWarning;
+import com.capstone.logue.global.entity.Message;
 import com.capstone.logue.global.entity.SourceDataWarning;
+import com.capstone.logue.global.entity.enums.AnalysisType;
+import com.capstone.logue.global.entity.enums.FlowWarningKey;
 import com.capstone.logue.global.entity.enums.JobStatus;
+import com.capstone.logue.global.entity.enums.MetricType;
+import com.capstone.logue.global.entity.enums.SemanticRoleType;
 import com.capstone.logue.global.entity.enums.SourceWarningKey;
 import com.capstone.logue.global.exception.ErrorCode;
 import com.capstone.logue.global.exception.LogueException;
@@ -22,7 +39,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -43,6 +62,10 @@ public class JobStateService {
     private final DataSourceColumnRepository dataSourceColumnRepository;
     private final DataSourceRepository dataSourceRepository;
     private final SourceDataWarningRepository sourceDataWarningRepository;
+    private final MessageRepository messageRepository;
+    private final AnalysisCriteriaRepository analysisCriteriaRepository;
+    private final AnalysisFlowColumnRepository analysisFlowColumnRepository;
+    private final FlowDataWarningRepository flowDataWarningRepository;
     private final ObjectMapper objectMapper;
 
     /**
@@ -173,5 +196,133 @@ public class JobStateService {
 
         job.markRetrying(errorMessage);
         log.info("[JobStateService] RETRYING: jobId={}, retryCount={}", jobId, job.getRetryCount());
+    }
+
+    /**
+     * 분석 기준 도출 작업을 RUNNING 으로 변경하고, FastAPI 요청에 필요한 컨텍스트를 묶어 반환합니다.
+     *
+     * <p>현재 사용자 메시지, 같은 플로우의 이전 메시지, 데이터 소스 및 컬럼 메타데이터,
+     * 컬럼별 시맨틱 역할 매핑을 한 번에 로드합니다.</p>
+     *
+     * @param jobId 분석 기준 도출 작업 ID
+     * @return FastAPI 요청 빌드용 {@link CriteriaJobContext}
+     */
+    @Transactional
+    public CriteriaJobContext markCriteriaRunningAndGetContext(Long jobId) {
+        AiTaggingJob job = aiTaggingJobRepository.findById(jobId)
+                .orElseThrow(() -> new LogueException(ErrorCode.JOB_NOT_FOUND));
+        job.markRunning();
+
+        Message currentMessage = job.getMessage();
+        AnalysisFlow flow = job.getAnalysisFlow();
+        DataSource dataSource = flow.getDataSource();
+
+        List<DataSourceColumn> columns = dataSourceColumnRepository.findByDataSourceId(dataSource.getId());
+        List<AnalysisFlowColumn> flowColumns = analysisFlowColumnRepository.findByAnalysisFlowId(flow.getId());
+
+        List<Message> previousMessages = messageRepository
+                .findByAnalysisFlowIdOrderByCreatedAtAsc(flow.getId())
+                .stream()
+                .filter(m -> currentMessage == null || !m.getId().equals(currentMessage.getId()))
+                .collect(Collectors.toList());
+
+        return new CriteriaJobContext(currentMessage, flow, dataSource, columns, flowColumns, previousMessages);
+    }
+
+    /**
+     * FastAPI 가 반환한 분석 기준 + 플로우 컬럼 + 경고를 영속화하고 작업을 SUCCESS 로 변경합니다.
+     *
+     * <p>{@code unsupportedQuestion} 이 존재하면 분석 기준을 저장하지 않고 즉시 FAILED 로 마킹합니다.
+     * CANCELED 상태인 경우 저장을 skip 합니다.
+     * {@code flowColumns} 에 데이터 소스에 없는 컬럼명이 포함되면 {@link ErrorCode#COLUMN_NOT_FOUND} 예외가 발생하며
+     * 트랜잭션이 롤백됩니다.</p>
+     *
+     * @param jobId    분석 기준 도출 작업 ID
+     * @param response FastAPI 응답
+     */
+    @Transactional
+    public void saveCriteriaAndMarkSuccess(Long jobId, QuestionAnalysisResponse response) {
+        AiTaggingJob job = aiTaggingJobRepository.findById(jobId).orElseThrow();
+
+        if (job.getStatus() == JobStatus.CANCELED) {
+            log.info("[JobStateService] 이미 취소된 분석 기준 작업 - 결과 저장 skip: jobId={}", jobId);
+            return;
+        }
+
+        if (response.unsupportedQuestion() != null) {
+            log.info("[JobStateService] 지원하지 않는 질문 유형: jobId={}, reason={}", jobId, response.unsupportedQuestion().reason());
+            job.markFailed("UNSUPPORTED_QUESTION: " + response.unsupportedQuestion().reason());
+            return;
+        }
+
+        AnalysisCriteriaInfo criteriaInfo = response.analysisCriteria();
+        if (criteriaInfo == null) {
+            throw new LogueException(ErrorCode.LLM_CALL_FAILED);
+        }
+
+        AnalysisFlow flow = job.getAnalysisFlow();
+
+        AnalysisCriteria criteria = AnalysisCriteria.builder()
+                .analysisFlow(flow)
+                .analysisType(AnalysisType.valueOf(criteriaInfo.analysisType()))
+                .metricName(criteriaInfo.metricName())
+                .metricType(MetricType.valueOf(criteriaInfo.metricType()))
+                .formulaNumerator(criteriaInfo.formulaNumerator())
+                .formulaDenominator(criteriaInfo.formulaDenominator())
+                .baseDateColumn(criteriaInfo.baseDateColumn())
+                .standardPeriod(criteriaInfo.standardPeriod())
+                .comparePeriod(criteriaInfo.comparePeriod())
+                .sortBy(criteriaInfo.sortBy())
+                .sortDirection(criteriaInfo.sortDirection())
+                .groupBy(objectMapper.valueToTree(criteriaInfo.groupBy()))
+                .limitNum(criteriaInfo.limitNum())
+                .filters(criteriaInfo.filters() == null ? null : objectMapper.valueToTree(criteriaInfo.filters()))
+                .dataWarnings(response.warnings() == null || response.warnings().isEmpty()
+                        ? null
+                        : objectMapper.valueToTree(response.warnings()))
+                .isConfirmed(false)
+                .build();
+
+        AnalysisCriteria savedCriteria = analysisCriteriaRepository.save(criteria);
+
+        List<FlowColumnInfo> flowColumns = response.flowColumns() == null ? List.of() : response.flowColumns();
+        if (!flowColumns.isEmpty()) {
+            Map<String, DataSourceColumn> columnByName = new HashMap<>();
+            for (DataSourceColumn col : dataSourceColumnRepository.findByDataSourceId(flow.getDataSource().getId())) {
+                columnByName.put(col.getColumnName(), col);
+            }
+            for (FlowColumnInfo fc : flowColumns) {
+                DataSourceColumn dsColumn = columnByName.get(fc.columnName());
+                if (dsColumn == null) {
+                    throw new LogueException(ErrorCode.COLUMN_NOT_FOUND);
+                }
+                AnalysisFlowColumn afc = AnalysisFlowColumn.builder()
+                        .analysisFlow(flow)
+                        .dataSourceColumn(dsColumn)
+                        .semanticRole(SemanticRoleType.valueOf(fc.semanticRole()))
+                        .build();
+                analysisFlowColumnRepository.save(afc);
+            }
+        }
+
+        List<FlowWarningInfo> warnings = response.warnings() == null ? List.of() : response.warnings();
+        for (FlowWarningInfo w : warnings) {
+            FlowWarningKey key;
+            try {
+                key = FlowWarningKey.valueOf(w.code());
+            } catch (IllegalArgumentException e) {
+                log.warn("[JobStateService] 알 수 없는 FlowWarningKey 무시: code={}", w.code());
+                continue;
+            }
+            FlowDataWarning warning = FlowDataWarning.builder()
+                    .analysisCriteria(savedCriteria)
+                    .code(key)
+                    .name(key.getName())
+                    .comment(key.getComment())
+                    .build();
+            flowDataWarningRepository.save(warning);
+        }
+
+        job.markSuccess();
     }
 }

--- a/apps/be/src/main/java/com/capstone/logue/anal/service/QuestionAnalysisAsyncService.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/service/QuestionAnalysisAsyncService.java
@@ -1,0 +1,121 @@
+package com.capstone.logue.anal.service;
+
+import com.capstone.logue.anal.client.FastApiClient;
+import com.capstone.logue.anal.dto.fastapi.request.QuestionAnalysisRequest;
+import com.capstone.logue.anal.dto.fastapi.response.QuestionAnalysisResponse;
+import com.capstone.logue.global.exception.LogueException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.ResourceAccessException;
+
+/**
+ * 질문 → 분석 기준 도출을 위한 FastAPI 호출을 비동기로 수행하는 서비스입니다.
+ *
+ * <p>트랜잭션 흐름은 {@link FileAnalysisAsyncService} 와 동일합니다.</p>
+ * <pre>
+ * [트랜잭션 1: markCriteriaRunningAndGetContext]
+ *        ↓
+ * [트랜잭션 없음: FastAPI 호출 - 재시도 루프]
+ *   - 5xx / 네트워크 에러: 최대 3회 재시도 (1s→2s→4s ±30% jitter), RETRYING 상태 전환
+ *   - 4xx: 재시도 없이 즉시 FAILED
+ *   - 2xx 스키마 불일치: 트랜잭션 롤백 후 FAILED
+ *        ↓
+ * [트랜잭션 2: saveCriteriaAndMarkSuccess]
+ *        또는
+ * [트랜잭션 3: markFailed]
+ * </pre>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class QuestionAnalysisAsyncService {
+
+    private static final int MAX_ATTEMPTS = 3;
+
+    private final JobStateService jobStateService;
+    private final QuestionAnalysisRequestBuilder requestBuilder;
+    private final FastApiClient fastApiClient;
+
+    /**
+     * 분석 기준 도출 비동기 작업을 수행합니다.
+     *
+     * @param jobId      분석 기준 도출 작업 ID
+     * @param question   사용자 질문 원문
+     */
+    @Async
+    public void resolveCriteriaAsync(Long jobId, String question) {
+        CriteriaJobContext context = jobStateService.markCriteriaRunningAndGetContext(jobId);
+
+        QuestionAnalysisRequest request = requestBuilder.build(
+                String.valueOf(jobId),
+                context.analysisFlow().getConversation().getId(),
+                question,
+                context.previousMessages(),
+                context.dataSource(),
+                context.dataSourceColumns(),
+                context.analysisFlowColumns()
+        );
+
+        for (int attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+            try {
+                ResponseEntity<QuestionAnalysisResponse> response = fastApiClient.resolveAnalysisCriteria(request);
+                int status = response.getStatusCode().value();
+
+                if (status >= 400 && status < 500) {
+                    log.warn("[QuestionAnalysisAsyncService] 4xx 에러 - 즉시 FAILED: jobId={}, status={}", jobId, status);
+                    jobStateService.markFailed(jobId, "FastAPI 4xx 에러: " + status);
+                    return;
+                }
+
+                if (status >= 500) {
+                    log.warn("[QuestionAnalysisAsyncService] 5xx 에러: jobId={}, status={}, attempt={}", jobId, status, attempt);
+                    handleRetryOrFail(jobId, attempt, "FastAPI 5xx 에러: " + status);
+                    continue;
+                }
+
+                jobStateService.saveCriteriaAndMarkSuccess(jobId, response.getBody());
+                log.info("[QuestionAnalysisAsyncService] 분석 기준 도출 완료: jobId={}", jobId);
+                return;
+
+            } catch (ResourceAccessException e) {
+                log.warn("[QuestionAnalysisAsyncService] 네트워크 에러: jobId={}, attempt={}, msg={}", jobId, attempt, e.getMessage());
+                handleRetryOrFail(jobId, attempt, "네트워크 에러: " + e.getMessage());
+            } catch (LogueException e) {
+                log.warn("[QuestionAnalysisAsyncService] 스키마 불일치 - FAILED: jobId={}, msg={}", jobId, e.getMessage());
+                jobStateService.markFailed(jobId, "응답 스키마 불일치: " + e.getMessage());
+                return;
+            } catch (Exception e) {
+                log.error("[QuestionAnalysisAsyncService] 예상치 못한 에러: jobId={}", jobId, e);
+                jobStateService.markFailed(jobId, e.getMessage());
+                return;
+            }
+        }
+    }
+
+    private void handleRetryOrFail(Long jobId, int attempt, String errorMessage) {
+        if (attempt == MAX_ATTEMPTS) {
+            log.warn("[QuestionAnalysisAsyncService] 재시도 소진 - FAILED: jobId={}", jobId);
+            jobStateService.markFailed(jobId, "재시도 3회 소진: " + errorMessage);
+            return;
+        }
+        jobStateService.markRetrying(jobId, errorMessage);
+        sleep(backoffMillis(attempt));
+    }
+
+    private long backoffMillis(int attempt) {
+        long base = (long) (1000 * Math.pow(2, attempt - 1));
+        double jitter = 1.0 + (Math.random() * 0.6 - 0.3);
+        return (long) (base * jitter);
+    }
+
+    private void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/apps/be/src/main/java/com/capstone/logue/anal/service/QuestionAnalysisAsyncService.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/service/QuestionAnalysisAsyncService.java
@@ -76,7 +76,13 @@ public class QuestionAnalysisAsyncService {
                     continue;
                 }
 
-                jobStateService.saveCriteriaAndMarkSuccess(jobId, response.getBody());
+                QuestionAnalysisResponse body = response.getBody();
+                if (body == null) {
+                    log.warn("[QuestionAnalysisAsyncService] 응답 body null - FAILED: jobId={}", jobId);
+                    jobStateService.markFailed(jobId, "FastAPI 응답 body가 null입니다");
+                    return;
+                }
+                jobStateService.saveCriteriaAndMarkSuccess(jobId, body);
                 log.info("[QuestionAnalysisAsyncService] 분석 기준 도출 완료: jobId={}", jobId);
                 return;
 

--- a/apps/be/src/main/java/com/capstone/logue/anal/service/QuestionAnalysisRequestBuilder.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/service/QuestionAnalysisRequestBuilder.java
@@ -1,0 +1,135 @@
+package com.capstone.logue.anal.service;
+
+import com.capstone.logue.anal.dto.fastapi.request.FlowWarningKeyInfo;
+import com.capstone.logue.anal.dto.fastapi.request.PredefinedMetricInfo;
+import com.capstone.logue.anal.dto.fastapi.request.PreviousMessageInfo;
+import com.capstone.logue.anal.dto.fastapi.request.QuestionAnalysisRequest;
+import com.capstone.logue.anal.dto.fastapi.request.QuestionCatalogInfo;
+import com.capstone.logue.anal.dto.fastapi.request.QuestionContextInfo;
+import com.capstone.logue.anal.dto.fastapi.request.QuestionDataSourceColumnInfo;
+import com.capstone.logue.anal.dto.fastapi.request.QuestionDataSourceInfo;
+import com.capstone.logue.global.entity.AnalysisFlowColumn;
+import com.capstone.logue.global.entity.DataSource;
+import com.capstone.logue.global.entity.DataSourceColumn;
+import com.capstone.logue.global.entity.Message;
+import com.capstone.logue.global.entity.enums.AnalysisType;
+import com.capstone.logue.global.entity.enums.FlowWarningKey;
+import com.capstone.logue.global.entity.enums.MetricType;
+import com.capstone.logue.global.entity.enums.SemanticRoleType;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * FastAPI {@code POST /v1/llm/analysis-criteria/resolve} 호출용 요청 DTO를 빌드하는 컴포넌트입니다.
+ *
+ * <p>카탈로그(허용 ENUM·지표·기간·경고 정의)는 빌더 내부 상수로 고정되며, 컬럼별 시맨틱 역할은
+ * 같은 플로우의 {@link AnalysisFlowColumn} 매핑이 있으면 사용하고 없으면 기본값 {@code "DIMENSION"} 으로 보냅니다.</p>
+ */
+@Component
+@RequiredArgsConstructor
+public class QuestionAnalysisRequestBuilder {
+
+    private static final List<String> SUPPORTED_PERIODS = List.of(
+            "today",
+            "this_week",
+            "last_week",
+            "this_month",
+            "last_month",
+            "this_quarter",
+            "last_quarter",
+            "this_year",
+            "last_year"
+    );
+
+    private static final List<PredefinedMetricInfo> PREDEFINED_METRICS = List.of(
+            new PredefinedMetricInfo(
+                    "conversion_rate",
+                    "가입 전환율",
+                    MetricType.RATIO.name(),
+                    "signup_complete",
+                    "landing_sessions"
+            ),
+            new PredefinedMetricInfo(
+                    "total_count",
+                    "총 건수",
+                    MetricType.COUNT.name(),
+                    null,
+                    null
+            )
+    );
+
+    private static final String DEFAULT_SEMANTIC_ROLE = SemanticRoleType.DIMENSION.name();
+
+    /**
+     * FastAPI 요청 DTO를 빌드합니다.
+     *
+     * @param requestId        Spring 이 발급한 요청 추적 ID (보통 jobId 문자열)
+     * @param conversationId   대화 ID
+     * @param question         현재 사용자 질문 원문
+     * @param previousMessages 같은 플로우의 이전 메시지 목록 (시간순)
+     * @param dataSource       분석 대상 데이터 소스
+     * @param dataSourceColumns 데이터 소스 컬럼 메타데이터 목록
+     * @param flowColumns      같은 플로우에서의 컬럼별 시맨틱 역할 매핑 (없으면 기본값 사용)
+     * @return FastAPI 전송용 {@link QuestionAnalysisRequest}
+     */
+    public QuestionAnalysisRequest build(
+            String requestId,
+            Long conversationId,
+            String question,
+            List<Message> previousMessages,
+            DataSource dataSource,
+            List<DataSourceColumn> dataSourceColumns,
+            List<AnalysisFlowColumn> flowColumns
+    ) {
+        Map<Long, String> semanticRoleByColumnId = flowColumns.stream()
+                .collect(Collectors.toMap(
+                        fc -> fc.getDataSourceColumn().getId(),
+                        fc -> fc.getSemanticRole().name(),
+                        (left, right) -> left
+                ));
+
+        List<QuestionDataSourceColumnInfo> columnInfos = dataSourceColumns.stream()
+                .map(col -> new QuestionDataSourceColumnInfo(
+                        col.getColumnName(),
+                        col.getDataType(),
+                        semanticRoleByColumnId.getOrDefault(col.getId(), DEFAULT_SEMANTIC_ROLE),
+                        col.getNullRatio(),
+                        coerceSampleValues(col.getSampleValues())
+                ))
+                .collect(Collectors.toList());
+
+        QuestionDataSourceInfo dataSourceInfo = new QuestionDataSourceInfo(
+                dataSource.getId(),
+                columnInfos
+        );
+
+        QuestionContextInfo questionInfo = new QuestionContextInfo(
+                question,
+                previousMessages.stream()
+                        .map(m -> new PreviousMessageInfo(m.getRole().name(), m.getContent()))
+                        .collect(Collectors.toList())
+        );
+
+        QuestionCatalogInfo catalog = new QuestionCatalogInfo(
+                Arrays.stream(AnalysisType.values()).map(Enum::name).collect(Collectors.toList()),
+                Arrays.stream(MetricType.values()).map(Enum::name).collect(Collectors.toList()),
+                PREDEFINED_METRICS,
+                SUPPORTED_PERIODS,
+                Arrays.stream(FlowWarningKey.values())
+                        .map(k -> new FlowWarningKeyInfo(k.name(), k.getName(), k.getComment()))
+                        .collect(Collectors.toList())
+        );
+
+        return new QuestionAnalysisRequest(requestId, conversationId, questionInfo, dataSourceInfo, catalog);
+    }
+
+    private JsonNode coerceSampleValues(JsonNode sampleValues) {
+        return sampleValues;
+    }
+}

--- a/apps/be/src/main/java/com/capstone/logue/anal/service/QuestionCriteriaService.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/service/QuestionCriteriaService.java
@@ -80,7 +80,7 @@ public class QuestionCriteriaService {
         AnalysisFlow flow = validateAccess(conversationId, analysisFlowId);
 
         AiTaggingJob latestDataStatusJob = aiTaggingJobRepository
-                .findTopByAnalysisFlowIdAndStageOrderByCreatedAtDesc(analysisFlowId, JobStage.DATA_STATUS)
+                .findTopByAnalysisFlowIdAndStageOrderByCreatedAtDescIdDesc(analysisFlowId, JobStage.DATA_STATUS)
                 .orElseThrow(() -> new LogueException(ErrorCode.DATASOURCE_NOT_READY));
         if (latestDataStatusJob.getStatus() != JobStatus.SUCCESS) {
             throw new LogueException(ErrorCode.DATASOURCE_NOT_READY);
@@ -127,7 +127,7 @@ public class QuestionCriteriaService {
         Message message = loadMessage(flow, messageId);
 
         AiTaggingJob job = aiTaggingJobRepository
-                .findTopByMessageIdAndStageOrderByCreatedAtDesc(messageId, JobStage.ANALYSIS_CRITERIA)
+                .findTopByMessageIdAndStageOrderByCreatedAtDescIdDesc(messageId, JobStage.ANALYSIS_CRITERIA)
                 .orElseThrow(() -> new LogueException(ErrorCode.CRITERIA_NOT_FOUND));
 
         if (job.getStatus() != JobStatus.SUCCESS) {
@@ -135,7 +135,7 @@ public class QuestionCriteriaService {
         }
 
         AnalysisCriteria criteria = analysisCriteriaRepository
-                .findTopByAnalysisFlowIdOrderByCreatedAtDesc(flow.getId())
+                .findTopByAnalysisFlowIdOrderByCreatedAtDescIdDesc(flow.getId())
                 .orElseThrow(() -> new LogueException(ErrorCode.CRITERIA_NOT_FOUND));
 
         List<FlowDataWarning> warnings = flowDataWarningRepository
@@ -193,7 +193,7 @@ public class QuestionCriteriaService {
         loadMessage(flow, messageId);
 
         AnalysisCriteria criteria = analysisCriteriaRepository
-                .findTopByAnalysisFlowIdOrderByCreatedAtDesc(flow.getId())
+                .findTopByAnalysisFlowIdOrderByCreatedAtDescIdDesc(flow.getId())
                 .orElseThrow(() -> new LogueException(ErrorCode.CRITERIA_NOT_FOUND));
 
         if (Boolean.TRUE.equals(criteria.getIsConfirmed()) && request.confirmed()) {
@@ -222,7 +222,7 @@ public class QuestionCriteriaService {
         loadMessage(flow, messageId);
 
         AiTaggingJob job = aiTaggingJobRepository
-                .findTopByMessageIdAndStageOrderByCreatedAtDesc(messageId, JobStage.ANALYSIS_CRITERIA)
+                .findTopByMessageIdAndStageOrderByCreatedAtDescIdDesc(messageId, JobStage.ANALYSIS_CRITERIA)
                 .orElseThrow(() -> new LogueException(ErrorCode.CRITERIA_NOT_FOUND));
 
         JobStatus status = job.getStatus();
@@ -261,7 +261,7 @@ public class QuestionCriteriaService {
         loadMessage(flow, messageId);
 
         AiTaggingJob job = aiTaggingJobRepository
-                .findTopByMessageIdAndStageOrderByCreatedAtDesc(messageId, JobStage.ANALYSIS_CRITERIA)
+                .findTopByMessageIdAndStageOrderByCreatedAtDescIdDesc(messageId, JobStage.ANALYSIS_CRITERIA)
                 .orElseThrow(() -> new LogueException(ErrorCode.CRITERIA_NOT_FOUND));
 
         return new GetQuestionCriteriaStatusResponse(job.getStatus().name());
@@ -342,9 +342,6 @@ public class QuestionCriteriaService {
         Set<String> result = new LinkedHashSet<>();
         for (JsonNode warning : dataWarnings) {
             JsonNode related = warning.path("relatedFields");
-            if (!related.isArray()) {
-                related = warning.path("related_fields");
-            }
             if (related.isArray()) {
                 related.forEach(f -> {
                     String v = f.asText(null);

--- a/apps/be/src/main/java/com/capstone/logue/anal/service/QuestionCriteriaService.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/service/QuestionCriteriaService.java
@@ -28,15 +28,12 @@ import com.capstone.logue.global.exception.ErrorCode;
 import com.capstone.logue.global.exception.LogueException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;

--- a/apps/be/src/main/java/com/capstone/logue/anal/service/QuestionCriteriaService.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/service/QuestionCriteriaService.java
@@ -1,0 +1,360 @@
+package com.capstone.logue.anal.service;
+
+import com.capstone.logue.anal.client.FastApiClient;
+import com.capstone.logue.anal.dto.spring.request.CreateQuestionRequest;
+import com.capstone.logue.anal.dto.spring.request.UpdateQuestionCriteriaRequest;
+import com.capstone.logue.anal.dto.spring.response.CancelQuestionCriteriaResponse;
+import com.capstone.logue.anal.dto.spring.response.CreateQuestionResponse;
+import com.capstone.logue.anal.dto.spring.response.GetQuestionCriteriaResponse;
+import com.capstone.logue.anal.dto.spring.response.GetQuestionCriteriaStatusResponse;
+import com.capstone.logue.anal.dto.spring.response.UpdateQuestionCriteriaResponse;
+import com.capstone.logue.anal.repository.AiTaggingJobRepository;
+import com.capstone.logue.anal.repository.AnalysisCriteriaRepository;
+import com.capstone.logue.anal.repository.AnalysisFlowRepository;
+import com.capstone.logue.anal.repository.ConversationRepository;
+import com.capstone.logue.anal.repository.FlowDataWarningRepository;
+import com.capstone.logue.anal.repository.MessageRepository;
+import com.capstone.logue.auth.provider.SecurityContextProvider;
+import com.capstone.logue.global.entity.AiTaggingJob;
+import com.capstone.logue.global.entity.AnalysisCriteria;
+import com.capstone.logue.global.entity.AnalysisFlow;
+import com.capstone.logue.global.entity.Conversation;
+import com.capstone.logue.global.entity.FlowDataWarning;
+import com.capstone.logue.global.entity.Message;
+import com.capstone.logue.global.entity.enums.JobStage;
+import com.capstone.logue.global.entity.enums.JobStatus;
+import com.capstone.logue.global.entity.enums.MessageRole;
+import com.capstone.logue.global.exception.ErrorCode;
+import com.capstone.logue.global.exception.LogueException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * 질문 분석 플로우(분석 기준 도출/조회/수정/취소/상태폴링)의 비즈니스 로직을 담당합니다.
+ *
+ * <p>비동기 FastAPI 호출은 {@link QuestionAnalysisAsyncService} 에 위임합니다.
+ * 상태/결과 영속화는 {@link JobStateService} 에 위임합니다.</p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class QuestionCriteriaService {
+
+    private final ConversationRepository conversationRepository;
+    private final AnalysisFlowRepository analysisFlowRepository;
+    private final AiTaggingJobRepository aiTaggingJobRepository;
+    private final MessageRepository messageRepository;
+    private final AnalysisCriteriaRepository analysisCriteriaRepository;
+    private final FlowDataWarningRepository flowDataWarningRepository;
+    private final SecurityContextProvider securityContextProvider;
+    private final QuestionAnalysisAsyncService questionAnalysisAsyncService;
+    private final FastApiClient fastApiClient;
+    private final ObjectMapper objectMapper;
+
+    private static final String MESSAGE_CRITERIA_READY =
+            "질문 분석이 완료되었어요. 아래 분석 기준으로 검증을 진행해도 될까요?";
+    private static final String MESSAGE_CRITERIA_NEED_CONFIRM =
+            "질문 분석이 완료되었어요. 문제가 있는 부분은 임의로 넣어보았으니 꼭 확인해주세요.";
+
+    /**
+     * 사용자 질문을 메시지로 저장하고 분석 기준 도출 비동기 작업을 트리거합니다.
+     *
+     * @param conversationId 대화 ID
+     * @param analysisFlowId 분석 흐름 ID
+     * @param request        질문 내용
+     * @return 생성된 메시지 정보
+     */
+    @Transactional
+    public CreateQuestionResponse createQuestion(
+            Long conversationId, Long analysisFlowId, CreateQuestionRequest request) {
+
+        AnalysisFlow flow = validateAccess(conversationId, analysisFlowId);
+
+        AiTaggingJob latestDataStatusJob = aiTaggingJobRepository
+                .findTopByAnalysisFlowIdAndStageOrderByCreatedAtDesc(analysisFlowId, JobStage.DATA_STATUS)
+                .orElseThrow(() -> new LogueException(ErrorCode.DATASOURCE_NOT_READY));
+        if (latestDataStatusJob.getStatus() != JobStatus.SUCCESS) {
+            throw new LogueException(ErrorCode.DATASOURCE_NOT_READY);
+        }
+
+        Message message = Message.builder()
+                .analysisFlow(flow)
+                .role(MessageRole.USER)
+                .content(request.question())
+                .build();
+        Message savedMessage = messageRepository.save(message);
+
+        AiTaggingJob job = AiTaggingJob.builder()
+                .conversation(flow.getConversation())
+                .analysisFlow(flow)
+                .message(savedMessage)
+                .stage(JobStage.ANALYSIS_CRITERIA)
+                .status(JobStatus.QUEUED)
+                .build();
+        AiTaggingJob savedJob = aiTaggingJobRepository.save(job);
+
+        questionAnalysisAsyncService.resolveCriteriaAsync(savedJob.getId(), savedMessage.getContent());
+
+        return new CreateQuestionResponse(
+                savedMessage.getId(),
+                savedMessage.getContent(),
+                savedMessage.getCreatedAt()
+        );
+    }
+
+    /**
+     * 분석 기준 도출 결과를 조회합니다.
+     *
+     * @param conversationId 대화 ID
+     * @param analysisFlowId 분석 흐름 ID
+     * @param messageId      사용자 메시지 ID
+     * @return 분석 기준 + 데이터 경고 + 사용자 확인 필요 필드 목록
+     */
+    @Transactional(readOnly = true)
+    public GetQuestionCriteriaResponse getCriteria(
+            Long conversationId, Long analysisFlowId, Long messageId) {
+
+        AnalysisFlow flow = validateAccess(conversationId, analysisFlowId);
+        Message message = loadMessage(flow, messageId);
+
+        AiTaggingJob job = aiTaggingJobRepository
+                .findTopByMessageIdAndStageOrderByCreatedAtDesc(messageId, JobStage.ANALYSIS_CRITERIA)
+                .orElseThrow(() -> new LogueException(ErrorCode.CRITERIA_NOT_FOUND));
+
+        if (job.getStatus() != JobStatus.SUCCESS) {
+            throw new LogueException(ErrorCode.CRITERIA_NOT_COMPLETED);
+        }
+
+        AnalysisCriteria criteria = analysisCriteriaRepository
+                .findTopByAnalysisFlowIdOrderByCreatedAtDesc(flow.getId())
+                .orElseThrow(() -> new LogueException(ErrorCode.CRITERIA_NOT_FOUND));
+
+        List<FlowDataWarning> warnings = flowDataWarningRepository
+                .findByAnalysisCriteriaId(criteria.getId());
+
+        List<GetQuestionCriteriaResponse.DataWarningItem> warningItems = new ArrayList<>();
+        int order = 1;
+        for (FlowDataWarning w : warnings) {
+            warningItems.add(new GetQuestionCriteriaResponse.DataWarningItem(order++, w.getComment()));
+        }
+
+        List<String> needConfirm = extractNeedConfirm(criteria.getDataWarnings());
+
+        GetQuestionCriteriaResponse.CriteriaInfo criteriaInfo = new GetQuestionCriteriaResponse.CriteriaInfo(
+                criteria.getAnalysisType().name(),
+                criteria.getMetricName(),
+                criteria.getBaseDateColumn(),
+                criteria.getStandardPeriod(),
+                criteria.getComparePeriod(),
+                jsonNodeToStringList(criteria.getGroupBy()),
+                criteria.getSortBy(),
+                criteria.getSortDirection(),
+                criteria.getLimitNum(),
+                jsonNodeToFilters(criteria.getFilters()),
+                warningItems,
+                needConfirm
+        );
+
+        String userMessage = warnings.isEmpty() ? MESSAGE_CRITERIA_READY : MESSAGE_CRITERIA_NEED_CONFIRM;
+
+        return new GetQuestionCriteriaResponse(
+                message.getId(),
+                message.getContent(),
+                userMessage,
+                criteriaInfo,
+                criteria.getCreatedAt()
+        );
+    }
+
+    /**
+     * 분석 기준을 수정하거나 확정합니다.
+     *
+     * @param conversationId 대화 ID
+     * @param analysisFlowId 분석 흐름 ID
+     * @param messageId      사용자 메시지 ID
+     * @param request        수정 요청
+     * @return 분석 기준 ID + 확정 시각 (확정되지 않은 경우 null)
+     */
+    @Transactional
+    public UpdateQuestionCriteriaResponse updateCriteria(
+            Long conversationId, Long analysisFlowId, Long messageId,
+            UpdateQuestionCriteriaRequest request) {
+
+        AnalysisFlow flow = validateAccess(conversationId, analysisFlowId);
+        loadMessage(flow, messageId);
+
+        AnalysisCriteria criteria = analysisCriteriaRepository
+                .findTopByAnalysisFlowIdOrderByCreatedAtDesc(flow.getId())
+                .orElseThrow(() -> new LogueException(ErrorCode.CRITERIA_NOT_FOUND));
+
+        if (Boolean.TRUE.equals(criteria.getIsConfirmed()) && request.confirmed()) {
+            throw new LogueException(ErrorCode.CRITERIA_ALREADY_CONFIRMED);
+        }
+
+        applyUpdate(criteria, request);
+        analysisCriteriaRepository.save(criteria);
+
+        return new UpdateQuestionCriteriaResponse(criteria.getId(), criteria.getConfirmedAt());
+    }
+
+    /**
+     * 진행 중인 분석 기준 도출 작업을 취소합니다.
+     *
+     * @param conversationId 대화 ID
+     * @param analysisFlowId 분석 흐름 ID
+     * @param messageId      사용자 메시지 ID
+     * @return 취소 결과 (status: CANCELLED)
+     */
+    @Transactional
+    public CancelQuestionCriteriaResponse cancelCriteria(
+            Long conversationId, Long analysisFlowId, Long messageId) {
+
+        AnalysisFlow flow = validateAccess(conversationId, analysisFlowId);
+        loadMessage(flow, messageId);
+
+        AiTaggingJob job = aiTaggingJobRepository
+                .findTopByMessageIdAndStageOrderByCreatedAtDesc(messageId, JobStage.ANALYSIS_CRITERIA)
+                .orElseThrow(() -> new LogueException(ErrorCode.CRITERIA_NOT_FOUND));
+
+        JobStatus status = job.getStatus();
+        boolean cancellable = status == JobStatus.QUEUED
+                || status == JobStatus.RUNNING
+                || status == JobStatus.RETRYING;
+        if (!cancellable) {
+            throw new LogueException(ErrorCode.CRITERIA_NOT_STARTED);
+        }
+
+        job.markCanceled();
+        aiTaggingJobRepository.save(job);
+
+        try {
+            fastApiClient.cancelAnalysis(job.getId());
+        } catch (Exception e) {
+            log.warn("[QuestionCriteriaService] FastAPI 분석 기준 취소 요청 실패 (무시): jobId={}", job.getId(), e);
+        }
+
+        return new CancelQuestionCriteriaResponse("CANCELLED");
+    }
+
+    /**
+     * 분석 기준 도출 작업 상태를 조회합니다.
+     *
+     * @param conversationId 대화 ID
+     * @param analysisFlowId 분석 흐름 ID
+     * @param messageId      사용자 메시지 ID
+     * @return 현재 작업 상태 문자열
+     */
+    @Transactional(readOnly = true)
+    public GetQuestionCriteriaStatusResponse getCriteriaStatus(
+            Long conversationId, Long analysisFlowId, Long messageId) {
+
+        AnalysisFlow flow = validateAccess(conversationId, analysisFlowId);
+        loadMessage(flow, messageId);
+
+        AiTaggingJob job = aiTaggingJobRepository
+                .findTopByMessageIdAndStageOrderByCreatedAtDesc(messageId, JobStage.ANALYSIS_CRITERIA)
+                .orElseThrow(() -> new LogueException(ErrorCode.CRITERIA_NOT_FOUND));
+
+        return new GetQuestionCriteriaStatusResponse(job.getStatus().name());
+    }
+
+    /**
+     * 대화 소유권 + 플로우 소속 + (선택) 메시지 소속을 검증합니다.
+     */
+    private AnalysisFlow validateAccess(Long conversationId, Long analysisFlowId) {
+        Conversation conversation = conversationRepository.findById(conversationId)
+                .orElseThrow(() -> new LogueException(ErrorCode.CONVERSATION_NOT_FOUND));
+
+        Long currentUserId = securityContextProvider.getAuthenticatedUser().userId();
+        if (!conversation.getUser().getId().equals(currentUserId)) {
+            throw new LogueException(ErrorCode.FORBIDDEN);
+        }
+
+        AnalysisFlow flow = analysisFlowRepository.findById(analysisFlowId)
+                .orElseThrow(() -> new LogueException(ErrorCode.DATASOURCE_NOT_FOUND));
+
+        if (!flow.getConversation().getId().equals(conversationId)) {
+            throw new LogueException(ErrorCode.FORBIDDEN);
+        }
+
+        return flow;
+    }
+
+    private Message loadMessage(AnalysisFlow flow, Long messageId) {
+        Message message = messageRepository.findById(messageId)
+                .orElseThrow(() -> new LogueException(ErrorCode.MESSAGE_NOT_FOUND));
+        if (!message.getAnalysisFlow().getId().equals(flow.getId())) {
+            throw new LogueException(ErrorCode.FORBIDDEN);
+        }
+        return message;
+    }
+
+    private void applyUpdate(AnalysisCriteria criteria, UpdateQuestionCriteriaRequest request) {
+        JsonNode groupByNode = request.groupBy() == null ? null : objectMapper.valueToTree(request.groupBy());
+        JsonNode filtersNode = request.filters() == null ? null : objectMapper.valueToTree(request.filters());
+
+        criteria.applyUserUpdate(
+                request.baseDateColumn(),
+                request.standardPeriod(),
+                request.comparePeriod(),
+                request.sortBy(),
+                request.sortDirection(),
+                request.limitNum(),
+                groupByNode,
+                filtersNode
+        );
+
+        if (request.confirmed() && !Boolean.TRUE.equals(criteria.getIsConfirmed())) {
+            criteria.confirm();
+        }
+    }
+
+    private List<String> jsonNodeToStringList(JsonNode node) {
+        if (node == null || !node.isArray()) return List.of();
+        List<String> result = new ArrayList<>();
+        node.forEach(n -> result.add(n.asText()));
+        return result;
+    }
+
+    private List<GetQuestionCriteriaResponse.FilterInfo> jsonNodeToFilters(JsonNode node) {
+        if (node == null || !node.isArray()) return List.of();
+        List<GetQuestionCriteriaResponse.FilterInfo> result = new ArrayList<>();
+        for (JsonNode item : node) {
+            String field = item.path("field").asText(null);
+            String operator = item.path("operator").asText(null);
+            JsonNode value = item.path("value");
+            result.add(new GetQuestionCriteriaResponse.FilterInfo(field, operator, value));
+        }
+        return result;
+    }
+
+    private List<String> extractNeedConfirm(JsonNode dataWarnings) {
+        if (dataWarnings == null || !dataWarnings.isArray()) return List.of();
+        Set<String> result = new LinkedHashSet<>();
+        for (JsonNode warning : dataWarnings) {
+            JsonNode related = warning.path("relatedFields");
+            if (!related.isArray()) {
+                related = warning.path("related_fields");
+            }
+            if (related.isArray()) {
+                related.forEach(f -> {
+                    String v = f.asText(null);
+                    if (v != null && !v.isBlank()) result.add(v);
+                });
+            }
+        }
+        return new ArrayList<>(result);
+    }
+}

--- a/apps/be/src/main/java/com/capstone/logue/global/entity/AnalysisCriteria.java
+++ b/apps/be/src/main/java/com/capstone/logue/global/entity/AnalysisCriteria.java
@@ -166,4 +166,40 @@ public class AnalysisCriteria extends BaseTimeEntity {
     @Builder.Default
     @OneToMany(mappedBy = "analysisCriteria", fetch = FetchType.LAZY)
     private List<FlowDataWarning> flowDataWarnings = new ArrayList<>();
+
+    /**
+     * 사용자 수정 요청을 반영합니다.
+     *
+     * <p>baseDateColumn, standardPeriod, comparePeriod, sortBy, sortDirection, limitNum 은 항상 갱신되며,
+     * groupBy / filters 는 null 이 아닌 경우에만 갱신됩니다.</p>
+     */
+    public void applyUserUpdate(
+            String baseDateColumn,
+            String standardPeriod,
+            String comparePeriod,
+            String sortBy,
+            String sortDirection,
+            Long limitNum,
+            JsonNode groupBy,
+            JsonNode filters
+    ) {
+        this.baseDateColumn = baseDateColumn;
+        this.standardPeriod = standardPeriod;
+        this.comparePeriod = comparePeriod;
+        this.sortBy = sortBy;
+        this.sortDirection = sortDirection;
+        this.limitNum = limitNum;
+        if (groupBy != null) {
+            this.groupBy = groupBy;
+        }
+        this.filters = filters;
+    }
+
+    /**
+     * 분석 기준을 확정 상태로 전환합니다.
+     */
+    public void confirm() {
+        this.isConfirmed = Boolean.TRUE;
+        this.confirmedAt = OffsetDateTime.now();
+    }
 }

--- a/apps/be/src/main/java/com/capstone/logue/global/entity/AnalysisCriteria.java
+++ b/apps/be/src/main/java/com/capstone/logue/global/entity/AnalysisCriteria.java
@@ -192,7 +192,9 @@ public class AnalysisCriteria extends BaseTimeEntity {
         if (groupBy != null) {
             this.groupBy = groupBy;
         }
-        this.filters = filters;
+        if (filters != null) {
+            this.filters = filters;
+        }
     }
 
     /**

--- a/apps/be/src/main/java/com/capstone/logue/global/entity/enums/FlowWarningKey.java
+++ b/apps/be/src/main/java/com/capstone/logue/global/entity/enums/FlowWarningKey.java
@@ -12,6 +12,23 @@ package com.capstone.logue.global.entity.enums;
  * </ul>
  */
 public enum FlowWarningKey {
-    QUESTION_DATA_MISMATCH,
-    CRITICAL_NULL_DETECTED
+    QUESTION_DATA_MISMATCH(
+            "필요한 항목이 없어요",
+            "없는 항목은 다른 기준으로 바꿔서 계속할 수 있어요."
+    ),
+    CRITICAL_NULL_DETECTED(
+            "분석에 필요한 값이 일부 비어 있어요",
+            "비어 있는 값이 많아 결과가 부정확할 수 있어요."
+    );
+
+    private final String name;
+    private final String comment;
+
+    FlowWarningKey(String name, String comment) {
+        this.name = name;
+        this.comment = comment;
+    }
+
+    public String getName() { return name; }
+    public String getComment() { return comment; }
 }

--- a/apps/be/src/main/java/com/capstone/logue/global/exception/ErrorCode.java
+++ b/apps/be/src/main/java/com/capstone/logue/global/exception/ErrorCode.java
@@ -39,7 +39,21 @@ public enum ErrorCode {
 
     // Analysis
     JOB_NOT_FOUND(HttpStatus.NOT_FOUND, "AN001", "분석 작업을 찾을 수 없습니다."),
-    JOB_NOT_RETRYABLE(HttpStatus.BAD_REQUEST, "AN002", "재시도는 FAILED 상태에서만 가능합니다.")
+    JOB_NOT_RETRYABLE(HttpStatus.BAD_REQUEST, "AN002", "재시도는 FAILED 상태에서만 가능합니다."),
+
+    // Question Analysis Criteria
+    CRITERIA_NOT_FOUND(HttpStatus.NOT_FOUND, "AN101", "분석 기준을 찾을 수 없습니다."),
+    CRITERIA_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "AN102", "분석 기준 도출이 완료되지 않았습니다."),
+    CRITERIA_NOT_STARTED(HttpStatus.BAD_REQUEST, "AN103", "분석 기준 도출이 시작되지 않았습니다."),
+    CRITERIA_ALREADY_CONFIRMED(HttpStatus.CONFLICT, "AN104", "이미 확정된 분석 기준입니다."),
+    UNSUPPORTED_QUESTION(HttpStatus.BAD_REQUEST, "AN105", "이번 MVP에서 지원하지 않는 질문 유형입니다."),
+    DATASOURCE_NOT_READY(HttpStatus.BAD_REQUEST, "AN106", "데이터 상태 요약이 완료되어야 질문을 분석할 수 있습니다."),
+
+    // Message
+    MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "M001", "메시지를 찾을 수 없습니다."),
+
+    // LLM
+    LLM_CALL_FAILED(HttpStatus.BAD_GATEWAY, "L001", "LLM 호출에 실패했습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/apps/be/src/test/java/com/capstone/logue/anal/service/QuestionAnalysisAsyncServiceTest.java
+++ b/apps/be/src/test/java/com/capstone/logue/anal/service/QuestionAnalysisAsyncServiceTest.java
@@ -1,0 +1,193 @@
+package com.capstone.logue.anal.service;
+
+import com.capstone.logue.anal.client.FastApiClient;
+import com.capstone.logue.anal.dto.fastapi.request.QuestionAnalysisRequest;
+import com.capstone.logue.anal.dto.fastapi.response.AnalysisCriteriaInfo;
+import com.capstone.logue.anal.dto.fastapi.response.QuestionAnalysisResponse;
+import com.capstone.logue.anal.dto.fastapi.response.UnsupportedQuestionInfo;
+import com.capstone.logue.global.entity.AnalysisFlow;
+import com.capstone.logue.global.entity.Conversation;
+import com.capstone.logue.global.entity.DataSource;
+import com.capstone.logue.global.entity.User;
+import com.capstone.logue.global.exception.ErrorCode;
+import com.capstone.logue.global.exception.LogueException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.ResourceAccessException;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@link QuestionAnalysisAsyncService} 단위 테스트.
+ *
+ * <p>FastAPI 응답 유형별 에러 처리 및 재시도 로직, unsupported_question 처리를 검증합니다.</p>
+ */
+@ExtendWith(MockitoExtension.class)
+class QuestionAnalysisAsyncServiceTest {
+
+    private static final Long JOB_ID = 1L;
+    private static final Long CONVERSATION_ID = 10L;
+    private static final Long FLOW_ID = 11L;
+    private static final Long DATASOURCE_ID = 5L;
+
+    @Mock private JobStateService jobStateService;
+    @Mock private QuestionAnalysisRequestBuilder requestBuilder;
+    @Mock private FastApiClient fastApiClient;
+
+    private QuestionAnalysisAsyncService service;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        service = new QuestionAnalysisAsyncService(jobStateService, requestBuilder, fastApiClient);
+    }
+
+    private CriteriaJobContext stubContext() {
+        User user = User.builder().id(1L).email("e").providerUserId("p").name("n").provider("GOOGLE").build();
+        Conversation conversation = Conversation.builder().id(CONVERSATION_ID).user(user).title("t").build();
+        DataSource dataSource = DataSource.builder()
+                .id(DATASOURCE_ID).user(user).fileName("f").rowCount(1).columnCount(1)
+                .schemaJson(objectMapper.createObjectNode()).build();
+        AnalysisFlow flow = AnalysisFlow.builder()
+                .id(FLOW_ID).conversation(conversation).dataSource(dataSource).build();
+        return new CriteriaJobContext(null, flow, dataSource, List.of(), List.of(), List.of());
+    }
+
+    private QuestionAnalysisResponse successResponse() {
+        AnalysisCriteriaInfo criteria = new AnalysisCriteriaInfo(
+                "COMPARISON", "conversion_rate", "RATIO",
+                "signup_complete", "landing_sessions",
+                "signed_at", "this_week", "last_week",
+                "delta", "asc",
+                List.of("channel"),
+                null, List.of()
+        );
+        return new QuestionAnalysisResponse(
+                String.valueOf(JOB_ID), criteria, List.of(), List.of(), null);
+    }
+
+    @Test
+    @DisplayName("4xx 응답 시 재시도 없이 즉시 FAILED")
+    void resolveCriteriaAsync_4xx_failed() {
+        when(jobStateService.markCriteriaRunningAndGetContext(JOB_ID)).thenReturn(stubContext());
+        when(requestBuilder.build(any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(mock(QuestionAnalysisRequest.class));
+        when(fastApiClient.resolveAnalysisCriteria(any()))
+                .thenReturn(ResponseEntity.status(422).build());
+
+        service.resolveCriteriaAsync(JOB_ID, "Q?");
+
+        verify(jobStateService).markFailed(eq(JOB_ID), contains("4xx"));
+        verify(jobStateService, never()).markRetrying(any(), any());
+        verify(jobStateService, never()).saveCriteriaAndMarkSuccess(any(), any());
+    }
+
+    @Test
+    @DisplayName("5xx 응답 3회 연속이면 재시도 소진 후 FAILED")
+    void resolveCriteriaAsync_5xx_exhaustFailed() {
+        when(jobStateService.markCriteriaRunningAndGetContext(JOB_ID)).thenReturn(stubContext());
+        when(requestBuilder.build(any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(mock(QuestionAnalysisRequest.class));
+        when(fastApiClient.resolveAnalysisCriteria(any()))
+                .thenReturn(ResponseEntity.status(500).build());
+
+        service.resolveCriteriaAsync(JOB_ID, "Q?");
+
+        verify(fastApiClient, times(3)).resolveAnalysisCriteria(any());
+        verify(jobStateService, times(2)).markRetrying(eq(JOB_ID), any());
+        verify(jobStateService).markFailed(eq(JOB_ID), contains("재시도 3회 소진"));
+    }
+
+    @Test
+    @DisplayName("5xx 2회 후 성공이면 SUCCESS")
+    void resolveCriteriaAsync_5xxThenSuccess() {
+        when(jobStateService.markCriteriaRunningAndGetContext(JOB_ID)).thenReturn(stubContext());
+        when(requestBuilder.build(any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(mock(QuestionAnalysisRequest.class));
+        when(fastApiClient.resolveAnalysisCriteria(any()))
+                .thenReturn(ResponseEntity.status(500).build())
+                .thenReturn(ResponseEntity.status(500).build())
+                .thenReturn(ResponseEntity.ok(successResponse()));
+
+        service.resolveCriteriaAsync(JOB_ID, "Q?");
+
+        verify(fastApiClient, times(3)).resolveAnalysisCriteria(any());
+        verify(jobStateService, times(2)).markRetrying(eq(JOB_ID), any());
+        verify(jobStateService).saveCriteriaAndMarkSuccess(eq(JOB_ID), any());
+        verify(jobStateService, never()).markFailed(any(), any());
+    }
+
+    @Test
+    @DisplayName("네트워크 에러 3회 소진 시 FAILED")
+    void resolveCriteriaAsync_network_exhaustFailed() {
+        when(jobStateService.markCriteriaRunningAndGetContext(JOB_ID)).thenReturn(stubContext());
+        when(requestBuilder.build(any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(mock(QuestionAnalysisRequest.class));
+        when(fastApiClient.resolveAnalysisCriteria(any()))
+                .thenThrow(new ResourceAccessException("Connection refused"));
+
+        service.resolveCriteriaAsync(JOB_ID, "Q?");
+
+        verify(fastApiClient, times(3)).resolveAnalysisCriteria(any());
+        verify(jobStateService).markFailed(eq(JOB_ID), contains("재시도 3회 소진"));
+    }
+
+    @Test
+    @DisplayName("2xx 인데 스키마 불일치(LogueException) 면 재시도 없이 FAILED")
+    void resolveCriteriaAsync_schemaMismatch_failed() {
+        when(jobStateService.markCriteriaRunningAndGetContext(JOB_ID)).thenReturn(stubContext());
+        when(requestBuilder.build(any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(mock(QuestionAnalysisRequest.class));
+        when(fastApiClient.resolveAnalysisCriteria(any()))
+                .thenReturn(ResponseEntity.ok(successResponse()));
+        doThrow(new LogueException(ErrorCode.COLUMN_NOT_FOUND))
+                .when(jobStateService).saveCriteriaAndMarkSuccess(any(), any());
+
+        service.resolveCriteriaAsync(JOB_ID, "Q?");
+
+        verify(fastApiClient, times(1)).resolveAnalysisCriteria(any());
+        verify(jobStateService).markFailed(eq(JOB_ID), contains("스키마 불일치"));
+        verify(jobStateService, never()).markRetrying(any(), any());
+    }
+
+    @Test
+    @DisplayName("unsupported_question 응답 시 saveCriteriaAndMarkSuccess 가 호출되어 분기 처리")
+    void resolveCriteriaAsync_unsupported_routesToSave() {
+        when(jobStateService.markCriteriaRunningAndGetContext(JOB_ID)).thenReturn(stubContext());
+        when(requestBuilder.build(any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(mock(QuestionAnalysisRequest.class));
+
+        UnsupportedQuestionInfo unsupported = new UnsupportedQuestionInfo("MVP 미지원 질문 유형", "funnel");
+        QuestionAnalysisResponse response = new QuestionAnalysisResponse(
+                String.valueOf(JOB_ID), null, List.of(), List.of(), unsupported);
+
+        when(fastApiClient.resolveAnalysisCriteria(any()))
+                .thenReturn(ResponseEntity.ok(response));
+
+        service.resolveCriteriaAsync(JOB_ID, "Q?");
+
+        verify(fastApiClient, times(1)).resolveAnalysisCriteria(any());
+        verify(jobStateService).saveCriteriaAndMarkSuccess(eq(JOB_ID),
+                argThat(r -> r.unsupportedQuestion() != null
+                        && r.unsupportedQuestion().reason().contains("MVP")));
+        verify(jobStateService, never()).markRetrying(any(), any());
+    }
+}

--- a/apps/be/src/test/java/com/capstone/logue/anal/service/QuestionCriteriaServiceTest.java
+++ b/apps/be/src/test/java/com/capstone/logue/anal/service/QuestionCriteriaServiceTest.java
@@ -132,7 +132,7 @@ class QuestionCriteriaServiceTest {
                 .id(99L).conversation(conversation).analysisFlow(flow)
                 .stage(JobStage.DATA_STATUS).status(JobStatus.SUCCESS)
                 .build();
-        when(aiTaggingJobRepository.findTopByAnalysisFlowIdAndStageOrderByCreatedAtDesc(
+        when(aiTaggingJobRepository.findTopByAnalysisFlowIdAndStageOrderByCreatedAtDescIdDesc(
                 ANALYSIS_FLOW_ID, JobStage.DATA_STATUS))
                 .thenReturn(Optional.of(dataStatusJob));
 
@@ -166,7 +166,7 @@ class QuestionCriteriaServiceTest {
                 .id(99L).conversation(conversation).analysisFlow(flow)
                 .stage(JobStage.DATA_STATUS).status(JobStatus.RUNNING)
                 .build();
-        when(aiTaggingJobRepository.findTopByAnalysisFlowIdAndStageOrderByCreatedAtDesc(
+        when(aiTaggingJobRepository.findTopByAnalysisFlowIdAndStageOrderByCreatedAtDescIdDesc(
                 ANALYSIS_FLOW_ID, JobStage.DATA_STATUS))
                 .thenReturn(Optional.of(runningJob));
 
@@ -183,7 +183,7 @@ class QuestionCriteriaServiceTest {
     @DisplayName("createQuestion: DATA_STATUS Job 이 아예 없으면 DATASOURCE_NOT_READY")
     void createQuestion_noDataStatusJob() {
         stubAccess();
-        when(aiTaggingJobRepository.findTopByAnalysisFlowIdAndStageOrderByCreatedAtDesc(
+        when(aiTaggingJobRepository.findTopByAnalysisFlowIdAndStageOrderByCreatedAtDescIdDesc(
                 ANALYSIS_FLOW_ID, JobStage.DATA_STATUS))
                 .thenReturn(Optional.empty());
 
@@ -206,7 +206,7 @@ class QuestionCriteriaServiceTest {
                 .id(JOB_ID).conversation(conversation).analysisFlow(flow).message(message)
                 .stage(JobStage.ANALYSIS_CRITERIA).status(JobStatus.SUCCESS)
                 .build();
-        when(aiTaggingJobRepository.findTopByMessageIdAndStageOrderByCreatedAtDesc(
+        when(aiTaggingJobRepository.findTopByMessageIdAndStageOrderByCreatedAtDescIdDesc(
                 MESSAGE_ID, JobStage.ANALYSIS_CRITERIA))
                 .thenReturn(Optional.of(job));
 
@@ -219,7 +219,7 @@ class QuestionCriteriaServiceTest {
                 .groupBy(objectMapper.valueToTree(List.of("channel")))
                 .isConfirmed(false)
                 .build();
-        when(analysisCriteriaRepository.findTopByAnalysisFlowIdOrderByCreatedAtDesc(ANALYSIS_FLOW_ID))
+        when(analysisCriteriaRepository.findTopByAnalysisFlowIdOrderByCreatedAtDescIdDesc(ANALYSIS_FLOW_ID))
                 .thenReturn(Optional.of(criteria));
         when(flowDataWarningRepository.findByAnalysisCriteriaId(CRITERIA_ID))
                 .thenReturn(List.of());
@@ -246,7 +246,7 @@ class QuestionCriteriaServiceTest {
                 .id(JOB_ID).conversation(conversation).analysisFlow(flow).message(message)
                 .stage(JobStage.ANALYSIS_CRITERIA).status(JobStatus.SUCCESS)
                 .build();
-        when(aiTaggingJobRepository.findTopByMessageIdAndStageOrderByCreatedAtDesc(
+        when(aiTaggingJobRepository.findTopByMessageIdAndStageOrderByCreatedAtDescIdDesc(
                 MESSAGE_ID, JobStage.ANALYSIS_CRITERIA))
                 .thenReturn(Optional.of(job));
 
@@ -263,7 +263,7 @@ class QuestionCriteriaServiceTest {
                 )))
                 .isConfirmed(false)
                 .build();
-        when(analysisCriteriaRepository.findTopByAnalysisFlowIdOrderByCreatedAtDesc(ANALYSIS_FLOW_ID))
+        when(analysisCriteriaRepository.findTopByAnalysisFlowIdOrderByCreatedAtDescIdDesc(ANALYSIS_FLOW_ID))
                 .thenReturn(Optional.of(criteria));
 
         FlowDataWarning warning = FlowDataWarning.builder()
@@ -294,7 +294,7 @@ class QuestionCriteriaServiceTest {
                 .id(JOB_ID).conversation(conversation).analysisFlow(flow).message(message)
                 .stage(JobStage.ANALYSIS_CRITERIA).status(JobStatus.RUNNING)
                 .build();
-        when(aiTaggingJobRepository.findTopByMessageIdAndStageOrderByCreatedAtDesc(
+        when(aiTaggingJobRepository.findTopByMessageIdAndStageOrderByCreatedAtDescIdDesc(
                 MESSAGE_ID, JobStage.ANALYSIS_CRITERIA))
                 .thenReturn(Optional.of(job));
 
@@ -319,7 +319,7 @@ class QuestionCriteriaServiceTest {
                 .groupBy(objectMapper.valueToTree(List.of("channel")))
                 .isConfirmed(false)
                 .build();
-        when(analysisCriteriaRepository.findTopByAnalysisFlowIdOrderByCreatedAtDesc(ANALYSIS_FLOW_ID))
+        when(analysisCriteriaRepository.findTopByAnalysisFlowIdOrderByCreatedAtDescIdDesc(ANALYSIS_FLOW_ID))
                 .thenReturn(Optional.of(criteria));
         when(analysisCriteriaRepository.save(any(AnalysisCriteria.class))).thenReturn(criteria);
 
@@ -351,7 +351,7 @@ class QuestionCriteriaServiceTest {
                 .groupBy(objectMapper.valueToTree(List.of("g")))
                 .isConfirmed(true)
                 .build();
-        when(analysisCriteriaRepository.findTopByAnalysisFlowIdOrderByCreatedAtDesc(ANALYSIS_FLOW_ID))
+        when(analysisCriteriaRepository.findTopByAnalysisFlowIdOrderByCreatedAtDescIdDesc(ANALYSIS_FLOW_ID))
                 .thenReturn(Optional.of(criteria));
 
         UpdateQuestionCriteriaRequest request = new UpdateQuestionCriteriaRequest(
@@ -374,7 +374,7 @@ class QuestionCriteriaServiceTest {
                 .id(JOB_ID).conversation(conversation).analysisFlow(flow).message(message)
                 .stage(JobStage.ANALYSIS_CRITERIA).status(JobStatus.QUEUED)
                 .build();
-        when(aiTaggingJobRepository.findTopByMessageIdAndStageOrderByCreatedAtDesc(
+        when(aiTaggingJobRepository.findTopByMessageIdAndStageOrderByCreatedAtDescIdDesc(
                 MESSAGE_ID, JobStage.ANALYSIS_CRITERIA))
                 .thenReturn(Optional.of(job));
 
@@ -397,7 +397,7 @@ class QuestionCriteriaServiceTest {
                 .id(JOB_ID).conversation(conversation).analysisFlow(flow).message(message)
                 .stage(JobStage.ANALYSIS_CRITERIA).status(JobStatus.RUNNING)
                 .build();
-        when(aiTaggingJobRepository.findTopByMessageIdAndStageOrderByCreatedAtDesc(
+        when(aiTaggingJobRepository.findTopByMessageIdAndStageOrderByCreatedAtDescIdDesc(
                 MESSAGE_ID, JobStage.ANALYSIS_CRITERIA))
                 .thenReturn(Optional.of(job));
 
@@ -421,7 +421,7 @@ class QuestionCriteriaServiceTest {
                 .id(JOB_ID).conversation(conversation).analysisFlow(flow).message(message)
                 .stage(JobStage.ANALYSIS_CRITERIA).status(JobStatus.SUCCESS)
                 .build();
-        when(aiTaggingJobRepository.findTopByMessageIdAndStageOrderByCreatedAtDesc(
+        when(aiTaggingJobRepository.findTopByMessageIdAndStageOrderByCreatedAtDescIdDesc(
                 MESSAGE_ID, JobStage.ANALYSIS_CRITERIA))
                 .thenReturn(Optional.of(job));
 
@@ -443,7 +443,7 @@ class QuestionCriteriaServiceTest {
                 .id(JOB_ID).conversation(conversation).analysisFlow(flow).message(message)
                 .stage(JobStage.ANALYSIS_CRITERIA).status(JobStatus.RUNNING)
                 .build();
-        when(aiTaggingJobRepository.findTopByMessageIdAndStageOrderByCreatedAtDesc(
+        when(aiTaggingJobRepository.findTopByMessageIdAndStageOrderByCreatedAtDescIdDesc(
                 MESSAGE_ID, JobStage.ANALYSIS_CRITERIA))
                 .thenReturn(Optional.of(job));
 

--- a/apps/be/src/test/java/com/capstone/logue/anal/service/QuestionCriteriaServiceTest.java
+++ b/apps/be/src/test/java/com/capstone/logue/anal/service/QuestionCriteriaServiceTest.java
@@ -1,0 +1,455 @@
+package com.capstone.logue.anal.service;
+
+import com.capstone.logue.anal.client.FastApiClient;
+import com.capstone.logue.anal.dto.spring.request.CreateQuestionRequest;
+import com.capstone.logue.anal.dto.spring.request.UpdateQuestionCriteriaRequest;
+import com.capstone.logue.anal.dto.spring.response.CancelQuestionCriteriaResponse;
+import com.capstone.logue.anal.dto.spring.response.CreateQuestionResponse;
+import com.capstone.logue.anal.dto.spring.response.GetQuestionCriteriaResponse;
+import com.capstone.logue.anal.dto.spring.response.GetQuestionCriteriaStatusResponse;
+import com.capstone.logue.anal.dto.spring.response.UpdateQuestionCriteriaResponse;
+import com.capstone.logue.anal.repository.AiTaggingJobRepository;
+import com.capstone.logue.anal.repository.AnalysisCriteriaRepository;
+import com.capstone.logue.anal.repository.AnalysisFlowRepository;
+import com.capstone.logue.anal.repository.ConversationRepository;
+import com.capstone.logue.anal.repository.FlowDataWarningRepository;
+import com.capstone.logue.anal.repository.MessageRepository;
+import com.capstone.logue.auth.provider.SecurityContextProvider;
+import com.capstone.logue.auth.security.UserPrincipal;
+import com.capstone.logue.global.entity.AiTaggingJob;
+import com.capstone.logue.global.entity.AnalysisCriteria;
+import com.capstone.logue.global.entity.AnalysisFlow;
+import com.capstone.logue.global.entity.Conversation;
+import com.capstone.logue.global.entity.DataSource;
+import com.capstone.logue.global.entity.FlowDataWarning;
+import com.capstone.logue.global.entity.Message;
+import com.capstone.logue.global.entity.User;
+import com.capstone.logue.global.entity.enums.AnalysisType;
+import com.capstone.logue.global.entity.enums.FlowWarningKey;
+import com.capstone.logue.global.entity.enums.JobStage;
+import com.capstone.logue.global.entity.enums.JobStatus;
+import com.capstone.logue.global.entity.enums.MessageRole;
+import com.capstone.logue.global.entity.enums.MetricType;
+import com.capstone.logue.global.exception.ErrorCode;
+import com.capstone.logue.global.exception.LogueException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestClientException;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@link QuestionCriteriaService} 단위 테스트.
+ */
+@ExtendWith(MockitoExtension.class)
+class QuestionCriteriaServiceTest {
+
+    private static final Long USER_ID = 1L;
+    private static final Long CONVERSATION_ID = 10L;
+    private static final Long ANALYSIS_FLOW_ID = 11L;
+    private static final Long DATASOURCE_ID = 5L;
+    private static final Long MESSAGE_ID = 22L;
+    private static final Long JOB_ID = 100L;
+    private static final Long CRITERIA_ID = 200L;
+
+    @Mock private ConversationRepository conversationRepository;
+    @Mock private AnalysisFlowRepository analysisFlowRepository;
+    @Mock private AiTaggingJobRepository aiTaggingJobRepository;
+    @Mock private MessageRepository messageRepository;
+    @Mock private AnalysisCriteriaRepository analysisCriteriaRepository;
+    @Mock private FlowDataWarningRepository flowDataWarningRepository;
+    @Mock private SecurityContextProvider securityContextProvider;
+    @Mock private QuestionAnalysisAsyncService questionAnalysisAsyncService;
+    @Mock private FastApiClient fastApiClient;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private QuestionCriteriaService service;
+
+    private User user;
+    private Conversation conversation;
+    private DataSource dataSource;
+    private AnalysisFlow flow;
+
+    @BeforeEach
+    void setUp() {
+        service = new QuestionCriteriaService(
+                conversationRepository,
+                analysisFlowRepository,
+                aiTaggingJobRepository,
+                messageRepository,
+                analysisCriteriaRepository,
+                flowDataWarningRepository,
+                securityContextProvider,
+                questionAnalysisAsyncService,
+                fastApiClient,
+                objectMapper
+        );
+
+        user = User.builder()
+                .id(USER_ID).email("t@t.com").providerUserId("p").name("n").provider("GOOGLE")
+                .build();
+        conversation = Conversation.builder()
+                .id(CONVERSATION_ID).user(user).title("새 대화")
+                .build();
+        dataSource = DataSource.builder()
+                .id(DATASOURCE_ID).user(user).fileName("d.csv").rowCount(10).columnCount(2)
+                .schemaJson(objectMapper.createObjectNode())
+                .build();
+        flow = AnalysisFlow.builder()
+                .id(ANALYSIS_FLOW_ID).conversation(conversation).dataSource(dataSource)
+                .build();
+    }
+
+    private void stubAccess() {
+        when(conversationRepository.findById(CONVERSATION_ID)).thenReturn(Optional.of(conversation));
+        when(analysisFlowRepository.findById(ANALYSIS_FLOW_ID)).thenReturn(Optional.of(flow));
+        when(securityContextProvider.getAuthenticatedUser())
+                .thenReturn(new UserPrincipal(USER_ID, "t@t.com"));
+    }
+
+    @Test
+    @DisplayName("createQuestion: DATA_STATUS Job 이 SUCCESS 면 메시지+Job 생성 후 비동기 호출")
+    void createQuestion_success() {
+        stubAccess();
+
+        AiTaggingJob dataStatusJob = AiTaggingJob.builder()
+                .id(99L).conversation(conversation).analysisFlow(flow)
+                .stage(JobStage.DATA_STATUS).status(JobStatus.SUCCESS)
+                .build();
+        when(aiTaggingJobRepository.findTopByAnalysisFlowIdAndStageOrderByCreatedAtDesc(
+                ANALYSIS_FLOW_ID, JobStage.DATA_STATUS))
+                .thenReturn(Optional.of(dataStatusJob));
+
+        Message savedMessage = Message.builder()
+                .id(MESSAGE_ID).analysisFlow(flow).role(MessageRole.USER).content("Q?")
+                .build();
+        when(messageRepository.save(any(Message.class))).thenReturn(savedMessage);
+
+        AiTaggingJob savedJob = AiTaggingJob.builder()
+                .id(JOB_ID).conversation(conversation).analysisFlow(flow).message(savedMessage)
+                .stage(JobStage.ANALYSIS_CRITERIA).status(JobStatus.QUEUED)
+                .build();
+        when(aiTaggingJobRepository.save(any(AiTaggingJob.class))).thenReturn(savedJob);
+
+        CreateQuestionResponse response = service.createQuestion(
+                CONVERSATION_ID, ANALYSIS_FLOW_ID, new CreateQuestionRequest("Q?"));
+
+        assertThat(response.messageId()).isEqualTo(MESSAGE_ID);
+        assertThat(response.question()).isEqualTo("Q?");
+        verify(messageRepository).save(any(Message.class));
+        verify(aiTaggingJobRepository).save(any(AiTaggingJob.class));
+        verify(questionAnalysisAsyncService).resolveCriteriaAsync(eq(JOB_ID), eq("Q?"));
+    }
+
+    @Test
+    @DisplayName("createQuestion: DATA_STATUS Job 이 SUCCESS 아니면 DATASOURCE_NOT_READY")
+    void createQuestion_dataStatusNotReady() {
+        stubAccess();
+
+        AiTaggingJob runningJob = AiTaggingJob.builder()
+                .id(99L).conversation(conversation).analysisFlow(flow)
+                .stage(JobStage.DATA_STATUS).status(JobStatus.RUNNING)
+                .build();
+        when(aiTaggingJobRepository.findTopByAnalysisFlowIdAndStageOrderByCreatedAtDesc(
+                ANALYSIS_FLOW_ID, JobStage.DATA_STATUS))
+                .thenReturn(Optional.of(runningJob));
+
+        assertThatThrownBy(() -> service.createQuestion(
+                CONVERSATION_ID, ANALYSIS_FLOW_ID, new CreateQuestionRequest("Q?")))
+                .isInstanceOf(LogueException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.DATASOURCE_NOT_READY);
+
+        verify(messageRepository, never()).save(any());
+        verify(questionAnalysisAsyncService, never()).resolveCriteriaAsync(any(), any());
+    }
+
+    @Test
+    @DisplayName("createQuestion: DATA_STATUS Job 이 아예 없으면 DATASOURCE_NOT_READY")
+    void createQuestion_noDataStatusJob() {
+        stubAccess();
+        when(aiTaggingJobRepository.findTopByAnalysisFlowIdAndStageOrderByCreatedAtDesc(
+                ANALYSIS_FLOW_ID, JobStage.DATA_STATUS))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.createQuestion(
+                CONVERSATION_ID, ANALYSIS_FLOW_ID, new CreateQuestionRequest("Q?")))
+                .isInstanceOf(LogueException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.DATASOURCE_NOT_READY);
+    }
+
+    @Test
+    @DisplayName("getCriteria: Job 이 SUCCESS 이고 데이터 경고가 없으면 ready 메시지를 반환")
+    void getCriteria_success_noWarning() {
+        stubAccess();
+        Message message = Message.builder()
+                .id(MESSAGE_ID).analysisFlow(flow).role(MessageRole.USER).content("Q?")
+                .build();
+        when(messageRepository.findById(MESSAGE_ID)).thenReturn(Optional.of(message));
+
+        AiTaggingJob job = AiTaggingJob.builder()
+                .id(JOB_ID).conversation(conversation).analysisFlow(flow).message(message)
+                .stage(JobStage.ANALYSIS_CRITERIA).status(JobStatus.SUCCESS)
+                .build();
+        when(aiTaggingJobRepository.findTopByMessageIdAndStageOrderByCreatedAtDesc(
+                MESSAGE_ID, JobStage.ANALYSIS_CRITERIA))
+                .thenReturn(Optional.of(job));
+
+        AnalysisCriteria criteria = AnalysisCriteria.builder()
+                .id(CRITERIA_ID).analysisFlow(flow)
+                .analysisType(AnalysisType.COMPARISON).metricName("conversion_rate")
+                .metricType(MetricType.RATIO)
+                .baseDateColumn("signed_at").standardPeriod("this_week").comparePeriod("last_week")
+                .sortBy("delta").sortDirection("asc")
+                .groupBy(objectMapper.valueToTree(List.of("channel")))
+                .isConfirmed(false)
+                .build();
+        when(analysisCriteriaRepository.findTopByAnalysisFlowIdOrderByCreatedAtDesc(ANALYSIS_FLOW_ID))
+                .thenReturn(Optional.of(criteria));
+        when(flowDataWarningRepository.findByAnalysisCriteriaId(CRITERIA_ID))
+                .thenReturn(List.of());
+
+        GetQuestionCriteriaResponse response = service.getCriteria(
+                CONVERSATION_ID, ANALYSIS_FLOW_ID, MESSAGE_ID);
+
+        assertThat(response.messageId()).isEqualTo(MESSAGE_ID);
+        assertThat(response.criteria().analysisType()).isEqualTo("COMPARISON");
+        assertThat(response.criteria().dataWarning()).isEmpty();
+        assertThat(response.message()).contains("아래 분석 기준으로 검증");
+    }
+
+    @Test
+    @DisplayName("getCriteria: 데이터 경고가 있으면 need-confirm 메시지를 반환")
+    void getCriteria_success_withWarning() {
+        stubAccess();
+        Message message = Message.builder()
+                .id(MESSAGE_ID).analysisFlow(flow).role(MessageRole.USER).content("Q?")
+                .build();
+        when(messageRepository.findById(MESSAGE_ID)).thenReturn(Optional.of(message));
+
+        AiTaggingJob job = AiTaggingJob.builder()
+                .id(JOB_ID).conversation(conversation).analysisFlow(flow).message(message)
+                .stage(JobStage.ANALYSIS_CRITERIA).status(JobStatus.SUCCESS)
+                .build();
+        when(aiTaggingJobRepository.findTopByMessageIdAndStageOrderByCreatedAtDesc(
+                MESSAGE_ID, JobStage.ANALYSIS_CRITERIA))
+                .thenReturn(Optional.of(job));
+
+        AnalysisCriteria criteria = AnalysisCriteria.builder()
+                .id(CRITERIA_ID).analysisFlow(flow)
+                .analysisType(AnalysisType.COMPARISON).metricName("conversion_rate")
+                .metricType(MetricType.RATIO)
+                .baseDateColumn("signed_at").standardPeriod("this_week").comparePeriod("last_week")
+                .sortBy("delta").sortDirection("asc")
+                .groupBy(objectMapper.valueToTree(List.of("channel")))
+                .dataWarnings(objectMapper.valueToTree(List.of(
+                        java.util.Map.of("code", "QUESTION_DATA_MISMATCH",
+                                "relatedFields", List.of("device_type"))
+                )))
+                .isConfirmed(false)
+                .build();
+        when(analysisCriteriaRepository.findTopByAnalysisFlowIdOrderByCreatedAtDesc(ANALYSIS_FLOW_ID))
+                .thenReturn(Optional.of(criteria));
+
+        FlowDataWarning warning = FlowDataWarning.builder()
+                .id(1L).analysisCriteria(criteria)
+                .code(FlowWarningKey.QUESTION_DATA_MISMATCH)
+                .name(FlowWarningKey.QUESTION_DATA_MISMATCH.getName())
+                .comment(FlowWarningKey.QUESTION_DATA_MISMATCH.getComment())
+                .build();
+        when(flowDataWarningRepository.findByAnalysisCriteriaId(CRITERIA_ID))
+                .thenReturn(List.of(warning));
+
+        GetQuestionCriteriaResponse response = service.getCriteria(
+                CONVERSATION_ID, ANALYSIS_FLOW_ID, MESSAGE_ID);
+
+        assertThat(response.criteria().dataWarning()).hasSize(1);
+        assertThat(response.criteria().needConfirm()).containsExactly("device_type");
+        assertThat(response.message()).contains("꼭 확인해주세요");
+    }
+
+    @Test
+    @DisplayName("getCriteria: Job 이 SUCCESS 가 아니면 CRITERIA_NOT_COMPLETED")
+    void getCriteria_notCompleted() {
+        stubAccess();
+        Message message = Message.builder().id(MESSAGE_ID).analysisFlow(flow).role(MessageRole.USER).content("Q?").build();
+        when(messageRepository.findById(MESSAGE_ID)).thenReturn(Optional.of(message));
+
+        AiTaggingJob job = AiTaggingJob.builder()
+                .id(JOB_ID).conversation(conversation).analysisFlow(flow).message(message)
+                .stage(JobStage.ANALYSIS_CRITERIA).status(JobStatus.RUNNING)
+                .build();
+        when(aiTaggingJobRepository.findTopByMessageIdAndStageOrderByCreatedAtDesc(
+                MESSAGE_ID, JobStage.ANALYSIS_CRITERIA))
+                .thenReturn(Optional.of(job));
+
+        assertThatThrownBy(() -> service.getCriteria(CONVERSATION_ID, ANALYSIS_FLOW_ID, MESSAGE_ID))
+                .isInstanceOf(LogueException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.CRITERIA_NOT_COMPLETED);
+    }
+
+    @Test
+    @DisplayName("updateCriteria: confirmed=true 면 isConfirmed=true 와 confirmedAt 갱신")
+    void updateCriteria_confirm() {
+        stubAccess();
+        Message message = Message.builder().id(MESSAGE_ID).analysisFlow(flow).role(MessageRole.USER).content("Q?").build();
+        when(messageRepository.findById(MESSAGE_ID)).thenReturn(Optional.of(message));
+
+        AnalysisCriteria criteria = AnalysisCriteria.builder()
+                .id(CRITERIA_ID).analysisFlow(flow)
+                .analysisType(AnalysisType.COMPARISON).metricName("conversion_rate")
+                .metricType(MetricType.RATIO)
+                .baseDateColumn("signed_at").standardPeriod("this_week").comparePeriod("last_week")
+                .sortBy("delta").sortDirection("asc")
+                .groupBy(objectMapper.valueToTree(List.of("channel")))
+                .isConfirmed(false)
+                .build();
+        when(analysisCriteriaRepository.findTopByAnalysisFlowIdOrderByCreatedAtDesc(ANALYSIS_FLOW_ID))
+                .thenReturn(Optional.of(criteria));
+        when(analysisCriteriaRepository.save(any(AnalysisCriteria.class))).thenReturn(criteria);
+
+        UpdateQuestionCriteriaRequest request = new UpdateQuestionCriteriaRequest(
+                "signed_at", "this_week", "last_week",
+                List.of("channel", "device"),
+                "delta", "asc", null, List.of(), true);
+
+        UpdateQuestionCriteriaResponse response = service.updateCriteria(
+                CONVERSATION_ID, ANALYSIS_FLOW_ID, MESSAGE_ID, request);
+
+        assertThat(response.analysisCriteriaId()).isEqualTo(CRITERIA_ID);
+        assertThat(criteria.getIsConfirmed()).isTrue();
+        assertThat(criteria.getConfirmedAt()).isNotNull();
+        verify(analysisCriteriaRepository).save(criteria);
+    }
+
+    @Test
+    @DisplayName("updateCriteria: 이미 confirmed 인데 다시 confirmed=true 면 CRITERIA_ALREADY_CONFIRMED")
+    void updateCriteria_alreadyConfirmed() {
+        stubAccess();
+        Message message = Message.builder().id(MESSAGE_ID).analysisFlow(flow).role(MessageRole.USER).content("Q?").build();
+        when(messageRepository.findById(MESSAGE_ID)).thenReturn(Optional.of(message));
+
+        AnalysisCriteria criteria = AnalysisCriteria.builder()
+                .id(CRITERIA_ID).analysisFlow(flow)
+                .analysisType(AnalysisType.COMPARISON).metricName("m").metricType(MetricType.RATIO)
+                .baseDateColumn("d").standardPeriod("p").sortBy("s").sortDirection("asc")
+                .groupBy(objectMapper.valueToTree(List.of("g")))
+                .isConfirmed(true)
+                .build();
+        when(analysisCriteriaRepository.findTopByAnalysisFlowIdOrderByCreatedAtDesc(ANALYSIS_FLOW_ID))
+                .thenReturn(Optional.of(criteria));
+
+        UpdateQuestionCriteriaRequest request = new UpdateQuestionCriteriaRequest(
+                "d", "p", null, List.of("g"), "s", "asc", null, List.of(), true);
+
+        assertThatThrownBy(() -> service.updateCriteria(
+                CONVERSATION_ID, ANALYSIS_FLOW_ID, MESSAGE_ID, request))
+                .isInstanceOf(LogueException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.CRITERIA_ALREADY_CONFIRMED);
+    }
+
+    @Test
+    @DisplayName("cancelCriteria: QUEUED Job 을 CANCELED 로 전이하고 FastAPI 취소 시도")
+    void cancelCriteria_queued() {
+        stubAccess();
+        Message message = Message.builder().id(MESSAGE_ID).analysisFlow(flow).role(MessageRole.USER).content("Q?").build();
+        when(messageRepository.findById(MESSAGE_ID)).thenReturn(Optional.of(message));
+
+        AiTaggingJob job = AiTaggingJob.builder()
+                .id(JOB_ID).conversation(conversation).analysisFlow(flow).message(message)
+                .stage(JobStage.ANALYSIS_CRITERIA).status(JobStatus.QUEUED)
+                .build();
+        when(aiTaggingJobRepository.findTopByMessageIdAndStageOrderByCreatedAtDesc(
+                MESSAGE_ID, JobStage.ANALYSIS_CRITERIA))
+                .thenReturn(Optional.of(job));
+
+        CancelQuestionCriteriaResponse response = service.cancelCriteria(
+                CONVERSATION_ID, ANALYSIS_FLOW_ID, MESSAGE_ID);
+
+        assertThat(response.status()).isEqualTo("CANCELLED");
+        assertThat(job.getStatus()).isEqualTo(JobStatus.CANCELED);
+        verify(fastApiClient).cancelAnalysis(JOB_ID);
+    }
+
+    @Test
+    @DisplayName("cancelCriteria: FastAPI 취소 실패해도 응답은 CANCELLED")
+    void cancelCriteria_fastApiFailureSwallowed() {
+        stubAccess();
+        Message message = Message.builder().id(MESSAGE_ID).analysisFlow(flow).role(MessageRole.USER).content("Q?").build();
+        when(messageRepository.findById(MESSAGE_ID)).thenReturn(Optional.of(message));
+
+        AiTaggingJob job = AiTaggingJob.builder()
+                .id(JOB_ID).conversation(conversation).analysisFlow(flow).message(message)
+                .stage(JobStage.ANALYSIS_CRITERIA).status(JobStatus.RUNNING)
+                .build();
+        when(aiTaggingJobRepository.findTopByMessageIdAndStageOrderByCreatedAtDesc(
+                MESSAGE_ID, JobStage.ANALYSIS_CRITERIA))
+                .thenReturn(Optional.of(job));
+
+        doThrow(new RestClientException("connect refused")).when(fastApiClient).cancelAnalysis(JOB_ID);
+
+        CancelQuestionCriteriaResponse response = service.cancelCriteria(
+                CONVERSATION_ID, ANALYSIS_FLOW_ID, MESSAGE_ID);
+
+        assertThat(response.status()).isEqualTo("CANCELLED");
+        assertThat(job.getStatus()).isEqualTo(JobStatus.CANCELED);
+    }
+
+    @Test
+    @DisplayName("cancelCriteria: 이미 SUCCESS 인 Job 은 CRITERIA_NOT_STARTED")
+    void cancelCriteria_notCancellable() {
+        stubAccess();
+        Message message = Message.builder().id(MESSAGE_ID).analysisFlow(flow).role(MessageRole.USER).content("Q?").build();
+        when(messageRepository.findById(MESSAGE_ID)).thenReturn(Optional.of(message));
+
+        AiTaggingJob job = AiTaggingJob.builder()
+                .id(JOB_ID).conversation(conversation).analysisFlow(flow).message(message)
+                .stage(JobStage.ANALYSIS_CRITERIA).status(JobStatus.SUCCESS)
+                .build();
+        when(aiTaggingJobRepository.findTopByMessageIdAndStageOrderByCreatedAtDesc(
+                MESSAGE_ID, JobStage.ANALYSIS_CRITERIA))
+                .thenReturn(Optional.of(job));
+
+        assertThatThrownBy(() -> service.cancelCriteria(CONVERSATION_ID, ANALYSIS_FLOW_ID, MESSAGE_ID))
+                .isInstanceOf(LogueException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.CRITERIA_NOT_STARTED);
+
+        verify(fastApiClient, never()).cancelAnalysis(any());
+    }
+
+    @Test
+    @DisplayName("getCriteriaStatus: Job 상태 문자열 반환")
+    void getCriteriaStatus_returnsStatus() {
+        stubAccess();
+        Message message = Message.builder().id(MESSAGE_ID).analysisFlow(flow).role(MessageRole.USER).content("Q?").build();
+        when(messageRepository.findById(MESSAGE_ID)).thenReturn(Optional.of(message));
+
+        AiTaggingJob job = AiTaggingJob.builder()
+                .id(JOB_ID).conversation(conversation).analysisFlow(flow).message(message)
+                .stage(JobStage.ANALYSIS_CRITERIA).status(JobStatus.RUNNING)
+                .build();
+        when(aiTaggingJobRepository.findTopByMessageIdAndStageOrderByCreatedAtDesc(
+                MESSAGE_ID, JobStage.ANALYSIS_CRITERIA))
+                .thenReturn(Optional.of(job));
+
+        GetQuestionCriteriaStatusResponse response = service.getCriteriaStatus(
+                CONVERSATION_ID, ANALYSIS_FLOW_ID, MESSAGE_ID);
+
+        assertThat(response.status()).isEqualTo("RUNNING");
+    }
+}


### PR DESCRIPTION
## 요약
- 클라이언트용 분석 기준 API 5종 신설 + Spring → FastAPI `POST /v1/llm/analysis-criteria/resolve` 비동기 연동(`JobStage.ANALYSIS_CRITERIA`)을 일괄 추가해 질문 분석 플로우를 완성한다.

## 변경 사항
- [x] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트
- [x] 기타 (미사용 import 정리)

### 상세
- **클라이언트 API 5종** (`AnalController`)
  - `POST   /api/anal/conversations/{cId}/analysisFlows/{fId}/messages` — 사용자 질문 전송 (Message 저장 + ANALYSIS_CRITERIA Job QUEUED + 비동기 트리거). DATA_STATUS Job 이 SUCCESS 가 아니면 `400 / AN106 DATASOURCE_NOT_READY`.
  - `GET    .../messages/{mId}/analysisCriterias` — 분석 기준 + 플로우 경고 + `needConfirm` 반환. Job 이 SUCCESS 가 아니면 `400 / AN102 CRITERIA_NOT_COMPLETED`.
  - `PUT    .../messages/{mId}/analysisCriterias` — 분석 기준 수정/확정. 이미 확정 상태면 `409 / AN104 CRITERIA_ALREADY_CONFIRMED`.
  - `POST   .../messages/{mId}/analysisCriterias/cancel` — `QUEUED/RUNNING/RETRYING` 만 취소 가능, 그 외 `400 / AN103 CRITERIA_NOT_STARTED`. FastAPI 취소 실패는 swallow.
  - `GET    .../messages/{mId}/analysisCriterias/status` — Job 상태 폴링.
- **Spring → FastAPI 연동**
  - `FastApiClient.resolveAnalysisCriteria(QuestionAnalysisRequest)` 추가.
  - `QuestionAnalysisRequestBuilder` — DataSourceColumn + AnalysisFlowColumn 기반 컬럼 메타 + 빌더 내장 카탈로그(`AnalysisType`/`MetricType` 전체값, `supportedPeriods` 9개, `predefinedMetrics` 2개, `flowWarningKeys` 전체값) 구성. 시맨틱 역할 미매핑 컬럼은 기본값 `DIMENSION` 으로 보냄.
  - `QuestionAnalysisAsyncService` — 기존 `FileAnalysisAsyncService` 와 동일 패턴 (MAX_ATTEMPTS=3, 1s/2s/4s ±30% jitter, 4xx 즉시 FAILED, 5xx·네트워크 3회 재시도, 스키마 불일치 LogueException 즉시 FAILED).
  - `JobStateService` 에 `markCriteriaRunningAndGetContext` + `saveCriteriaAndMarkSuccess` 추가. `unsupported_question` 응답은 `UNSUPPORTED_QUESTION` 사유와 함께 `markFailed`, CANCELED 상태는 저장 skip.
- **DTO**
  - 클라 ↔ Spring DTO 7종 (`CreateQuestion(Request|Response)`, `UpdateQuestionCriteria(Request|Response)`, `GetQuestionCriteriaResponse`, `CancelQuestionCriteriaResponse`, `GetQuestionCriteriaStatusResponse`) — `.claude/dto_reference.md` 매핑.
  - Spring ↔ FastAPI DTO (Request/Response + 하위 record 11종) — `.claude/dto_reference2.md` 매핑. snake_case 변환은 `AppConfig.fastApiRestTemplate` 의 SNAKE_CASE 전략에 위임.

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `cd apps/be && ./gradlew test --tests "com.capstone.logue.anal.service.QuestionCriteriaServiceTest" --tests "com.capstone.logue.anal.service.QuestionAnalysisAsyncServiceTest"` — 18/18 그린
  - `cd apps/be && ./gradlew compileJava compileTestJava` — 그린
  - Swagger 목록에서 확인 (로컬이라 토큰 발급 후 실제 테스트는 진행 못함)
    1. `POST /api/anal/conversations` → `conversationId`
    2. `POST /api/datasources` → `dataSourceId`
    3. `POST /api/anal/conversations/{cId}/analysisFlows` → `analysisFlowId`, SUMMARY SUCCESS 폴링
    4. `POST .../analysisFlows/{fId}/messages` → `messageId`
    5. `GET  .../messages/{mId}/analysisCriterias/status` 폴링 → SUCCESS
    6. `GET  .../messages/{mId}/analysisCriterias` → 분석 기준 + needConfirm
    7. `PUT  .../messages/{mId}/analysisCriterias` `confirmed: true` → `confirmedAt`

## 스크린샷/로그 (선택)
- 없음

## 롤백/리스크
- 리스크 포인트:
  - FastAPI 호출 실패 시 동작은 기존 파일 분석과 동일한 재시도/실패 모델을 따르므로 영향 범위 좁음. 다만 `JobStage.ANALYSIS_CRITERIA` 단계가 신설되면서 `AiTaggingJob` 테이블에 신규 행이 쌓일 수 있음.
  - `JobStateService` 생성자에 의존성 4개(MessageRepo, AnalysisCriteriaRepo, AnalysisFlowColumnRepo, FlowDataWarningRepo)가 늘어남 → Spring 컨테이너 외부에서 직접 생성하는 곳은 없으므로 기존 호출부 영향 없음.
  - `AnalysisFlowColumn` 매핑이 비어 있는 기존 플로우에 대해 분석 기준 도출 시 `semantic_role` 기본값(`DIMENSION`) 으로 FastAPI 에 전달 — FastAPI 가 다시 분류하므로 기능엔 영향 없음.
- 롤백 방법:
  - 본 PR revert 시 데이터 마이그레이션 별도 필요 없음 (스키마 변경 없음).
  - 이미 생성된 `analysis_criteria`/`flow_data_warnings`/`analysis_flow_columns` 행은 그대로 두어도 다른 기능에 영향 없음.

## 관련 이슈
Closes #82

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자 질문으로 분석 기준을 자동 도출하는 기능과 질문 생성/기준 조회/업데이트/취소/상태 조회용 API 추가
  * 비동기 기준 도출 처리(재시도·백오프 포함) 및 진행 상태 모니터링 제공

* **개선 사항**
  * 지원하지 않는 질문 유형 감지 및 안내, 데이터 준비 상태 검증 추가
  * 도출된 기준에 대한 사용자 확인(경고 표시·확정) 흐름 지원

* **테스트**
  * 기준 도출 및 서비스 흐름에 대한 단위/통합 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/26-ewha-capstone-logue/logue/pull/83)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->