### PR TITLE
hotfix: PR 103 CodeRabbit 설정 충돌 해결

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -6,8 +6,8 @@ reviews:
   high_level_summary: true
   high_level_summary_placeholder: "@coderabbitai summary"
   auto_review:
-    # CodeRabbit always includes the repository default branch when enabled is true.
-    # Use label opt-in so dev -> main release PRs stay quiet.
+    # CodeRabbit uses the base branch configuration for PRs.
+    # Keep automatic reviews label-based so dev -> main release PRs stay quiet.
     enabled: false
     drafts: false
     labels:

--- a/.github/workflows/coderabbit-auto-review.yml
+++ b/.github/workflows/coderabbit-auto-review.yml
@@ -11,7 +11,7 @@ on:
 
 permissions:
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   sync-review-label:

--- a/.github/workflows/coderabbit-auto-review.yml
+++ b/.github/workflows/coderabbit-auto-review.yml
@@ -11,7 +11,7 @@ on:
 
 permissions:
   issues: write
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   sync-review-label:
@@ -33,7 +33,14 @@ jobs:
               --color "B2D6D0" \
               --description "Opt in to CodeRabbit automatic review" \
               --force
-            gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --add-label "$LABEL"
+            gh api \
+              --method POST \
+              "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels" \
+              -f "labels[]=$LABEL" \
+              --silent
           else
-            gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "$LABEL" || true
+            gh api \
+              --method DELETE \
+              "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels/$LABEL" \
+              --silent || true
           fi


### PR DESCRIPTION
## 요약
- PR #103의 `.coderabbit.yaml` 충돌을 풀기 위해 `dev`의 CodeRabbit 설정 주석을 `main`과 동일하게 맞췄습니다.
- `dev` 대상 PR에서 `coderabbit-review` 라벨 자동 부착이 실패하지 않도록 GraphQL 기반 `gh pr edit` 대신 REST issue labels API를 사용합니다.

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [x] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `.coderabbit.yaml`, `.github/workflows/coderabbit-auto-review.yml` YAML 파싱 확인
  - `git diff --check`

## 스크린샷/로그 (선택)
- PR #103에서 `.coderabbit.yaml` conflict가 발생했습니다.
- 기존 PR #104는 main 전체 merge diff가 커져 닫고, 이 PR은 필요한 두 파일만 최소 변경으로 다시 올립니다.
- 기존 workflow는 `gh pr edit --add-label`에서 `GraphQL: Resource not accessible by integration`으로 실패했습니다.

## 롤백/리스크
- 리스크 포인트: CodeRabbit 자동 리뷰 라벨 동기화가 PR GraphQL API 대신 issue labels REST API를 사용합니다.
- 롤백 방법: 이 PR의 커밋을 revert합니다.

## 관련 이슈
Refs #103
Refs #99
Refs #76