### PR TITLE
hotfix: main CodeRabbit 라벨 동기화 API 수정

### DIFF
--- a/.github/workflows/coderabbit-auto-review.yml
+++ b/.github/workflows/coderabbit-auto-review.yml
@@ -33,7 +33,14 @@ jobs:
               --color "B2D6D0" \
               --description "Opt in to CodeRabbit automatic review" \
               --force
-            gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --add-label "$LABEL"
+            gh api \
+              --method POST \
+              "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels" \
+              -f "labels[]=$LABEL" \
+              --silent
           else
-            gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "$LABEL" || true
+            gh api \
+              --method DELETE \
+              "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels/$LABEL" \
+              --silent || true
           fi


### PR DESCRIPTION
## 요약
- `main`의 CodeRabbit 라벨 동기화 workflow도 `dev`와 동일하게 REST issue labels API 방식으로 맞췄습니다.
- PR #103의 `.github/workflows/coderabbit-auto-review.yml` 충돌을 해소하기 위한 main hotfix입니다.

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [x] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `.github/workflows/coderabbit-auto-review.yml` YAML 파싱 확인
  - `git diff --check`

## 스크린샷/로그 (선택)
- PR #103에서 `.github/workflows/coderabbit-auto-review.yml` conflict가 발생했습니다.
- 기존 `gh pr edit --add-label` 방식은 `GraphQL: Resource not accessible by integration` 오류가 발생했습니다.

## 롤백/리스크
- 리스크 포인트: CodeRabbit 라벨 동기화가 PR GraphQL API 대신 issue labels REST API를 사용합니다.
- 롤백 방법: 이 PR의 커밋을 revert합니다.

## 관련 이슈
Refs #103
Refs #105
Refs #99
Refs #76