### PR TITLE
feat: 파일 업로드 피드백 UI 완성

### DIFF
--- a/apps/fe/src/app/(main)/analysis/_components/PromptInput.tsx
+++ b/apps/fe/src/app/(main)/analysis/_components/PromptInput.tsx
@@ -12,6 +12,7 @@ export type PromptInputValue = {
 export type PromptInputProps = {
   /** textarea placeholder */
   placeholder?: string;
+  validateFile?: (file: File) => string | null;
   /** 전송 콜백 */
   onSubmit?: (value: PromptInputValue) => void;
   /** 파일 업로드 에러 콜백 */
@@ -23,6 +24,7 @@ const DEFAULT_PLACEHOLDER =
 
 export default function PromptInput({
   placeholder = DEFAULT_PLACEHOLDER,
+  validateFile,
   onSubmit,
   onError,
 }: PromptInputProps) {
@@ -64,6 +66,7 @@ export default function PromptInput({
 
       <Modal open={isUploadOpen} onClose={() => setIsUploadOpen(false)}>
         <FileUploadZone
+          validateFile={validateFile}
           onFileSelect={handleFileSelect}
           onError={handleFileError}
         />

--- a/apps/fe/src/app/(main)/analysis/_components/PromptInput.tsx
+++ b/apps/fe/src/app/(main)/analysis/_components/PromptInput.tsx
@@ -64,11 +64,16 @@ export default function PromptInput({
         onFileAttach={() => setIsUploadOpen((prev) => !prev)}
       />
 
-      <Modal open={isUploadOpen} onClose={() => setIsUploadOpen(false)}>
+      <Modal
+        open={isUploadOpen}
+        onClose={() => setIsUploadOpen(false)}
+        contentClassName="relative z-10 w-full max-w-[64.8rem] rounded-16 bg-transparent p-0 shadow-none"
+      >
         <FileUploadZone
           validateFile={validateFile}
           onFileSelect={handleFileSelect}
           onError={handleFileError}
+          onClose={() => setIsUploadOpen(false)}
         />
       </Modal>
 

--- a/apps/fe/src/app/(main)/analysis/page.tsx
+++ b/apps/fe/src/app/(main)/analysis/page.tsx
@@ -95,7 +95,7 @@ export default function AnalysisPage() {
       <SampleDataSection />
 
       {toastMessage && (
-        <div className="pointer-events-none fixed bottom-44 left-1/2 z-[60] -translate-x-1/2">
+        <div className="pointer-events-none fixed bottom-[4.4rem] left-1/2 z-[60] -translate-x-1/2">
           <ToastAlert role="alert">{toastMessage}</ToastAlert>
         </div>
       )}

--- a/apps/fe/src/app/(main)/analysis/page.tsx
+++ b/apps/fe/src/app/(main)/analysis/page.tsx
@@ -1,8 +1,11 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { getMyInfo } from '@/apis/user';
+import { ToastAlert } from '@/components';
+import { validateCsvFile } from '@/lib/fileValidation';
 import { useAuthSession } from '@/providers/AuthProvider';
 import GreetingSection from './_components/GreetingSection';
 import PromptInput, { type PromptInputValue } from './_components/PromptInput';
@@ -10,9 +13,16 @@ import SampleDataSection from './_components/SampleDataSection';
 
 const FALLBACK_USER_NAME = '사용자';
 const USER_INFO_STALE_TIME = 5 * 60 * 1000;
+const TOAST_DURATION_MS = 2500;
+
+const ANALYSIS_FILE_MESSAGES = {
+  invalidType: 'Logue는 CSV 형식의 파일만 지원해요',
+  tooLarge: '파일이 너무 커요. 50MB까지만 업로드 가능해요',
+};
 
 export default function AnalysisPage() {
   const router = useRouter();
+  const [toastMessage, setToastMessage] = useState<string | null>(null);
   const { hasAccessToken } = useAuthSession();
   const {
     data: myInfo,
@@ -33,6 +43,15 @@ export default function AnalysisPage() {
     ? (myInfo?.name ?? FALLBACK_USER_NAME)
     : FALLBACK_USER_NAME;
 
+  useEffect(() => {
+    if (!toastMessage) return;
+    const timer = window.setTimeout(
+      () => setToastMessage(null),
+      TOAST_DURATION_MS,
+    );
+    return () => window.clearTimeout(timer);
+  }, [toastMessage]);
+
   const handleSubmit = (value: PromptInputValue) => {
     // TODO: 분석 생성 API 호출 후 응답 id 로 교체
     // e.g. const { id } = await createAnalysis({ prompt: value.prompt, file: value.file });
@@ -45,8 +64,7 @@ export default function AnalysisPage() {
   };
 
   const handlePromptError = (message: string) => {
-    // TODO: Replace alert with toast/snackbar when shared feedback UI is ready.
-    alert(message);
+    setToastMessage(message);
   };
 
   return (
@@ -68,9 +86,19 @@ export default function AnalysisPage() {
         )}
       </div>
 
-      <PromptInput onSubmit={handleSubmit} onError={handlePromptError} />
+      <PromptInput
+        validateFile={(file) => validateCsvFile(file, ANALYSIS_FILE_MESSAGES)}
+        onSubmit={handleSubmit}
+        onError={handlePromptError}
+      />
 
       <SampleDataSection />
+
+      {toastMessage && (
+        <div className="pointer-events-none fixed bottom-44 left-1/2 z-[60] -translate-x-1/2">
+          <ToastAlert role="alert">{toastMessage}</ToastAlert>
+        </div>
+      )}
     </main>
   );
 }

--- a/apps/fe/src/app/(main)/data/page.tsx
+++ b/apps/fe/src/app/(main)/data/page.tsx
@@ -1,15 +1,22 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import ChatIcon from '@/assets/icons/chat.svg';
-import { FileUploadModal, Modal } from '@/components';
+import SuccessIcon from '@/assets/icons/success.svg';
+import { FileUploadModal, Modal, ToastAlert } from '@/components';
+import { formatFileSize, validateCsvFile } from '@/lib/fileValidation';
 import Checkbox from './_components/Checkbox';
 import SortDropdown from './_components/SortDropdown';
 
 const DELETE_ILLUST_SRC = '/illusts/delete.svg';
+const TOAST_DURATION_MS = 2500;
 
 type SortKey = 'usage' | 'latest';
+type ToastState = {
+  message: string;
+  tone: 'error' | 'success';
+};
 
 type DataSource = {
   id: string;
@@ -23,6 +30,11 @@ const SORT_OPTIONS = [
   { value: 'latest', label: '최근 업로드 순' },
 ];
 
+const DATA_FILE_MESSAGES = {
+  invalidType: '파일 형식이 맞지 않습니다.',
+  tooLarge: '파일이 너무 커요. 50MB까지만 업로드 가능해요',
+};
+
 // TODO: API 연동
 const DUMMY_DATA: DataSource[] = Array.from({ length: 8 }, (_, i) => ({
   id: `data-${i}`,
@@ -34,13 +46,24 @@ const DUMMY_DATA: DataSource[] = Array.from({ length: 8 }, (_, i) => ({
 export default function DataPage() {
   const router = useRouter();
   const [sortKey, setSortKey] = useState<SortKey>('latest');
+  const [data, setData] = useState<DataSource[]>(DUMMY_DATA);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [uploadOpen, setUploadOpen] = useState(false);
+  const [toast, setToast] = useState<ToastState | null>(null);
 
   // TODO: 실제 정렬/필터 로직 (현재는 더미)
-  const data = DUMMY_DATA;
   void sortKey;
+
+  useEffect(() => {
+    if (!toast) return;
+    const timer = window.setTimeout(() => setToast(null), TOAST_DURATION_MS);
+    return () => window.clearTimeout(timer);
+  }, [toast]);
+
+  const showToast = (message: string, tone: ToastState['tone']) => {
+    setToast({ message, tone });
+  };
 
   const allSelected =
     data.length > 0 && data.every((d) => selectedIds.has(d.id));
@@ -70,8 +93,17 @@ export default function DataPage() {
 
   const handleUploaded = (uploaded: File) => {
     // TODO: 업로드된 파일을 서버에 보내고 목록 갱신
-    void uploaded;
+    setData((prev) => [
+      {
+        id: `data-${Date.now()}`,
+        fileName: uploaded.name,
+        fileSize: formatFileSize(uploaded.size),
+        uploadedAt: '방금 전',
+      },
+      ...prev,
+    ]);
     setUploadOpen(false);
+    showToast('파일이 업로드 되었습니다.', 'success');
   };
 
   const handleDeleteClick = () => {
@@ -81,8 +113,10 @@ export default function DataPage() {
 
   const handleDeleteConfirm = () => {
     // TODO: 선택된 데이터 삭제 API 호출
+    setData((prev) => prev.filter((row) => !selectedIds.has(row.id)));
     setSelectedIds(new Set());
     setDeleteOpen(false);
+    showToast('파일이 삭제되었습니다', 'success');
   };
 
   const handleChat = (id: string) => {
@@ -199,6 +233,8 @@ export default function DataPage() {
       <FileUploadModal
         open={uploadOpen}
         onClose={() => setUploadOpen(false)}
+        validateFile={(file) => validateCsvFile(file, DATA_FILE_MESSAGES)}
+        onError={(message) => showToast(message, 'error')}
         onUpload={handleUploaded}
       />
 
@@ -238,6 +274,21 @@ export default function DataPage() {
           </div>
         </div>
       </Modal>
+
+      {toast && (
+        <div className="pointer-events-none fixed bottom-44 left-1/2 z-[60] -translate-x-1/2">
+          <ToastAlert
+            role={toast.tone === 'error' ? 'alert' : 'status'}
+            icon={
+              toast.tone === 'success' ? (
+                <SuccessIcon aria-hidden className="icon-24" />
+              ) : undefined
+            }
+          >
+            {toast.message}
+          </ToastAlert>
+        </div>
+      )}
     </main>
   );
 }

--- a/apps/fe/src/app/(main)/data/page.tsx
+++ b/apps/fe/src/app/(main)/data/page.tsx
@@ -276,7 +276,7 @@ export default function DataPage() {
       </Modal>
 
       {toast && (
-        <div className="pointer-events-none fixed bottom-44 left-1/2 z-[60] -translate-x-1/2">
+        <div className="pointer-events-none fixed bottom-[4.4rem] left-1/2 z-[60] -translate-x-1/2">
           <ToastAlert
             role={toast.tone === 'error' ? 'alert' : 'status'}
             icon={

--- a/apps/fe/src/app/(main)/data/page.tsx
+++ b/apps/fe/src/app/(main)/data/page.tsx
@@ -95,7 +95,7 @@ export default function DataPage() {
     // TODO: 업로드된 파일을 서버에 보내고 목록 갱신
     setData((prev) => [
       {
-        id: `data-${Date.now()}`,
+        id: `data-${crypto.randomUUID()}`,
         fileName: uploaded.name,
         fileSize: formatFileSize(uploaded.size),
         uploadedAt: '방금 전',

--- a/apps/fe/src/components/FileUploadModal/FileUploadModal.tsx
+++ b/apps/fe/src/components/FileUploadModal/FileUploadModal.tsx
@@ -1,15 +1,7 @@
 'use client';
 
-import {
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-  type ChangeEvent,
-  type DragEvent,
-} from 'react';
-import CancelIcon from '@/assets/icons/cancel.svg';
-import PlusIcon from '@/assets/icons/plus.svg';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import FileUploadZone from '../FileUploadZone/FileUploadZone';
 import Modal from '../Modal/Modal';
 
 export type FileUploadModalProps = {
@@ -18,36 +10,15 @@ export type FileUploadModalProps = {
   onUpload?: (file: File) => void;
   validateFile?: (file: File) => string | null;
   onError?: (message: string) => void;
-  /** 허용 확장자 (기본 .csv) */
   accept?: string;
 };
 
 type Stage = 'idle' | 'uploading';
 
-// TODO: 실제 업로드 진행률은 API 진척률로 교체. 현재는 시뮬레이션용.
 const SIM_TICK_MS = 200;
 const SIM_INCREMENT = 10;
-
-/** accept 문자열("." prefix, mime type 모두 허용)에 매칭되는지 검사 */
-function matchesAccept(file: File, accept: string): boolean {
-  const tokens = accept
-    .split(',')
-    .map((t) => t.trim().toLowerCase())
-    .filter(Boolean);
-  if (tokens.length === 0) return true;
-
-  const lowerName = file.name.toLowerCase();
-  const lowerType = file.type.toLowerCase();
-
-  return tokens.some((token) => {
-    if (token.startsWith('.')) return lowerName.endsWith(token);
-    if (token.endsWith('/*')) {
-      const prefix = token.slice(0, -1); // "image/"
-      return lowerType.startsWith(prefix);
-    }
-    return lowerType === token;
-  });
-}
+const UPLOAD_MODAL_CONTENT_CLASS_NAME =
+  'relative z-10 w-full max-w-[64.8rem] rounded-16 bg-transparent p-0 shadow-none';
 
 export default function FileUploadModal({
   open,
@@ -60,10 +31,7 @@ export default function FileUploadModal({
   const [stage, setStage] = useState<Stage>('idle');
   const [file, setFile] = useState<File | null>(null);
   const [progress, setProgress] = useState(0);
-  const [isDragOver, setIsDragOver] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
-  const inputRef = useRef<HTMLInputElement>(null);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const clearTimer = useCallback(() => {
@@ -73,7 +41,6 @@ export default function FileUploadModal({
     }
   }, []);
 
-  // unmount 시 타이머 정리 (모달을 업로드 중에 닫는 경우 등)
   useEffect(() => {
     return () => clearTimer();
   }, [clearTimer]);
@@ -83,8 +50,6 @@ export default function FileUploadModal({
     setStage('idle');
     setFile(null);
     setProgress(0);
-    setIsDragOver(false);
-    setError(null);
   }, [clearTimer]);
 
   const handleClose = useCallback(() => {
@@ -94,173 +59,49 @@ export default function FileUploadModal({
 
   const startUpload = useCallback(
     (selected: File) => {
-      const validationError = validateFile?.(selected);
-      if (validationError) {
-        setError(validationError);
-        onError?.(validationError);
-        return;
-      }
-
-      // 런타임 파일 타입 검증 (accept 는 UI 필터일 뿐 우회 가능)
-      if (!matchesAccept(selected, accept)) {
-        const message = `허용되지 않은 파일 형식입니다. (${accept})`;
-        setError(message);
-        onError?.(message);
-        return;
-      }
-
-      setError(null);
       setFile(selected);
       setStage('uploading');
       setProgress(0);
       clearTimer();
+
       let p = 0;
       intervalRef.current = setInterval(() => {
         p += SIM_INCREMENT;
         setProgress(Math.min(p, 100));
+
         if (p >= 100) {
           reset();
           onUpload?.(selected);
         }
       }, SIM_TICK_MS);
     },
-    [accept, clearTimer, onError, onUpload, reset, validateFile],
+    [clearTimer, onUpload, reset],
   );
 
-  const pickFile = () => inputRef.current?.click();
-
-  const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const f = e.target.files?.[0];
-    if (f) startUpload(f);
-    e.target.value = '';
-  };
-
-  const handleDragOver = (e: DragEvent<HTMLDivElement>) => {
-    e.preventDefault();
-    setIsDragOver(true);
-  };
-
-  const handleDragLeave = (e: DragEvent<HTMLDivElement>) => {
-    e.preventDefault();
-    setIsDragOver(false);
-  };
-
-  const handleDrop = (e: DragEvent<HTMLDivElement>) => {
-    e.preventDefault();
-    setIsDragOver(false);
-    const f = e.dataTransfer.files[0];
-    if (f) startUpload(f);
-  };
-
-  const handleCancelFile = () => {
+  const handleCancelFile = useCallback(() => {
     clearTimer();
     setFile(null);
     setProgress(0);
     setStage('idle');
-  };
+  }, [clearTimer]);
 
   return (
-    <Modal open={open} onClose={handleClose}>
-      <div className="flex flex-col gap-20">
-        {/* 헤더 */}
-        <div className="flex items-center justify-between">
-          <h2 className="text-head4 font-semibold text-gray-900">
-            CSV 파일 업로드
-          </h2>
-          <button
-            type="button"
-            onClick={handleClose}
-            aria-label="닫기"
-            className="text-gray-500 transition-colors hover:text-gray-900"
-          >
-            <CancelIcon aria-hidden className="icon-20 text-gray-500" />
-          </button>
-        </div>
-
-        {/* idle: 점선 dropzone / uploading: 파일 카드 */}
-        {stage === 'idle' ? (
-          <div
-            onDragOver={handleDragOver}
-            onDragLeave={handleDragLeave}
-            onDrop={handleDrop}
-            className={`flex flex-col items-center justify-center gap-24 rounded-12 border-2 border-dashed px-40 py-20 transition-colors ${
-              isDragOver
-                ? 'border-orange-500 bg-orange-100/40'
-                : 'border-gray-400 bg-white'
-            }`}
-          >
-            <div className="flex h-40 w-40 items-center justify-center rounded-full bg-gray-300">
-              <PlusIcon aria-hidden className="icon-20 text-gray-700" />
-            </div>
-            <div className="flex flex-col items-center gap-8">
-              <p className="text-body2 text-gray-700">파일 드롭하기</p>
-              <p className="text-body4 text-gray-500">or</p>
-              <button
-                type="button"
-                onClick={pickFile}
-                className="rounded-full bg-orange-500 px-20 py-8 text-body4 font-medium text-white transition-colors hover:bg-orange-600"
-              >
-                파일 업로드
-              </button>
-            </div>
-            <input
-              ref={inputRef}
-              type="file"
-              accept={accept}
-              onChange={handleInputChange}
-              className="hidden"
-              aria-label="파일 업로드"
-            />
-            {error && (
-              <p role="alert" className="text-body4 text-error-500">
-                {error}
-              </p>
-            )}
-          </div>
-        ) : (
-          <div className="flex flex-col gap-12 rounded-12 border border-gray-300 bg-white px-16 py-16">
-            <div className="flex items-center gap-12">
-              <CsvFileIcon />
-              <div className="flex min-w-0 flex-1 flex-col gap-2">
-                <span className="truncate text-body4 text-gray-900">
-                  {file?.name}
-                </span>
-                <span className="text-body4 text-gray-500">
-                  {progress >= 100
-                    ? '업로드 완료'
-                    : `업로드 중... ${progress}%`}
-                </span>
-              </div>
-              <button
-                type="button"
-                onClick={handleCancelFile}
-                aria-label="업로드 취소"
-                className="shrink-0 text-gray-500 transition-colors hover:text-error-500"
-              >
-                <CancelIcon aria-hidden className="icon-16 text-gray-500" />
-              </button>
-            </div>
-            <div className="h-[0.6rem] w-full overflow-hidden rounded-full bg-gray-300">
-              <div
-                className="h-full rounded-full bg-orange-500 transition-[width] duration-200"
-                style={{ width: `${progress}%` }}
-              />
-            </div>
-          </div>
-        )}
-      </div>
-    </Modal>
-  );
-}
-
-/** 파일 카드 좌측의 작은 CSV 아이콘 */
-function CsvFileIcon() {
-  return (
-    <div
-      aria-hidden
-      className="relative flex h-32 w-28 shrink-0 items-center justify-center rounded-4 bg-orange-400"
+    <Modal
+      open={open}
+      onClose={handleClose}
+      contentClassName={UPLOAD_MODAL_CONTENT_CLASS_NAME}
     >
-      <span className="text-[0.9rem] font-bold text-white">CSV</span>
-    </div>
+      <FileUploadZone
+        accept={accept}
+        validateFile={validateFile}
+        onError={onError}
+        onFileSelect={startUpload}
+        state={stage === 'uploading' ? 'upload' : undefined}
+        fileName={file?.name}
+        progress={progress}
+        onClose={handleClose}
+        onRemove={handleCancelFile}
+      />
+    </Modal>
   );
 }

--- a/apps/fe/src/components/FileUploadModal/FileUploadModal.tsx
+++ b/apps/fe/src/components/FileUploadModal/FileUploadModal.tsx
@@ -16,6 +16,8 @@ export type FileUploadModalProps = {
   open: boolean;
   onClose: () => void;
   onUpload?: (file: File) => void;
+  validateFile?: (file: File) => string | null;
+  onError?: (message: string) => void;
   /** 허용 확장자 (기본 .csv) */
   accept?: string;
 };
@@ -51,6 +53,8 @@ export default function FileUploadModal({
   open,
   onClose,
   onUpload,
+  validateFile,
+  onError,
   accept = '.csv',
 }: FileUploadModalProps) {
   const [stage, setStage] = useState<Stage>('idle');
@@ -90,9 +94,18 @@ export default function FileUploadModal({
 
   const startUpload = useCallback(
     (selected: File) => {
+      const validationError = validateFile?.(selected);
+      if (validationError) {
+        setError(validationError);
+        onError?.(validationError);
+        return;
+      }
+
       // 런타임 파일 타입 검증 (accept 는 UI 필터일 뿐 우회 가능)
       if (!matchesAccept(selected, accept)) {
-        setError(`허용되지 않은 파일 형식입니다. (${accept})`);
+        const message = `허용되지 않은 파일 형식입니다. (${accept})`;
+        setError(message);
+        onError?.(message);
         return;
       }
 
@@ -106,12 +119,12 @@ export default function FileUploadModal({
         p += SIM_INCREMENT;
         setProgress(Math.min(p, 100));
         if (p >= 100) {
-          clearTimer();
+          reset();
           onUpload?.(selected);
         }
       }, SIM_TICK_MS);
     },
-    [accept, clearTimer, onUpload],
+    [accept, clearTimer, onError, onUpload, reset, validateFile],
   );
 
   const pickFile = () => inputRef.current?.click();

--- a/apps/fe/src/components/FileUploadZone/FileUploadZone.tsx
+++ b/apps/fe/src/components/FileUploadZone/FileUploadZone.tsx
@@ -30,23 +30,22 @@ const CSV_GRAPHIC_SRC = '/illusts/csv-graphic.svg';
 
 function UploadIcon() {
   return (
-    <span className="inline-flex h-[2.2rem] w-[2.2rem] items-center justify-center rounded-full bg-gray-400 text-white">
-      <svg className="icon-16" viewBox="0 0 24 24" fill="none" aria-hidden>
+    <span className="inline-flex h-[3rem] w-[3rem] items-center justify-center rounded-full bg-gray-400 text-white">
+      <svg className="icon-20" viewBox="0 0 24 24" fill="none" aria-hidden>
         <path
-          d="M12 17V7m0 0L8 11m4-4 4 4"
+          d="M12 5v14M5 12h14"
           stroke="currentColor"
           strokeWidth="2"
           strokeLinecap="round"
-          strokeLinejoin="round"
         />
       </svg>
     </span>
   );
 }
 
-function CloseIcon() {
+function CloseIcon({ className = 'icon-20' }: { className?: string }) {
   return (
-    <svg className="icon-20" viewBox="0 0 24 24" fill="none" aria-hidden>
+    <svg className={className} viewBox="0 0 24 24" fill="none" aria-hidden>
       <path
         d="m6 6 12 12M18 6 6 18"
         stroke="currentColor"
@@ -139,27 +138,27 @@ export default function FileUploadZone({
 
   return (
     <div
-      className={`relative w-full max-w-[64.8rem] overflow-hidden rounded-16 bg-white p-20 ${
+      className={`relative w-full max-w-[64.8rem] overflow-hidden rounded-16 bg-white px-20 pt-16 pb-20 ${
         isUpload ? 'h-[16.7rem]' : 'h-[25.8rem]'
       } ${disabled ? 'opacity-50' : ''} ${className}`.trim()}
       {...rest}
     >
-      <div className="mb-12 flex items-center justify-between">
+      <div className="mb-12 flex items-center">
         <p className="text-head3 text-gray-900 opacity-80">{title}</p>
-        {onClose && (
-          <button
-            type="button"
-            onClick={onClose}
-            className="text-gray-800 hover:text-gray-900"
-            aria-label="닫기"
-          >
-            <CloseIcon />
-          </button>
-        )}
       </div>
+      {onClose && (
+        <button
+          type="button"
+          onClick={onClose}
+          className="absolute top-[1.4rem] right-[1.5rem] flex h-28 w-28 items-center justify-center text-gray-800 hover:text-gray-900"
+          aria-label="닫기"
+        >
+          <CloseIcon />
+        </button>
+      )}
 
       {isUpload ? (
-        <div className="relative h-[9.1rem] rounded-8 border border-gray-400">
+        <div className="relative h-[9.1rem] rounded-8 border-[1.5px] border-gray-400">
           <div className="absolute left-[0.95rem] top-[0.85rem]">
             {uploadIcon ?? (
               // eslint-disable-next-line @next/next/no-img-element
@@ -171,10 +170,10 @@ export default function FileUploadZone({
               />
             )}
           </div>
-          <p className="absolute left-[6.7rem] top-[1.15rem] max-w-[42rem] truncate text-body3 text-gray-900 opacity-80">
+          <p className="absolute left-[6.3rem] top-[1.15rem] max-w-[42rem] truncate text-body3 text-gray-900 opacity-80">
             {fileName}
           </p>
-          <p className="absolute left-[6.8rem] top-[3.25rem] text-body4 text-gray-800 opacity-80">
+          <p className="absolute left-[6.4rem] top-[3.25rem] text-body4 text-gray-800 opacity-80">
             uploading...
           </p>
           <button
@@ -185,7 +184,7 @@ export default function FileUploadZone({
           >
             <CloseIcon />
           </button>
-          <div className="absolute bottom-[1.85rem] left-[1.85rem] h-[0.6rem] w-[54rem] max-w-[calc(100%-6.8rem)] rounded-222 bg-gray-300">
+          <div className="absolute bottom-[1.8rem] left-20 h-[0.6rem] w-[54rem] max-w-[calc(100%-6.8rem)] rounded-222 bg-gray-300">
             <div
               className="h-full rounded-222 bg-orange-500"
               style={{ width: `${Math.max(0, Math.min(progress, 100))}%` }}

--- a/apps/fe/src/components/FileUploadZone/FileUploadZone.tsx
+++ b/apps/fe/src/components/FileUploadZone/FileUploadZone.tsx
@@ -13,6 +13,7 @@ type FileUploadState = 'default' | 'drag' | 'upload';
 
 export type FileUploadZoneProps = {
   accept?: string;
+  validateFile?: (file: File) => string | null;
   onFileSelect?: (file: File) => void;
   onError?: (message: string) => void;
   disabled?: boolean;
@@ -58,6 +59,7 @@ function CloseIcon() {
 
 export default function FileUploadZone({
   accept = '.csv',
+  validateFile,
   onFileSelect,
   onError,
   disabled = false,
@@ -76,6 +78,12 @@ export default function FileUploadZone({
 
   const validateAndEmit = useCallback(
     (file: File) => {
+      const validationError = validateFile?.(file);
+      if (validationError) {
+        onError?.(validationError);
+        return;
+      }
+
       const extensions = accept.split(',').map((s) => s.trim().toLowerCase());
       const lowerFileName = file.name.toLowerCase();
       const valid = extensions.some((ext) => lowerFileName.endsWith(ext));
@@ -85,7 +93,7 @@ export default function FileUploadZone({
       }
       onFileSelect?.(file);
     },
-    [accept, onFileSelect, onError],
+    [accept, onFileSelect, onError, validateFile],
   );
 
   const handleDragOver = useCallback(

--- a/apps/fe/src/components/Modal/Modal.tsx
+++ b/apps/fe/src/components/Modal/Modal.tsx
@@ -13,7 +13,11 @@ export type ModalProps = {
   ariaLabelledBy?: string;
   /** 모달 내부 설명 영역 id */
   ariaDescribedBy?: string;
+  contentClassName?: string;
 };
+
+const DEFAULT_CONTENT_CLASS_NAME =
+  'relative z-10 w-full max-w-[60rem] rounded-20 bg-white p-32 shadow-[0_0.8rem_3.2rem_rgba(0,0,0,0.12)]';
 
 export default function Modal({
   open,
@@ -22,6 +26,7 @@ export default function Modal({
   ariaLabel,
   ariaLabelledBy,
   ariaDescribedBy,
+  contentClassName = DEFAULT_CONTENT_CLASS_NAME,
 }: ModalProps) {
   useEffect(() => {
     if (!open) return;
@@ -79,7 +84,7 @@ export default function Modal({
         aria-label={ariaLabelledBy ? undefined : ariaLabel}
         aria-labelledby={ariaLabelledBy}
         aria-describedby={ariaDescribedBy}
-        className="relative z-10 w-full max-w-[60rem] rounded-20 bg-white p-32 shadow-[0_0.8rem_3.2rem_rgba(0,0,0,0.12)]"
+        className={contentClassName}
         style={{ position: 'relative', zIndex: 10 }}
       >
         {children}

--- a/apps/fe/src/lib/fileValidation.ts
+++ b/apps/fe/src/lib/fileValidation.ts
@@ -1,0 +1,26 @@
+const ONE_MB = 1024 * 1024;
+
+export const CSV_MAX_FILE_SIZE_BYTES = 50 * ONE_MB;
+
+export type CsvValidationMessages = {
+  invalidType: string;
+  tooLarge: string;
+};
+
+export function validateCsvFile(
+  file: Pick<File, 'name' | 'size'>,
+  messages: CsvValidationMessages,
+) {
+  const isCsv = file.name.toLowerCase().endsWith('.csv');
+  if (!isCsv) return messages.invalidType;
+  if (file.size > CSV_MAX_FILE_SIZE_BYTES) return messages.tooLarge;
+  return null;
+}
+
+export function formatFileSize(bytes: number) {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < ONE_MB) return `${(bytes / 1024).toFixed(1)} KB`;
+
+  const mb = bytes / ONE_MB;
+  return `${Number.isInteger(mb) ? mb : mb.toFixed(1)}MB`;
+}

--- a/apps/fe/src/lib/fileValidation.ts
+++ b/apps/fe/src/lib/fileValidation.ts
@@ -13,7 +13,7 @@ export function validateCsvFile(
 ) {
   const isCsv = file.name.toLowerCase().endsWith('.csv');
   if (!isCsv) return messages.invalidType;
-  if (file.size > CSV_MAX_FILE_SIZE_BYTES) return messages.tooLarge;
+  if (file.size >= CSV_MAX_FILE_SIZE_BYTES) return messages.tooLarge;
   return null;
 }
 


### PR DESCRIPTION
## 요약
- 공통 CSV 검증 헬퍼를 추가해 `.csv` 확장자와 50MB 제한을 같은 기준으로 검사합니다.
- 분석 화면 파일 첨부 오류를 `alert()` 대신 Figma 문구의 `ToastAlert`로 표시합니다.
- 데이터 소스 화면 업로드/삭제 더미 상태를 갱신하고 오류/완료/삭제 완료 토스트를 연결합니다.

## 변경 사항
- [x] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `yarn lint`는 로컬 PATH에 `yarn`이 없어 직접 실행 불가
  - `node node_modules/eslint/bin/eslint.js .` 통과
  - `NEXT_PUBLIC_API_URL=http://localhost:8080 node node_modules/next/dist/bin/next build --webpack` 통과
  - Browser smoke: `/analysis` 렌더링, 분석 파일 업로드 모달 열림 확인
  - Browser smoke: `/data` 렌더링, 데이터 업로드 모달 열림, 선택 후 삭제 확인 모달, 삭제 완료 토스트 확인

## 스크린샷/로그 (선택)
- 브라우저 스크린샷 캡처는 로컬 Browser 도구에서 타임아웃되어 DOM smoke check로 대체했습니다.

## 롤백/리스크
- 리스크: 현재 API 연동 전 더미 상태 기반이라 새로고침 시 업로드/삭제 상태는 초기화됩니다.
- 롤백 방법: 이 PR revert.

## 관련 이슈
Closes #125

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * CSV 파일 검증 기능 추가 (파일 형식 및 크기 제한 검사)

* **개선 사항**
  * 알림창 대신 토스트 알림으로 사용자 피드백 개선
  * 파일 업로드 및 삭제 시 화면에 즉시 반영되도록 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/26-ewha-capstone-logue/logue/pull/127?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->