### PR TITLE
hotfix: update fe codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,6 @@
 /Makefile  @gyesswhat
 
 # 앱별 담당자
-/apps/fe/  @yeeeww
+/apps/fe/  @maetelson
 /apps/be/  @jxxxxxn @gyesswhat
 /apps/ai/  @yeeeww @maetelson


### PR DESCRIPTION
## Summary
- Change FE CODEOWNERS reviewer from @yeeeww to @maetelson.

## Verification
- Confirmed the diff only updates .github/CODEOWNERS for /apps/fe/.