### PR TITLE
fix: CodeRabbit dev PR 자동 리뷰 설정 정리

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -7,8 +7,9 @@ reviews:
   high_level_summary_placeholder: "@coderabbitai summary"
   auto_review:
     # CodeRabbit uses the base branch configuration for PRs.
-    # Keep reviews label-based so only dev-base PRs are opted in by workflow.
-    enabled: false
+    # Keep automatic reviews label-gated; workflow applies the label only to dev-base PRs.
+    enabled: true
+    auto_incremental_review: true
     drafts: false
     labels:
       - "coderabbit-review"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -7,14 +7,13 @@ reviews:
   high_level_summary_placeholder: "@coderabbitai summary"
   auto_review:
     # CodeRabbit uses the base branch configuration for PRs.
-    # Keep automatic reviews label-based so dev -> main release PRs stay quiet.
+    # Keep reviews label-based so only dev-base PRs are opted in by workflow.
     enabled: false
     drafts: false
     labels:
       - "coderabbit-review"
     base_branches:
       - "dev"
-      - "hotfix/.*"
   path_instructions:
     - path: "apps/fe/**"
       instructions: |

--- a/.github/workflows/coderabbit-auto-review.yml
+++ b/.github/workflows/coderabbit-auto-review.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
   pull-requests: read
 
 jobs:
@@ -20,17 +21,12 @@ jobs:
     steps:
       - name: Sync CodeRabbit opt-in label
         env:
-          GH_TOKEN: ${{ secrets.CODERABBIT_LABEL_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           LABEL: coderabbit-review
           PR_NUMBER: ${{ github.event.pull_request.number }}
           BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           set -euo pipefail
-
-          if [[ -z "${GH_TOKEN:-}" ]]; then
-            echo "::warning::CODERABBIT_LABEL_TOKEN is not configured; skipping CodeRabbit label sync."
-            exit 0
-          fi
 
           if [[ "$BASE_REF" == "dev" ]]; then
             if gh api \

--- a/.github/workflows/coderabbit-auto-review.yml
+++ b/.github/workflows/coderabbit-auto-review.yml
@@ -10,8 +10,8 @@ on:
       - synchronize
 
 permissions:
-  issues: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
 
 jobs:
   sync-review-label:
@@ -20,14 +20,19 @@ jobs:
     steps:
       - name: Sync CodeRabbit opt-in label
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.CODERABBIT_LABEL_TOKEN }}
           LABEL: coderabbit-review
           PR_NUMBER: ${{ github.event.pull_request.number }}
           BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           set -euo pipefail
 
-          if [[ "$BASE_REF" == "dev" || "$BASE_REF" == hotfix/* ]]; then
+          if [[ -z "${GH_TOKEN:-}" ]]; then
+            echo "::warning::CODERABBIT_LABEL_TOKEN is not configured; skipping CodeRabbit label sync."
+            exit 0
+          fi
+
+          if [[ "$BASE_REF" == "dev" ]]; then
             if gh api \
               --method POST \
               "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels" \


### PR DESCRIPTION
## 요약
- `main`을 default branch로 유지하면서 CodeRabbit 리뷰를 `coderabbit-review` 라벨 기반으로 제한합니다.
- CodeRabbit 자동 리뷰 자체는 켜두고, 라벨이 있는 PR만 리뷰하도록 해서 이후 push에서도 incremental review가 이어지도록 정리합니다.
- 라벨 자동 부착 workflow는 base branch가 정확히 `dev`인 PR에만 동작하도록 제한합니다.
- 기존 실패 원인이던 저장소 라벨 생성/수정 단계를 제거하고, 이미 존재하는 `coderabbit-review` 라벨을 REST issue labels API로만 부착/제거합니다.

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [x] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `.coderabbit.yaml`, `.github/workflows/coderabbit-auto-review.yml` YAML 파싱 확인
  - `git diff --check`
  - `git merge-tree --write-tree origin/main HEAD`로 `dev -> main` 충돌 없음 확인
  - #115에서 `coderabbit-review` 라벨을 나중에 수동 부착했을 때 CodeRabbit 리뷰가 실제로 재시작되고 완료되는지 확인
  - 라벨 부착 후 추가 push에서 `enabled: false` 기반 설정은 최신 커밋이 `Review skipped`가 될 수 있음을 확인하고, `enabled: true` + label gate + `auto_incremental_review: true`로 보정

## 스크린샷/로그 (선택)
- `coderabbit-review` 라벨은 이미 존재함을 확인했습니다.
- CodeRabbit은 라벨이 없으면 먼저 skip할 수 있지만, 라벨이 이후 부착되면 리뷰를 다시 시작하는 것을 #115에서 확인했습니다.

## 롤백/리스크
- 리스크 포인트: 저장소 라벨 자체가 삭제되면 라벨 부착 API가 실패할 수 있습니다.
- 롤백 방법: `.coderabbit.yaml`과 `.github/workflows/coderabbit-auto-review.yml`을 이전 커밋으로 revert합니다.

## 관련 이슈
Refs #99
Refs #76