### PR TITLE
hotfix: update fe codeowner on dev

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,6 @@
 /Makefile  @gyesswhat
 
 # 앱별 담당자
-/apps/fe/  @yeeeww
+/apps/fe/  @maetelson
 /apps/be/  @jxxxxxn @gyesswhat
 /apps/ai/  @yeeeww @maetelson

--- a/.github/workflows/coderabbit-auto-review.yml
+++ b/.github/workflows/coderabbit-auto-review.yml
@@ -11,7 +11,7 @@ on:
 
 permissions:
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   sync-review-label:
@@ -28,16 +28,15 @@ jobs:
           set -euo pipefail
 
           if [[ "$BASE_REF" == "dev" || "$BASE_REF" == hotfix/* ]]; then
-            gh label create "$LABEL" \
-              --repo "$GITHUB_REPOSITORY" \
-              --color "B2D6D0" \
-              --description "Opt in to CodeRabbit automatic review" \
-              --force
-            gh api \
+            if gh api \
               --method POST \
               "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels" \
               -f "labels[]=$LABEL" \
-              --silent
+              --silent; then
+              echo "Added $LABEL label to PR #$PR_NUMBER."
+            else
+              echo "::warning::Failed to add $LABEL label to PR #$PR_NUMBER. Check workflow token permissions."
+            fi
           else
             gh api \
               --method DELETE \


### PR DESCRIPTION
## 요약
- dev 브랜치의 FE CODEOWNERS 기본 리뷰어를 @maetelson으로 변경하고, CodeRabbit 라벨 동기화 실패가 PR 체크를 막지 않도록 조정했습니다.

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [x] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `git diff --check`
  - `gh pr checks 109`로 기존 실패 원인 확인

## 스크린샷/로그 (선택)
- 실패 로그: `gh: Resource not accessible by integration (HTTP 403)`
- 원인: `pull_request_target` workflow에서 `GITHUB_TOKEN`으로 repository label create/update를 시도하면서 권한 오류 발생

## 롤백/리스크
- 리스크 포인트: GitHub token 권한이 PR 라벨 추가까지 막는 경우 CodeRabbit 라벨 자동 부착은 warning만 남기고 통과합니다.
- 롤백 방법: 이 PR의 CODEOWNERS 및 `coderabbit-auto-review.yml` 변경 커밋을 revert합니다.

## 관련 이슈
없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 코드 소유자 정보를 업데이트했습니다.
  * 자동 리뷰 워크플로우의 권한 설정을 조정하고 라벨 처리 로직을 개선했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/26-ewha-capstone-logue/logue/pull/109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->