### PR TITLE
fix: 디자인 시스템 공통 컴포넌트 정합성 수정

### DIFF
--- a/apps/fe/src/components/Button/Button.stories.tsx
+++ b/apps/fe/src/components/Button/Button.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { fn } from 'storybook/test';
 
-import Button from './Button';
+import Button, { type ButtonProps } from './Button';
 
 function ChevronRightIcon() {
   return (
@@ -23,6 +23,7 @@ function ChevronRightIcon() {
 }
 
 type StoryOnlyArgs = { storyShowIcon?: boolean };
+type ButtonStoryArgs = ButtonProps & StoryOnlyArgs;
 
 const meta = {
   title: 'Components/Button',
@@ -34,6 +35,16 @@ const meta = {
 
 export default meta;
 type Story = StoryObj<typeof meta>;
+
+const renderButtonWithIcon = (args: Story['args']) => {
+  const { storyShowIcon, ...props } = args as ButtonStoryArgs;
+  return (
+    <Button
+      {...props}
+      icon={storyShowIcon ? <ChevronRightIcon /> : undefined}
+    />
+  );
+};
 
 /* ── 스토리 1: CTA (Controls로 disabled, children, icon 조작) ── */
 
@@ -54,15 +65,7 @@ export const CTA = {
       table: { category: 'Story only' },
     },
   },
-  render: (args) => {
-    const { storyShowIcon, ...props } = args as typeof args & StoryOnlyArgs;
-    return (
-      <Button
-        {...props}
-        icon={storyShowIcon ? <ChevronRightIcon /> : undefined}
-      />
-    );
-  },
+  render: renderButtonWithIcon,
 } as Story;
 
 /* ── 스토리 2: Primary (Controls로 size, disabled, children, icon, fullWidth 조작) ── */
@@ -85,15 +88,7 @@ export const Primary = {
       table: { category: 'Story only' },
     },
   },
-  render: (args) => {
-    const { storyShowIcon, ...props } = args as typeof args & StoryOnlyArgs;
-    return (
-      <Button
-        {...props}
-        icon={storyShowIcon ? <ChevronRightIcon /> : undefined}
-      />
-    );
-  },
+  render: renderButtonWithIcon,
 } as Story;
 
 /* ── Docs 전용: 모든 종류 한눈에 ── */
@@ -116,15 +111,7 @@ export const Outlined = {
       table: { category: 'Story only' },
     },
   },
