### PR TITLE
fix: main 머지 PR CodeRabbit 자동 리뷰 비활성화

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -6,8 +6,12 @@ reviews:
   high_level_summary: true
   high_level_summary_placeholder: "@coderabbitai summary"
   auto_review:
-    enabled: true
+    # CodeRabbit always includes the repository default branch when enabled is true.
+    # Use label opt-in so dev -> main release PRs stay quiet.
+    enabled: false
     drafts: false
+    labels:
+      - "coderabbit-review"
     base_branches:
       - "dev"
       - "hotfix/.*"

--- a/.github/workflows/coderabbit-auto-review.yml
+++ b/.github/workflows/coderabbit-auto-review.yml
@@ -1,0 +1,39 @@
+name: CodeRabbit Auto Review
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - edited
+      - synchronize
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  sync-review-label:
+    name: Sync review label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync CodeRabbit opt-in label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          LABEL: coderabbit-review
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$BASE_REF" == "dev" || "$BASE_REF" == hotfix/* ]]; then
+            gh label create "$LABEL" \
+              --repo "$GITHUB_REPOSITORY" \
+              --color "B2D6D0" \
+              --description "Opt in to CodeRabbit automatic review" \
+              --force
+            gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --add-label "$LABEL"
+          else
+            gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "$LABEL" || true
+          fi


### PR DESCRIPTION
## 요약
- `dev -> main` PR에서 CodeRabbit 자동 리뷰/요약이 동작하지 않도록 라벨 opt-in 방식으로 전환했습니다.

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [x] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - .coderabbit.yaml, .github/workflows/coderabbit-auto-review.yml YAML 파싱 확인
  - git diff --cached --check

## 스크린샷/로그 (선택)
- PR #98, PR #81 등 `dev -> main` PR에 `Summary by CodeRabbit` 자동 생성 내용이 추가된 사례를 확인했습니다.

## 롤백/리스크
- 리스크 포인트: 이 워크플로가 `dev`에 머지된 이후부터 `dev`/`hotfix/*` 대상 PR에 `coderabbit-review` 라벨을 자동 부착하는 방식으로 CodeRabbit 자동 리뷰가 동작합니다.
- 롤백 방법: `.coderabbit.yaml`의 `reviews.auto_review.enabled`를 `true`로 되돌리고 `.github/workflows/coderabbit-auto-review.yml`을 제거합니다.

## 관련 이슈
Closes #99
Refs #76

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * CodeRabbit 자동 리뷰 기능을 비활성화했습니다.
  * PR의 대상 브랜치에 따라 코드 리뷰 라벨을 자동으로 관리하는 워크플로우를 추가했습니다. 개발/핫픽스 브랜치 대상 PR에는 리뷰 라벨이 적용되며, 그 외 브랜치는 라벨이 제거됩니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/26-ewha-capstone-logue/logue/pull/100?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->