### PR TITLE
hotfix: main 머지 PR CodeRabbit 자동 리뷰 비활성화

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -6,8 +6,12 @@ reviews:
   high_level_summary: true
   high_level_summary_placeholder: "@coderabbitai summary"
   auto_review:
-    enabled: true
+    # CodeRabbit uses the base branch configuration for PRs.
+    # Keep automatic reviews label-based so dev -> main release PRs stay quiet.
+    enabled: false
     drafts: false
+    labels:
+      - "coderabbit-review"
     base_branches:
       - "dev"
       - "hotfix/.*"

--- a/.github/workflows/coderabbit-auto-review.yml
+++ b/.github/workflows/coderabbit-auto-review.yml
@@ -1,0 +1,39 @@
+name: CodeRabbit Auto Review
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - edited
+      - synchronize
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  sync-review-label:
+    name: Sync review label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync CodeRabbit opt-in label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          LABEL: coderabbit-review
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$BASE_REF" == "dev" || "$BASE_REF" == hotfix/* ]]; then
+            gh label create "$LABEL" \
+              --repo "$GITHUB_REPOSITORY" \
+              --color "B2D6D0" \
+              --description "Opt in to CodeRabbit automatic review" \
+              --force
+            gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --add-label "$LABEL"
+          else
+            gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "$LABEL" || true
+          fi


### PR DESCRIPTION
## 요약
- `dev -> main` PR에서 CodeRabbit 자동 리뷰/요약이 동작하지 않도록 `main` 브랜치 기준 설정을 먼저 hotfix로 반영합니다.

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [x] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `.coderabbit.yaml`, `.github/workflows/coderabbit-auto-review.yml` YAML 파싱 확인
  - `git diff --check`

## 스크린샷/로그 (선택)
- PR #101에서 CodeRabbit이 `Configuration used: Path: .coderabbit.yaml`로 실행되며, OSS 저장소에서는 PR 안의 설정 변경을 무시하고 base 브랜치 설정만 사용한다는 경고를 확인했습니다.

## 롤백/리스크
- 리스크 포인트: 이 PR이 main에 머지된 뒤부터 CodeRabbit 자동 리뷰는 `coderabbit-review` 라벨 opt-in 방식으로 동작합니다.
- 롤백 방법: `.coderabbit.yaml`의 `reviews.auto_review.enabled`를 `true`로 되돌리고 `.github/workflows/coderabbit-auto-review.yml`을 제거합니다.

## 관련 이슈
Closes #99
Refs #76
Refs #101