-  render: (args) => {
-    const { storyShowIcon, ...props } = args as typeof args & StoryOnlyArgs;
-    return (
-      <Button
-        {...props}
-        icon={storyShowIcon ? <ChevronRightIcon /> : undefined}
-      />
-    );
-  },
+  render: renderButtonWithIcon,
 } as Story;
 
 export const Text = {
@@ -133,27 +120,20 @@ export const Text = {
     children: 'Text',
     size: 'md',
     disabled: false,
+    fullWidth: false,
     storyShowIcon: false,
   } as Story['args'],
   argTypes: {
     variant: { table: { disable: true } },
-    size: { table: { disable: true } },
-    fullWidth: { table: { disable: true } },
+    size: { control: 'select', options: ['sm', 'md', 'lg'] },
+    fullWidth: { control: 'boolean' },
     storyShowIcon: {
       control: 'boolean',
       name: 'Icon',
       table: { category: 'Story only' },
     },
   },
-  render: (args) => {
-    const { storyShowIcon, ...props } = args as typeof args & StoryOnlyArgs;
-    return (
-      <Button
-        {...props}
-        icon={storyShowIcon ? <ChevronRightIcon /> : undefined}
-      />
-    );
-  },
+  render: renderButtonWithIcon,
 } as Story;
 
 export const AllVariants: Story = {

--- a/apps/fe/src/components/Button/Button.stories.tsx
+++ b/apps/fe/src/components/Button/Button.stories.tsx
@@ -98,6 +98,64 @@ export const Primary = {
 
 /* ── Docs 전용: 모든 종류 한눈에 ── */
 
+export const Outlined = {
+  args: {
+    variant: 'outlined',
+    children: 'Outlined',
+    size: 'md',
+    disabled: false,
+    fullWidth: false,
+    storyShowIcon: false,
+  } as Story['args'],
+  argTypes: {
+    variant: { table: { disable: true } },
+    size: { control: 'select', options: ['sm', 'md', 'lg'] },
+    storyShowIcon: {
+      control: 'boolean',
+      name: 'Icon',
+      table: { category: 'Story only' },
+    },
+  },
+  render: (args) => {
+    const { storyShowIcon, ...props } = args as typeof args & StoryOnlyArgs;
+    return (
+      <Button
+        {...props}
+        icon={storyShowIcon ? <ChevronRightIcon /> : undefined}
+      />
+    );
+  },
+} as Story;
+
+export const Text = {
+  args: {
+    variant: 'text',
+    children: 'Text',
+    size: 'md',
+    disabled: false,
+    storyShowIcon: false,
+  } as Story['args'],
+  argTypes: {
+    variant: { table: { disable: true } },
+    size: { table: { disable: true } },
+    fullWidth: { table: { disable: true } },
+    storyShowIcon: {
+      control: 'boolean',
+      name: 'Icon',
+      table: { category: 'Story only' },
+    },
+  },
+  render: (args) => {
+    const { storyShowIcon, ...props } = args as typeof args & StoryOnlyArgs;
+    return (
+      <Button
+        {...props}
+        icon={storyShowIcon ? <ChevronRightIcon /> : undefined}
+      />
+    );
+  },
+} as Story;
+
 export const AllVariants: Story = {
   tags: ['!autodocs'],
   parameters: { layout: 'padded' },

--- a/apps/fe/src/components/FileUploadModal/FileUploadModal.stories.tsx
+++ b/apps/fe/src/components/FileUploadModal/FileUploadModal.stories.tsx
@@ -24,7 +24,7 @@ export const Open: Story = {};
 
 export const Interactive: Story = {
   render: (args) => {
-    const [open, setOpen] = useState(true);
+    const [open, setOpen] = useState(false);
 
     return (
       <div className="flex min-h-[48rem] items-center justify-center bg-gray-200 p-40">

--- a/apps/fe/src/components/FileUploadModal/FileUploadModal.stories.tsx
+++ b/apps/fe/src/components/FileUploadModal/FileUploadModal.stories.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { fn } from 'storybook/test';
+
+import FileUploadModal from './FileUploadModal';
+
+const meta = {
+  title: 'Components/FileUploadModal',
+  component: FileUploadModal,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+  args: {
+    open: true,
+    onClose: fn(),
+    onUpload: fn(),
+    onError: fn(),
+  },
+} satisfies Meta<typeof FileUploadModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Open: Story = {};
+
+export const Interactive: Story = {
+  render: (args) => {
+    const [open, setOpen] = useState(true);
+
+    return (
+      <div className="flex min-h-[48rem] items-center justify-center bg-gray-200 p-40">
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="rounded-222 bg-orange-500 px-20 py-12 text-body2 text-white"
+        >
+          Open upload
+        </button>
+        <FileUploadModal
+          {...args}
+          open={open}
+          onClose={() => {
+            setOpen(false);
+            args.onClose?.();
+          }}
+        />
+      </div>
+    );
+  },
+};

--- a/apps/fe/src/components/FileUploadZone/FileUploadZone.tsx
+++ b/apps/fe/src/components/FileUploadZone/FileUploadZone.tsx
@@ -140,7 +140,7 @@ export default function FileUploadZone({
     <div
       className={`relative w-full max-w-[64.8rem] overflow-hidden rounded-16 bg-white px-20 pt-16 pb-20 ${
         isUpload ? 'h-[16.7rem]' : 'h-[25.8rem]'
-      } ${disabled ? 'opacity-50' : ''} ${className}`.trim()}
+      } border-2 border-orange-500 ${disabled ? 'opacity-50' : ''} ${className}`.trim()}
       {...rest}
     >
       <div className="mb-12 flex items-center">

--- a/apps/fe/src/components/FileUploadZone/FileUploadZone.tsx
+++ b/apps/fe/src/components/FileUploadZone/FileUploadZone.tsx
@@ -135,12 +135,18 @@ export default function FileUploadZone({
   const visualState = state ?? (isDragOver ? 'drag' : 'default');
   const isUpload = visualState === 'upload';
   const isDrag = visualState === 'drag';
+  const outerBorderClass = disabled ? 'border-gray-300' : 'border-orange-500';
+  const dropzoneBorderClass = disabled
+    ? 'border-gray-300'
+    : isDrag
+      ? 'border-orange-500 bg-orange-100/30'
+      : 'border-gray-400 hover:border-orange-500';
 
   return (
     <div
       className={`relative w-full max-w-[64.8rem] overflow-hidden rounded-16 bg-white px-20 pt-16 pb-20 ${
         isUpload ? 'h-[16.7rem]' : 'h-[25.8rem]'
-      } border-2 border-orange-500 ${disabled ? 'opacity-50' : ''} ${className}`.trim()}
+      } border-2 ${outerBorderClass} ${disabled ? 'opacity-50' : ''} ${className}`.trim()}
       {...rest}
     >
       <div className="mb-12 flex items-center">
@@ -205,11 +211,9 @@ export default function FileUploadZone({
           onDragOver={handleDragOver}
           onDragLeave={handleDragLeave}
           onDrop={handleDrop}
-          className={`flex h-[18.2rem] cursor-pointer flex-col items-center justify-center rounded-8 border-[1.5px] border-dashed transition-colors ${
-            isDrag
-              ? 'border-orange-500 bg-orange-100/30'
-              : 'border-gray-400 hover:border-orange-500'
-          } ${disabled ? 'cursor-not-allowed' : ''}`}
+          className={`flex h-[18.2rem] cursor-pointer flex-col items-center justify-center rounded-8 border-[1.5px] border-dashed transition-colors ${dropzoneBorderClass} ${
+            disabled ? 'cursor-not-allowed' : ''
+          }`}
         >
           <UploadIcon />
           <p className="mt-8 text-body2 text-gray-900 opacity-70">
@@ -218,7 +222,8 @@ export default function FileUploadZone({
           <p className="text-body4 text-gray-800 opacity-70">or</p>
           <button
             type="button"
-            className="mt-4 rounded-222 bg-orange-500 px-12 py-8 text-body2 text-white"
+            disabled={disabled}
+            className="mt-4 rounded-222 bg-orange-500 px-12 py-8 text-body2 text-white disabled:cursor-not-allowed disabled:bg-gray-400 disabled:text-gray-700"
           >
             파일 업로드
           </button>

--- a/apps/fe/src/components/TextField/TextField.stories.tsx
+++ b/apps/fe/src/components/TextField/TextField.stories.tsx
@@ -90,6 +90,12 @@ export const Interactive: Story = {
 
 /* ── 모든 상태 한눈에 ── */
 
+export const Filled: Story = {
+  args: {
+    defaultValue: '지난달과 이번달 매출을 비교해줘',
+  },
+};
+
 export const AllVariants: Story = {
   tags: ['!autodocs'],
   parameters: { layout: 'padded' },

--- a/apps/fe/src/components/TextField/TextField.tsx
+++ b/apps/fe/src/components/TextField/TextField.tsx
@@ -64,6 +64,13 @@ const TextField = forwardRef<HTMLTextAreaElement, TextFieldProps>(
 
     const handleKeyDown = useCallback(
       (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+        if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'a') {
+          e.preventDefault();
+          e.currentTarget.select();
+          onKeyDown?.(e);
+          return;
+        }
+
         if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
           e.preventDefault();
           if (!submitDisabled) onSubmit?.();
@@ -94,7 +101,7 @@ const TextField = forwardRef<HTMLTextAreaElement, TextFieldProps>(
         className={`inline-flex cursor-text bg-white shadow-[0_0.2rem_1.2rem_rgba(0,0,0,0.06)] ${
           isCompact
             ? 'min-w-[41.8rem] flex-row items-center rounded-16 px-24 py-12'
-            : 'min-w-[29rem] flex-col items-start gap-[5.9rem] rounded-20 px-[2.6rem] py-[2.9rem]'
+            : 'w-[115.5rem] max-w-full flex-col items-start gap-[5.9rem] rounded-20 px-[2.6rem] py-[2.9rem]'
         } ${fullWidth ? 'w-full' : ''} ${className}`.trim()}
       >
         <textarea
@@ -112,7 +119,7 @@ const TextField = forwardRef<HTMLTextAreaElement, TextFieldProps>(
             onBlur?.(e);
           }}
           onKeyDown={handleKeyDown}
-          className={`scrollbar-hide min-w-0 flex-1 resize-none bg-transparent outline-none ${
+          className={`scrollbar-hide min-w-0 w-full flex-1 resize-none bg-transparent outline-none ${
             isCompact ? 'text-body2' : 'text-head3'
           } ${toneClass}`}
           {...textareaProps}

--- a/apps/fe/src/components/TextField/TextField.tsx
+++ b/apps/fe/src/components/TextField/TextField.tsx
@@ -80,6 +80,13 @@ const TextField = forwardRef<HTMLTextAreaElement, TextFieldProps>(
         ? 'text-gray-800'
         : 'text-gray-700 placeholder:text-gray-700';
     const isCompact = size === 'md';
+    const submitToneClass = isCompact
+      ? 'bg-orange-500 text-white hover:bg-orange-600'
+      : hasValue
+        ? 'bg-orange-400 text-white hover:bg-orange-500'
+        : focused
+          ? 'bg-orange-500 text-white hover:bg-orange-600'
+          : 'bg-gray-300 text-gray-900 hover:bg-gray-400';
 
     return (
       <div
@@ -146,7 +153,7 @@ const TextField = forwardRef<HTMLTextAreaElement, TextFieldProps>(
             onClick={onSubmit}
             disabled={submitDisabled}
             aria-label="전송"
-            className="inline-flex h-[3.8rem] w-[3.8rem] shrink-0 items-center justify-center rounded-12 bg-orange-500 text-white transition-colors hover:bg-orange-600 disabled:cursor-not-allowed disabled:bg-gray-400 disabled:text-gray-600"
+            className={`inline-flex h-[3.8rem] w-[3.8rem] shrink-0 items-center justify-center rounded-12 transition-colors disabled:cursor-not-allowed disabled:bg-gray-400 disabled:text-gray-600 ${submitToneClass}`}
           >
             <ArrowUpIcon aria-hidden className="icon-20" />
           </button>

--- a/apps/fe/src/components/TextField/TextField.tsx
+++ b/apps/fe/src/components/TextField/TextField.tsx
@@ -70,11 +70,7 @@ const TextField = forwardRef<HTMLTextAreaElement, TextFieldProps>(
 
     const handleContainerClick = useCallback(
       (e: MouseEvent<HTMLDivElement>) => {
-        if (
-          e.target === e.currentTarget ||
-          (e.target as HTMLElement).closest('[data-toolbar]')
-        )
-          return;
+        if ((e.target as HTMLElement).closest('[data-toolbar]')) return;
         innerRef.current?.focus();
       },
       [],

--- a/apps/fe/src/components/TextField/TextField.tsx
+++ b/apps/fe/src/components/TextField/TextField.tsx
@@ -4,6 +4,8 @@ import {
   useImperativeHandle,
   useRef,
   useState,
+  type ChangeEvent,
+  type KeyboardEvent,
   type MouseEvent,
   type ReactNode,
   type TextareaHTMLAttributes,
@@ -23,6 +25,17 @@ export type TextFieldProps = {
   size?: TextFieldSize;
 } & Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'children'>;
 
+function getSubmitToneClass(
+  isCompact: boolean,
+  hasValue: boolean,
+  focused: boolean,
+) {
+  if (isCompact) return 'bg-orange-500 text-white hover:bg-orange-600';
+  if (hasValue) return 'bg-orange-400 text-white hover:bg-orange-500';
+  if (focused) return 'bg-orange-500 text-white hover:bg-orange-600';
+  return 'bg-gray-300 text-gray-900 hover:bg-gray-400';
+}
+
 const TextField = forwardRef<HTMLTextAreaElement, TextFieldProps>(
   function TextField(
     {
@@ -39,6 +52,7 @@ const TextField = forwardRef<HTMLTextAreaElement, TextFieldProps>(
       onKeyDown,
       onFocus,
       onBlur,
+      onChange,
       value,
       defaultValue,
       ...textareaProps
@@ -47,6 +61,10 @@ const TextField = forwardRef<HTMLTextAreaElement, TextFieldProps>(
   ) {
     const innerRef = useRef<HTMLTextAreaElement>(null);
     const [focused, setFocused] = useState(false);
+    const [internalHasValue, setInternalHasValue] = useState(
+      () => String(defaultValue ?? '').length > 0,
+    );
+    const isControlled = value !== undefined;
 
     useImperativeHandle(ref, () => innerRef.current as HTMLTextAreaElement, []);
 
@@ -63,7 +81,7 @@ const TextField = forwardRef<HTMLTextAreaElement, TextFieldProps>(
     );
 
     const handleKeyDown = useCallback(
-      (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      (e: KeyboardEvent<HTMLTextAreaElement>) => {
         if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'a') {
           e.preventDefault();
           e.currentTarget.select();
@@ -80,20 +98,24 @@ const TextField = forwardRef<HTMLTextAreaElement, TextFieldProps>(
       [onKeyDown, onSubmit, submitDisabled],
     );
 
-    const hasValue = String(value ?? defaultValue ?? '').length > 0;
+    const handleChange = useCallback(
+      (e: ChangeEvent<HTMLTextAreaElement>) => {
+        if (!isControlled) {
+          setInternalHasValue(e.currentTarget.value.length > 0);
+        }
+        onChange?.(e);
+      },
+      [isControlled, onChange],
+    );
+
+    const hasValue = isControlled ? String(value).length > 0 : internalHasValue;
     const toneClass = hasValue
       ? 'text-gray-900'
       : focused
         ? 'text-gray-800'
         : 'text-gray-700 placeholder:text-gray-700';
     const isCompact = size === 'md';
-    const submitToneClass = isCompact
-      ? 'bg-orange-500 text-white hover:bg-orange-600'
-      : hasValue
-        ? 'bg-orange-400 text-white hover:bg-orange-500'
-        : focused
-          ? 'bg-orange-500 text-white hover:bg-orange-600'
-          : 'bg-gray-300 text-gray-900 hover:bg-gray-400';
+    const submitToneClass = getSubmitToneClass(isCompact, hasValue, focused);
 
     return (
       <div
@@ -119,6 +141,7 @@ const TextField = forwardRef<HTMLTextAreaElement, TextFieldProps>(
             onBlur?.(e);
           }}
           onKeyDown={handleKeyDown}
+          onChange={handleChange}
           className={`scrollbar-hide min-w-0 w-full flex-1 resize-none bg-transparent outline-none ${
             isCompact ? 'text-body2' : 'text-head3'
           } ${toneClass}`}

--- a/apps/fe/src/styles/globals.css
+++ b/apps/fe/src/styles/globals.css
@@ -68,7 +68,7 @@
   --color-typo-tertiary: var(--color-gray-700);
   --color-typo-quaternary: var(--color-gray-600);
   --color-typo-error: var(--color-red-500);
-  --color-typo-disabled: var(--color-gray-300);
+  --color-typo-disabled: var(--color-gray-500);
   --color-typo-white: var(--color-white);
   --color-border-primary: var(--color-gray-800);
   --color-border-secondary: var(--color-gray-300);

--- a/apps/fe/src/styles/globals.css
+++ b/apps/fe/src/styles/globals.css
@@ -68,17 +68,17 @@
   --color-typo-tertiary: var(--color-gray-700);
   --color-typo-quaternary: var(--color-gray-600);
   --color-typo-error: var(--color-red-500);
-  --color-typo-disabled: var(--color-gray-500);
+  --color-typo-disabled: var(--color-gray-300);
   --color-typo-white: var(--color-white);
-  --color-border-primary: var(--color-gray-300);
-  --color-border-secondary: var(--color-gray-400);
+  --color-border-primary: var(--color-gray-800);
+  --color-border-secondary: var(--color-gray-300);
   --color-border-tertiary: var(--color-gray-500);
   --color-border-error: var(--color-red-500);
-  --color-divider-primary: var(--color-gray-400);
-  --color-background-secondary: var(--color-gray-200);
-  --color-background-tertiary: var(--color-gray-300);
-  --color-background-quaternary: var(--color-gray-400);
-  --color-background-quinary: var(--color-gray-500);
+  --color-divider-primary: var(--color-gray-300);
+  --color-background-secondary: var(--color-gray-300);
+  --color-background-tertiary: var(--color-gray-400);
+  --color-background-quaternary: var(--color-gray-900);
+  --color-background-quinary: var(--color-gray-200);
   --color-background-error: var(--color-red-500);
   --color-background-white: var(--color-white);
 


### PR DESCRIPTION
## 요약
- Figma design system 기준으로 FE semantic color token alias를 정렬했습니다.
- TextField, FileUploadZone의 상태별 color/radius/border 정합성을 보정했습니다.
- Button, TextField, FileUploadModal Storybook 상태를 보강했습니다.

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `node node_modules/eslint/bin/eslint.js .`
  - `node node_modules/storybook/dist/bin/dispatcher.js build`
  - `NEXT_PUBLIC_API_URL=http://localhost:8080 node node_modules/next/dist/bin/next build --webpack`
  - Playwright smoke: Button Outlined/Text, TextField Filled, FileUploadZone Default, FileUploadModal Open Storybook story 렌더 확인

## 스크린샷/로그 (선택)
- Storybook build 및 Playwright smoke 통과

## 롤백/리스크
- 리스크: semantic token alias 변경은 해당 토큰을 새로 사용하는 UI에 영향을 줄 수 있습니다. 현재 repo 내 직접 사용처는 globals 정의뿐입니다.
- 롤백 방법: 이 PR 커밋을 revert하면 이전 token/component 상태로 복구됩니다.

## 관련 이슈
Closes #128

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 텍스트 입력 필드에서 Ctrl/Cmd + A 키보드 단축키 지원 추가

* **개선 사항**
  * 전송 버튼의 동적 스타일링 (입력 상태, 크기, 포커스에 따라 변경)
  * 파일 업로드 영역의 시각적 강조 표시 개선
  * 텍스트 입력 필드의 레이아웃 및 가독성 개선
  * 전체 색상 테마 값 조정 및 시각적 계층 구조 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/26-ewha-capstone-logue/logue/pull/129?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->