### PR TITLE
feat: 데이터 소스 API 연동

### DIFF
--- a/apps/fe/src/apis/datasource.ts
+++ b/apps/fe/src/apis/datasource.ts
@@ -44,6 +44,10 @@ function serializeDataSourceIds(dataSourceIds: number[]) {
   return `id=${dataSourceIds.join(',')}`;
 }
 
+function getDeleteDataSourcesPath(dataSourceIds: number[]) {
+  return `/api/datasources?${serializeDataSourceIds(dataSourceIds)}`;
+}
+
 export const dataSourceKeys = {
   all: ['dataSources'] as const,
   lists: () => [...dataSourceKeys.all, 'list'] as const,
@@ -79,13 +83,7 @@ export async function deleteDataSources(dataSourceIds: number[]) {
   if (dataSourceIds.length === 0) return;
 
   const { data } = await instance.delete<ApiResponse<unknown>>(
-    '/api/datasources',
-    {
-      params: {
-        id: dataSourceIds,
-      },
-      paramsSerializer: () => serializeDataSourceIds(dataSourceIds),
-    },
+    getDeleteDataSourcesPath(dataSourceIds),
   );
 
   unwrapApiResponse(data);

--- a/apps/fe/src/apis/datasource.ts
+++ b/apps/fe/src/apis/datasource.ts
@@ -40,6 +40,10 @@ export type UploadFileResponse = {
   dataSourceId: number;
 };
 
+function serializeDataSourceIds(dataSourceIds: number[]) {
+  return `id=${dataSourceIds.join(',')}`;
+}
+
 export const dataSourceKeys = {
   all: ['dataSources'] as const,
   lists: () => [...dataSourceKeys.all, 'list'] as const,
@@ -78,8 +82,9 @@ export async function deleteDataSources(dataSourceIds: number[]) {
     '/api/datasources',
     {
       params: {
-        id: dataSourceIds.join(','),
+        id: dataSourceIds,
       },
+      paramsSerializer: () => serializeDataSourceIds(dataSourceIds),
     },
   );
 

--- a/apps/fe/src/apis/datasource.ts
+++ b/apps/fe/src/apis/datasource.ts
@@ -1,0 +1,103 @@
+import instance from '@/lib/axios';
+import { unwrapApiResponse, type ApiResponse } from './types';
+
+export type DataSourceSort = 'LATEST' | 'MOST_USED';
+
+export type DataSourceSummary = {
+  dataSourceId: number;
+  fileName: string;
+  fileSize: number;
+  uploadedAt: string;
+};
+
+export type GetDataSourceListParams = {
+  sort: DataSourceSort;
+  page: number;
+  size: number;
+};
+
+export type GetDataSourceListResponse = {
+  sort: DataSourceSort;
+  page: number;
+  size: number;
+  totalPages: number;
+  dataSources: DataSourceSummary[];
+};
+
+export type FilePreview = {
+  headers: string[];
+  rows: string[][];
+};
+
+export type GetFileResponse = {
+  fileName: string;
+  fileSize: number;
+  uploadedAt: string;
+  preview: FilePreview | null;
+};
+
+export type UploadFileResponse = {
+  dataSourceId: number;
+};
+
+export const dataSourceKeys = {
+  all: ['dataSources'] as const,
+  lists: () => [...dataSourceKeys.all, 'list'] as const,
+  list: (params: GetDataSourceListParams) =>
+    [...dataSourceKeys.lists(), params] as const,
+  details: () => [...dataSourceKeys.all, 'detail'] as const,
+  detail: (dataSourceId: number) =>
+    [...dataSourceKeys.details(), dataSourceId] as const,
+};
+
+export async function getDataSources(params: GetDataSourceListParams) {
+  const { data } = await instance.get<ApiResponse<GetDataSourceListResponse>>(
+    '/api/datasources',
+    { params },
+  );
+
+  return unwrapApiResponse(data);
+}
+
+export async function uploadDataSource(file: File) {
+  const formData = new FormData();
+  formData.append('file', file);
+
+  const { data } = await instance.post<ApiResponse<UploadFileResponse>>(
+    '/api/datasources',
+    formData,
+  );
+
+  return unwrapApiResponse(data);
+}
+
+export async function deleteDataSources(dataSourceIds: number[]) {
+  if (dataSourceIds.length === 0) return;
+
+  const { data } = await instance.delete<ApiResponse<unknown>>(
+    '/api/datasources',
+    {
+      params: {
+        id: dataSourceIds.join(','),
+      },
+    },
+  );
+
+  unwrapApiResponse(data);
+}
+
+export async function getDataSource(dataSourceId: number) {
+  const { data } = await instance.get<ApiResponse<GetFileResponse>>(
+    `/api/datasources/${dataSourceId}`,
+  );
+
+  return unwrapApiResponse(data);
+}
+
+export async function deleteDataSource(dataSourceId: number) {
+  const { data } = await instance.delete<ApiResponse<unknown>>(
+    `/api/datasources/${dataSourceId}`,
+  );
+
+  unwrapApiResponse(data);
+}

--- a/apps/fe/src/app/(main)/data/[id]/page.tsx
+++ b/apps/fe/src/app/(main)/data/[id]/page.tsx
@@ -1,28 +1,39 @@
 'use client';
 
-import { use, useState } from 'react';
+import { use, useEffect, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
-import { Modal } from '@/components';
+import {
+  dataSourceKeys,
+  deleteDataSource,
+  getDataSource,
+} from '@/apis/datasource';
+import { Modal, ToastAlert } from '@/components';
+import { formatDateTime } from '@/lib/dateTime';
+import { formatFileSize } from '@/lib/fileValidation';
+import { useAuthSession } from '@/providers/AuthProvider';
 import DataChartCard from '../_components/DataChartCard';
 
 type PageParams = { id: string };
 
 const DELETE_ILLUST_SRC = '/illusts/delete.svg';
+const TOAST_DURATION_MS = 2500;
 
-// TODO: API 연동 — 현재는 시안 더미
-type DataSourceDetail = {
-  fileName: string;
-  fileSize: string;
-  uploadedAt: string;
-};
+function DataDetailStatus({ message }: { message: string }) {
+  const router = useRouter();
 
-function getDummyDetail(id: string): DataSourceDetail {
-  void id;
-  return {
-    fileName: '파일명어쩌고저쩌고파일명파일명파일명파.csv',
-    fileSize: '37MB',
-    uploadedAt: '3분 전',
-  };
+  return (
+    <main className="scrollbar-hide flex min-h-0 flex-1 flex-col items-center justify-center overflow-y-auto px-40 pt-32 pb-40">
+      <p className="mb-16 text-body3 text-gray-700">{message}</p>
+      <button
+        type="button"
+        onClick={() => router.push('/data')}
+        className="rounded-full bg-orange-500 px-16 py-8 text-body4 font-medium text-white transition-colors hover:bg-orange-600"
+      >
+        목록으로 돌아가기
+      </button>
+    </main>
+  );
 }
 
 export default function DataDetailPage({
@@ -32,32 +43,90 @@ export default function DataDetailPage({
 }) {
   const { id } = use(params);
   const router = useRouter();
+  const queryClient = useQueryClient();
+  const { hasAccessToken } = useAuthSession();
   const [deleteOpen, setDeleteOpen] = useState(false);
+  const [toastMessage, setToastMessage] = useState<string | null>(null);
 
-  const detail = getDummyDetail(id);
+  const dataSourceId = Number(id);
+  const isValidDataSourceId =
+    Number.isSafeInteger(dataSourceId) && dataSourceId > 0;
+
+  const {
+    data: detail,
+    isError,
+    isLoading,
+  } = useQuery({
+    queryKey: dataSourceKeys.detail(dataSourceId),
+    queryFn: () => getDataSource(dataSourceId),
+    enabled: hasAccessToken && isValidDataSourceId,
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteDataSource(dataSourceId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: dataSourceKeys.lists(),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: dataSourceKeys.detail(dataSourceId),
+      });
+    },
+  });
 
   const handleChat = () => {
-    // TODO: 해당 데이터 ID로 분석 채팅 시작
     router.push(`/analysis/${id}`);
   };
 
-  const handleDeleteConfirm = () => {
-    // TODO: 삭제 API 호출
-    setDeleteOpen(false);
-    router.push('/data');
+  const handleDeleteConfirm = async () => {
+    try {
+      await deleteMutation.mutateAsync();
+      setDeleteOpen(false);
+      router.push('/data');
+    } catch {
+      setDeleteOpen(false);
+      setToastMessage('파일 삭제에 실패했습니다.');
+    }
   };
+
+  useEffect(() => {
+    if (!toastMessage) return;
+    const timer = window.setTimeout(
+      () => setToastMessage(null),
+      TOAST_DURATION_MS,
+    );
+    return () => window.clearTimeout(timer);
+  }, [toastMessage]);
+
+  if (!isValidDataSourceId) {
+    return <DataDetailStatus message="올바르지 않은 데이터 소스입니다." />;
+  }
+
+  if (!hasAccessToken) {
+    return (
+      <DataDetailStatus message="로그인 후 데이터 소스를 확인할 수 있습니다." />
+    );
+  }
+
+  if (isLoading) {
+    return <DataDetailStatus message="데이터 소스를 불러오는 중입니다." />;
+  }
+
+  if (isError || !detail) {
+    return <DataDetailStatus message="데이터 소스를 불러오지 못했습니다." />;
+  }
 
   return (
     <main className="scrollbar-hide flex min-h-0 flex-1 flex-col overflow-y-auto px-40 pt-32 pb-40">
       <DataChartCard
         fileName={detail.fileName}
-        fileSize={detail.fileSize}
-        uploadedAt={detail.uploadedAt}
+        fileSize={formatFileSize(detail.fileSize)}
+        uploadedAt={formatDateTime(detail.uploadedAt)}
+        preview={detail.preview}
         onChat={handleChat}
         onDelete={() => setDeleteOpen(true)}
       />
 
-      {/* 삭제 확인 모달 */}
       <Modal open={deleteOpen} onClose={() => setDeleteOpen(false)}>
         <div className="flex flex-col items-center gap-24">
           {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -72,27 +141,35 @@ export default function DataDetailPage({
               파일을 삭제하시겠어요?
             </h3>
             <p className="text-body4 text-gray-700">
-              삭제 후엔 복구할 수 없어요.
+              삭제 후에는 복구할 수 없어요.
             </p>
           </div>
           <div className="flex w-full justify-center gap-8">
             <button
               type="button"
               onClick={() => setDeleteOpen(false)}
-              className="min-w-[12rem] rounded-full bg-gray-300 px-20 py-12 text-body2 font-medium text-gray-700 transition-colors hover:bg-gray-400"
+              disabled={deleteMutation.isPending}
+              className="min-w-[12rem] rounded-full bg-gray-300 px-20 py-12 text-body2 font-medium text-gray-700 transition-colors hover:bg-gray-400 disabled:cursor-not-allowed disabled:opacity-60"
             >
               취소하기
             </button>
             <button
               type="button"
               onClick={handleDeleteConfirm}
-              className="min-w-[12rem] rounded-full bg-orange-500 px-20 py-12 text-body2 font-medium text-white transition-colors hover:bg-orange-600"
+              disabled={deleteMutation.isPending}
+              className="min-w-[12rem] rounded-full bg-orange-500 px-20 py-12 text-body2 font-medium text-white transition-colors hover:bg-orange-600 disabled:cursor-not-allowed disabled:bg-gray-400"
             >
-              삭제하기
+              {deleteMutation.isPending ? '삭제 중' : '삭제하기'}
             </button>
           </div>
         </div>
       </Modal>
+
+      {toastMessage && (
+        <div className="pointer-events-none fixed bottom-[4.4rem] left-1/2 z-[60] -translate-x-1/2">
+          <ToastAlert role="alert">{toastMessage}</ToastAlert>
+        </div>
+      )}
     </main>
   );
 }

--- a/apps/fe/src/app/(main)/data/_components/DataChartCard.tsx
+++ b/apps/fe/src/app/(main)/data/_components/DataChartCard.tsx
@@ -120,7 +120,7 @@ export default function DataChartCard({
             aria-label="삭제"
             className="text-gray-500 transition-colors hover:text-error-500"
           >
-            <TrashIcon aria-hidden className="icon-16 text-gray-500" />
+            <TrashIcon aria-hidden className="icon-16" />
           </button>
         </div>
       </div>

--- a/apps/fe/src/app/(main)/data/_components/DataChartCard.tsx
+++ b/apps/fe/src/app/(main)/data/_components/DataChartCard.tsx
@@ -1,92 +1,78 @@
 'use client';
 
-import {
-  Bar,
-  BarChart,
-  CartesianGrid,
-  Cell,
-  LabelList,
-  ResponsiveContainer,
-  XAxis,
-  YAxis,
-} from 'recharts';
+import type { FilePreview } from '@/apis/datasource';
 import ChatIcon from '@/assets/icons/chat.svg';
 import TrashIcon from '@/assets/icons/trash.svg';
-
-export type DataChartPoint = { name: string; value: number };
 
 export type DataChartCardProps = {
   fileName: string;
   fileSize: string;
   uploadedAt: string;
-  data?: DataChartPoint[];
+  preview?: FilePreview | null;
   onChat?: () => void;
   onDelete?: () => void;
 };
 
-// TODO: 실제 검증 데이터로 교체. 현재는 시안 더미.
-const DEFAULT_DATA: DataChartPoint[] = [
-  { name: '이름1', value: 120 },
-  { name: '이름2', value: 200 },
-  { name: '이름3', value: 150 },
-  { name: '이름4', value: 80 },
-  { name: '이름5', value: 70 },
-  { name: '이름6', value: 110 },
-  { name: '이름7', value: 130 },
-  { name: '이름8', value: 100 },
-  { name: '이름9', value: 125 },
-  { name: '이름10', value: 230 },
-];
+function DataPreviewTable({ preview }: { preview?: FilePreview | null }) {
+  const headers = preview?.headers ?? [];
+  const rows = preview?.rows ?? [];
 
-const BAR_COLORS = [
-  'var(--color-orange-100)',
-  'var(--color-orange-300)',
-  'var(--color-orange-200)',
-  'var(--color-orange-400)',
-  'var(--color-orange-200)',
-  'var(--color-orange-400)',
-  'var(--color-orange-600)',
-  'var(--color-orange-400)',
-  'var(--color-orange-700)',
-  'var(--color-orange-300)',
-];
+  if (headers.length === 0) {
+    return (
+      <div className="flex min-h-[28rem] flex-1 items-center justify-center rounded-8 border border-gray-300 bg-white text-body3 text-gray-600">
+        미리보기 데이터가 없습니다.
+      </div>
+    );
+  }
 
-// 풍선 라벨 시안: 3rem × 4.3571rem (1rem = 10px → 30 × 43.571px)
-const BALLOON_W = 30;
-const BALLOON_H = 43.571;
-const BALLOON_GAP = 6;
-
-type BalloonLabelProps = {
-  x?: number;
-  y?: number;
-  width?: number;
-  value?: number | string;
-};
-
-function BalloonLabel({ x = 0, y = 0, width = 0, value }: BalloonLabelProps) {
-  const cx = x + width / 2;
-  const top = y - BALLOON_H - BALLOON_GAP;
-  const headR = BALLOON_W / 2;
-  const headCy = top + headR;
-  const tailTipY = top + BALLOON_H;
   return (
-    <g>
-      <circle cx={cx} cy={headCy} r={headR} fill="var(--color-orange-500)" />
-      <path
-        d={`M ${cx - 5} ${headCy + headR - 2} L ${cx} ${tailTipY} L ${cx + 5} ${headCy + headR - 2} Z`}
-        fill="var(--color-orange-500)"
-      />
-      <text
-        x={cx}
-        y={headCy + 4}
-        textAnchor="middle"
-        fill="#FFFFFF"
-        fontSize="12"
-        fontWeight="600"
-      >
-        {value}
-      </text>
-    </g>
+    <div className="min-h-0 flex-1 overflow-hidden rounded-8 border border-gray-300 bg-white">
+      <div className="border-b border-gray-200 bg-gray-100 px-16 py-12">
+        <p className="text-body3 font-semibold text-gray-900">CSV 미리보기</p>
+      </div>
+      <div className="max-h-[42rem] overflow-auto">
+        <table className="min-w-full border-collapse text-body4">
+          <thead>
+            <tr className="bg-white text-gray-900">
+              {headers.map((header) => (
+                <th
+                  key={header}
+                  className="whitespace-nowrap border-b border-gray-200 px-16 py-12 text-left font-semibold"
+                >
+                  {header}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={headers.length}
+                  className="px-16 py-32 text-center text-gray-600"
+                >
+                  표시할 행이 없습니다.
+                </td>
+              </tr>
+            ) : (
+              rows.map((row, rowIndex) => (
+                <tr key={rowIndex} className="border-b border-gray-100">
+                  {headers.map((header, columnIndex) => (
+                    <td
+                      key={`${rowIndex}-${header}`}
+                      className="max-w-[24rem] truncate whitespace-nowrap px-16 py-12 text-gray-800"
+                      title={row[columnIndex] ?? '-'}
+                    >
+                      {row[columnIndex] || '-'}
+                    </td>
+                  ))}
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
   );
 }
 
@@ -94,13 +80,12 @@ export default function DataChartCard({
   fileName,
   fileSize,
   uploadedAt,
-  data = DEFAULT_DATA,
+  preview,
   onChat,
   onDelete,
 }: DataChartCardProps) {
   return (
     <div className="mx-auto flex min-h-[50rem] w-full max-w-[130rem] flex-1 flex-col gap-16 rounded-12 border border-gray-300 p-24">
-      {/* 헤더: 파일 정보 + 액션 버튼 */}
       <div className="flex items-start justify-between gap-16">
         <div className="flex min-w-0 flex-1 flex-col gap-4">
           <p className="truncate text-body3 font-semibold text-gray-900">
@@ -136,37 +121,7 @@ export default function DataChartCard({
         </div>
       </div>
 
-      {/* 차트 */}
-      <div className="min-h-0 w-full flex-1">
-        <ResponsiveContainer width="100%" height="100%">
-          <BarChart
-            data={data}
-            barCategoryGap="20%"
-            margin={{ top: 56, right: 8, bottom: 0, left: -8 }}
-          >
-            <CartesianGrid stroke="#ECECEC" vertical={false} />
-            <XAxis
-              dataKey="name"
-              axisLine={false}
-              tickLine={false}
-              tick={{ fontSize: 12, fill: '#999999' }}
-            />
-            <YAxis
-              axisLine={false}
-              tickLine={false}
-              ticks={[0, 50, 100, 150, 200, 250]}
-              domain={[0, 250]}
-              tick={{ fontSize: 12, fill: '#999999' }}
-            />
-            <Bar dataKey="value" radius={20} maxBarSize={56}>
-              {data.map((_, i) => (
-                <Cell key={i} fill={BAR_COLORS[i % BAR_COLORS.length]} />
-              ))}
-              <LabelList dataKey="value" content={<BalloonLabel />} />
-            </Bar>
-          </BarChart>
-        </ResponsiveContainer>
-      </div>
+      <DataPreviewTable preview={preview} />
     </div>
   );
 }

--- a/apps/fe/src/app/(main)/data/_components/DataChartCard.tsx
+++ b/apps/fe/src/app/(main)/data/_components/DataChartCard.tsx
@@ -34,9 +34,9 @@ function DataPreviewTable({ preview }: { preview?: FilePreview | null }) {
         <table className="min-w-full border-collapse text-body4">
           <thead>
             <tr className="bg-white text-gray-900">
-              {headers.map((header) => (
+              {headers.map((header, index) => (
                 <th
-                  key={header}
+                  key={`${header}-${index}`}
                   className="whitespace-nowrap border-b border-gray-200 px-16 py-12 text-left font-semibold"
                 >
                   {header}
@@ -57,15 +57,19 @@ function DataPreviewTable({ preview }: { preview?: FilePreview | null }) {
             ) : (
               rows.map((row, rowIndex) => (
                 <tr key={rowIndex} className="border-b border-gray-100">
-                  {headers.map((header, columnIndex) => (
-                    <td
-                      key={`${rowIndex}-${header}`}
-                      className="max-w-[24rem] truncate whitespace-nowrap px-16 py-12 text-gray-800"
-                      title={row[columnIndex] ?? '-'}
-                    >
-                      {row[columnIndex] || '-'}
-                    </td>
-                  ))}
+                  {headers.map((_, columnIndex) => {
+                    const cell = row[columnIndex] ?? '-';
+
+                    return (
+                      <td
+                        key={`${rowIndex}-${columnIndex}`}
+                        className="max-w-[24rem] truncate whitespace-nowrap px-16 py-12 text-gray-800"
+                        title={cell}
+                      >
+                        {cell}
+                      </td>
+                    );
+                  })}
                 </tr>
               ))
             )}

--- a/apps/fe/src/app/(main)/data/page.tsx
+++ b/apps/fe/src/app/(main)/data/page.tsx
@@ -1,16 +1,28 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
+import {
+  dataSourceKeys,
+  deleteDataSources,
+  getDataSources,
+  uploadDataSource,
+  type DataSourceSort,
+} from '@/apis/datasource';
 import ChatIcon from '@/assets/icons/chat.svg';
 import SuccessIcon from '@/assets/icons/success.svg';
 import { FileUploadModal, Modal, ToastAlert } from '@/components';
+import { formatDateTime } from '@/lib/dateTime';
 import { formatFileSize, validateCsvFile } from '@/lib/fileValidation';
+import { useAuthSession } from '@/providers/AuthProvider';
 import Checkbox from './_components/Checkbox';
 import SortDropdown from './_components/SortDropdown';
 
 const DELETE_ILLUST_SRC = '/illusts/delete.svg';
 const TOAST_DURATION_MS = 2500;
+const DATA_SOURCE_PAGE = 0;
+const DATA_SOURCE_PAGE_SIZE = 50;
 
 type SortKey = 'usage' | 'latest';
 type ToastState = {
@@ -18,42 +30,84 @@ type ToastState = {
   tone: 'error' | 'success';
 };
 
-type DataSource = {
-  id: string;
-  fileName: string;
-  fileSize: string;
-  uploadedAt: string;
-};
-
 const SORT_OPTIONS = [
   { value: 'usage', label: '사용량 많은 순' },
-  { value: 'latest', label: '최근 업로드 순' },
+  { value: 'latest', label: '최근 업로드순' },
 ];
+
+const SORT_PARAM_BY_KEY: Record<SortKey, DataSourceSort> = {
+  usage: 'MOST_USED',
+  latest: 'LATEST',
+};
 
 const DATA_FILE_MESSAGES = {
   invalidType: '파일 형식이 맞지 않습니다.',
-  tooLarge: '파일이 너무 커요. 50MB까지만 업로드 가능해요',
+  tooLarge: '파일이 너무 커요. 50MB까지 업로드할 수 있어요.',
 };
-
-// TODO: API 연동
-const DUMMY_DATA: DataSource[] = Array.from({ length: 8 }, (_, i) => ({
-  id: `data-${i}`,
-  fileName: '파일명.csv',
-  fileSize: '50MB',
-  uploadedAt: '5분 전',
-}));
 
 export default function DataPage() {
   const router = useRouter();
+  const queryClient = useQueryClient();
+  const { hasAccessToken } = useAuthSession();
   const [sortKey, setSortKey] = useState<SortKey>('latest');
-  const [data, setData] = useState<DataSource[]>(DUMMY_DATA);
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [uploadOpen, setUploadOpen] = useState(false);
   const [toast, setToast] = useState<ToastState | null>(null);
 
-  // TODO: 실제 정렬/필터 로직 (현재는 더미)
-  void sortKey;
+  const listParams = useMemo(
+    () => ({
+      sort: SORT_PARAM_BY_KEY[sortKey],
+      page: DATA_SOURCE_PAGE,
+      size: DATA_SOURCE_PAGE_SIZE,
+    }),
+    [sortKey],
+  );
+
+  const {
+    data: dataSourceList,
+    isError: isListError,
+    isLoading: isListLoading,
+  } = useQuery({
+    queryKey: dataSourceKeys.list(listParams),
+    queryFn: () => getDataSources(listParams),
+    enabled: hasAccessToken,
+  });
+
+  const dataSources = useMemo(
+    () => dataSourceList?.dataSources ?? [],
+    [dataSourceList?.dataSources],
+  );
+  const visibleIdSet = useMemo(
+    () => new Set(dataSources.map((d) => d.dataSourceId)),
+    [dataSources],
+  );
+  const selectedIdList = useMemo(
+    () => [...selectedIds].filter((id) => visibleIdSet.has(id)),
+    [selectedIds, visibleIdSet],
+  );
+  const selectedVisibleIdSet = useMemo(
+    () => new Set(selectedIdList),
+    [selectedIdList],
+  );
+
+  const uploadMutation = useMutation({
+    mutationFn: uploadDataSource,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: dataSourceKeys.lists(),
+      });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: deleteDataSources,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: dataSourceKeys.lists(),
+      });
+    },
+  });
 
   useEffect(() => {
     if (!toast) return;
@@ -66,19 +120,20 @@ export default function DataPage() {
   };
 
   const allSelected =
-    data.length > 0 && data.every((d) => selectedIds.has(d.id));
-  const partiallySelected = !allSelected && selectedIds.size > 0;
-  const hasSelection = selectedIds.size > 0;
+    dataSources.length > 0 &&
+    dataSources.every((d) => selectedVisibleIdSet.has(d.dataSourceId));
+  const partiallySelected = !allSelected && selectedIdList.length > 0;
+  const hasSelection = selectedIdList.length > 0;
 
   const toggleAll = () => {
     if (allSelected) {
       setSelectedIds(new Set());
     } else {
-      setSelectedIds(new Set(data.map((d) => d.id)));
+      setSelectedIds(new Set(dataSources.map((d) => d.dataSourceId)));
     }
   };
 
-  const toggleOne = (id: string) => {
+  const toggleOne = (id: number) => {
     setSelectedIds((prev) => {
       const next = new Set(prev);
       if (next.has(id)) next.delete(id);
@@ -91,19 +146,14 @@ export default function DataPage() {
     setUploadOpen(true);
   };
 
-  const handleUploaded = (uploaded: File) => {
-    // TODO: 업로드된 파일을 서버에 보내고 목록 갱신
-    setData((prev) => [
-      {
-        id: `data-${crypto.randomUUID()}`,
-        fileName: uploaded.name,
-        fileSize: formatFileSize(uploaded.size),
-        uploadedAt: '방금 전',
-      },
-      ...prev,
-    ]);
-    setUploadOpen(false);
-    showToast('파일이 업로드 되었습니다.', 'success');
+  const handleUploaded = async (uploaded: File) => {
+    try {
+      await uploadMutation.mutateAsync(uploaded);
+      setUploadOpen(false);
+      showToast('파일을 업로드했습니다.', 'success');
+    } catch {
+      showToast('파일 업로드에 실패했습니다.', 'error');
+    }
   };
 
   const handleDeleteClick = () => {
@@ -111,22 +161,36 @@ export default function DataPage() {
     setDeleteOpen(true);
   };
 
-  const handleDeleteConfirm = () => {
-    // TODO: 선택된 데이터 삭제 API 호출
-    setData((prev) => prev.filter((row) => !selectedIds.has(row.id)));
-    setSelectedIds(new Set());
-    setDeleteOpen(false);
-    showToast('파일이 삭제되었습니다', 'success');
+  const handleDeleteConfirm = async () => {
+    if (selectedIdList.length === 0) return;
+
+    try {
+      await deleteMutation.mutateAsync(selectedIdList);
+      setSelectedIds(new Set());
+      setDeleteOpen(false);
+      showToast('파일을 삭제했습니다.', 'success');
+    } catch {
+      showToast('파일 삭제에 실패했습니다.', 'error');
+    }
   };
 
-  const handleChat = (id: string) => {
-    // TODO: 해당 데이터로 분석 채팅 시작 (별도 페이지에서 처리 가능)
-    void id;
+  const handleChat = (id: number) => {
+    router.push(`/analysis/${id}`);
   };
 
-  const goToDetail = (id: string) => {
+  const goToDetail = (id: number) => {
     router.push(`/data/${id}`);
   };
+
+  const statusMessage = !hasAccessToken
+    ? '로그인 후 데이터 소스를 확인할 수 있습니다.'
+    : isListLoading
+      ? '데이터 소스를 불러오는 중입니다.'
+      : isListError
+        ? '데이터 소스를 불러오지 못했습니다.'
+        : dataSources.length === 0
+          ? '업로드된 데이터 소스가 없습니다.'
+          : null;
 
   return (
     <main className="scrollbar-hide flex min-h-0 flex-1 flex-col overflow-y-auto px-40 pt-32 pb-40">
@@ -134,7 +198,6 @@ export default function DataPage() {
         데이터 소스
       </h1>
 
-      {/* 상단 액션 영역 */}
       <div className="mb-16 flex items-center justify-between">
         <SortDropdown
           options={SORT_OPTIONS}
@@ -146,7 +209,8 @@ export default function DataPage() {
             <button
               type="button"
               onClick={handleDeleteClick}
-              className="text-body4 text-gray-700 underline underline-offset-2 hover:text-gray-900"
+              disabled={deleteMutation.isPending}
+              className="text-body4 text-gray-700 underline underline-offset-2 hover:text-gray-900 disabled:cursor-not-allowed disabled:text-gray-500"
             >
               삭제하기
             </button>
@@ -154,14 +218,14 @@ export default function DataPage() {
           <button
             type="button"
             onClick={handleUploadClick}
-            className="rounded-full bg-orange-500 px-16 py-8 text-body4 font-medium text-white transition-colors hover:bg-orange-600"
+            disabled={!hasAccessToken || uploadMutation.isPending}
+            className="rounded-full bg-orange-500 px-16 py-8 text-body4 font-medium text-white transition-colors hover:bg-orange-600 disabled:cursor-not-allowed disabled:bg-gray-400"
           >
-            새 CSV 파일 업로드
+            CSV 파일 업로드
           </button>
         </div>
       </div>
 
-      {/* 테이블 */}
       <div className="overflow-hidden rounded-12 border border-gray-300 bg-white">
         <table className="w-full border-collapse text-body4">
           <thead>
@@ -177,7 +241,7 @@ export default function DataPage() {
               <th className="w-[14rem] py-16 text-left font-semibold">
                 파일 크기
               </th>
-              <th className="w-[16rem] py-16 text-left font-semibold">
+              <th className="w-[18rem] py-16 text-left font-semibold">
                 최근 업로드
               </th>
               <th className="w-[14rem] py-16 pr-24 text-right font-semibold">
@@ -186,50 +250,61 @@ export default function DataPage() {
             </tr>
           </thead>
           <tbody>
-            {data.map((row) => {
-              const checked = selectedIds.has(row.id);
-              return (
-                <tr
-                  key={row.id}
-                  onClick={() => goToDetail(row.id)}
-                  className="cursor-pointer border-t border-gray-200 transition-colors hover:bg-gray-100"
-                >
-                  <td
-                    className="py-16 pl-24"
-                    onClick={(e) => e.stopPropagation()}
+            {statusMessage ? (
+              <tr>
+                <td colSpan={5} className="py-48 text-center text-gray-600">
+                  {statusMessage}
+                </td>
+              </tr>
+            ) : (
+              dataSources.map((row) => {
+                const checked = selectedVisibleIdSet.has(row.dataSourceId);
+                return (
+                  <tr
+                    key={row.dataSourceId}
+                    onClick={() => goToDetail(row.dataSourceId)}
+                    className="cursor-pointer border-t border-gray-200 transition-colors hover:bg-gray-100"
                   >
-                    <Checkbox
-                      checked={checked}
-                      onChange={() => toggleOne(row.id)}
-                    />
-                  </td>
-                  <td className="py-16 text-gray-900">{row.fileName}</td>
-                  <td className="py-16 text-gray-800">{row.fileSize}</td>
-                  <td className="py-16 text-gray-800">{row.uploadedAt}</td>
-                  <td
-                    className="py-16 pr-24 text-right"
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    <button
-                      type="button"
-                      onClick={() => handleChat(row.id)}
-                      className="inline-flex items-center gap-4 rounded-full border border-gray-300 bg-white px-12 py-6 text-body4 text-gray-700 transition-colors hover:bg-gray-100"
+                    <td
+                      className="py-16 pl-24"
+                      onClick={(e) => e.stopPropagation()}
                     >
-                      <ChatIcon
-                        aria-hidden
-                        className="icon-12 text-orange-500"
+                      <Checkbox
+                        checked={checked}
+                        onChange={() => toggleOne(row.dataSourceId)}
                       />
-                      <span>채팅</span>
-                    </button>
-                  </td>
-                </tr>
-              );
-            })}
+                    </td>
+                    <td className="py-16 text-gray-900">{row.fileName}</td>
+                    <td className="py-16 text-gray-800">
+                      {formatFileSize(row.fileSize)}
+                    </td>
+                    <td className="py-16 text-gray-800">
+                      {formatDateTime(row.uploadedAt)}
+                    </td>
+                    <td
+                      className="py-16 pr-24 text-right"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <button
+                        type="button"
+                        onClick={() => handleChat(row.dataSourceId)}
+                        className="inline-flex items-center gap-4 rounded-full border border-gray-300 bg-white px-12 py-6 text-body4 text-gray-700 transition-colors hover:bg-gray-100"
+                      >
+                        <ChatIcon
+                          aria-hidden
+                          className="icon-12 text-orange-500"
+                        />
+                        <span>채팅</span>
+                      </button>
+                    </td>
+                  </tr>
+                );
+              })
+            )}
           </tbody>
         </table>
       </div>
 
-      {/* CSV 파일 업로드 모달 */}
       <FileUploadModal
         open={uploadOpen}
         onClose={() => setUploadOpen(false)}
@@ -238,7 +313,6 @@ export default function DataPage() {
         onUpload={handleUploaded}
       />
 
-      {/* 삭제 확인 모달 */}
       <Modal open={deleteOpen} onClose={() => setDeleteOpen(false)}>
         <div className="flex flex-col items-center gap-24">
           {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -253,23 +327,25 @@ export default function DataPage() {
               파일을 삭제하시겠어요?
             </h3>
             <p className="text-body4 text-gray-700">
-              삭제 후엔 복구할 수 없어요.
+              삭제 후에는 복구할 수 없어요.
             </p>
           </div>
           <div className="flex w-full justify-center gap-8">
             <button
               type="button"
               onClick={() => setDeleteOpen(false)}
-              className="min-w-[12rem] rounded-full bg-gray-300 px-20 py-12 text-body2 font-medium text-gray-700 transition-colors hover:bg-gray-400"
+              disabled={deleteMutation.isPending}
+              className="min-w-[12rem] rounded-full bg-gray-300 px-20 py-12 text-body2 font-medium text-gray-700 transition-colors hover:bg-gray-400 disabled:cursor-not-allowed disabled:opacity-60"
             >
               취소하기
             </button>
             <button
               type="button"
               onClick={handleDeleteConfirm}
-              className="min-w-[12rem] rounded-full bg-orange-500 px-20 py-12 text-body2 font-medium text-white transition-colors hover:bg-orange-600"
+              disabled={deleteMutation.isPending}
+              className="min-w-[12rem] rounded-full bg-orange-500 px-20 py-12 text-body2 font-medium text-white transition-colors hover:bg-orange-600 disabled:cursor-not-allowed disabled:bg-gray-400"
             >
-              삭제하기
+              {deleteMutation.isPending ? '삭제 중' : '삭제하기'}
             </button>
           </div>
         </div>

--- a/apps/fe/src/app/(main)/data/page.tsx
+++ b/apps/fe/src/app/(main)/data/page.tsx
@@ -170,6 +170,7 @@ export default function DataPage() {
       setDeleteOpen(false);
       showToast('파일을 삭제했습니다.', 'success');
     } catch {
+      setDeleteOpen(false);
       showToast('파일 삭제에 실패했습니다.', 'error');
     }
   };

--- a/apps/fe/src/app/(main)/layout.tsx
+++ b/apps/fe/src/app/(main)/layout.tsx
@@ -2,7 +2,6 @@
 
 import { usePathname, useRouter } from 'next/navigation';
 import { Header, type NavItem } from '@/components';
-import { getOAuthLoginUrl } from '@/lib/authRedirect';
 import { useAuthSession } from '@/providers/AuthProvider';
 import FileIcon from '@/assets/icons/file.svg';
 import GTapIcon from '@/assets/icons/G-tap.svg';
@@ -41,9 +40,7 @@ export default function MainLayout({
   const showDataSearch = pathname.startsWith('/data');
 
   const handleProfileClick = () => {
-    if (!hasAccessToken) {
-      window.location.assign(getOAuthLoginUrl());
-    }
+    router.push('/login');
   };
 
   return (
@@ -54,7 +51,7 @@ export default function MainLayout({
         searchSlot={showDataSearch ? <DataSourceSearchInput /> : undefined}
         onLogoClick={() => router.push('/analysis')}
         onNavClick={(href) => router.push(href)}
-        onProfileClick={handleProfileClick}
+        onProfileClick={hasAccessToken ? undefined : handleProfileClick}
       />
       {children}
     </div>

--- a/apps/fe/src/app/(main)/layout.tsx
+++ b/apps/fe/src/app/(main)/layout.tsx
@@ -2,6 +2,7 @@
 
 import { usePathname, useRouter } from 'next/navigation';
 import { Header, type NavItem } from '@/components';
+import { getOAuthLoginUrl } from '@/lib/authRedirect';
 import { useAuthSession } from '@/providers/AuthProvider';
 import FileIcon from '@/assets/icons/file.svg';
 import GTapIcon from '@/assets/icons/G-tap.svg';
@@ -41,7 +42,7 @@ export default function MainLayout({
 
   const handleProfileClick = () => {
     if (!hasAccessToken) {
-      window.location.assign('/login');
+      window.location.assign(getOAuthLoginUrl());
     }
   };
 

--- a/apps/fe/src/app/(main)/layout.tsx
+++ b/apps/fe/src/app/(main)/layout.tsx
@@ -2,6 +2,7 @@
 
 import { usePathname, useRouter } from 'next/navigation';
 import { Header, type NavItem } from '@/components';
+import { useAuthSession } from '@/providers/AuthProvider';
 import FileIcon from '@/assets/icons/file.svg';
 import GTapIcon from '@/assets/icons/G-tap.svg';
 import GHistoryIcon from '@/assets/icons/G-history.svg';
@@ -34,8 +35,15 @@ export default function MainLayout({
 }) {
   const router = useRouter();
   const pathname = usePathname();
+  const { hasAccessToken } = useAuthSession();
 
   const showDataSearch = pathname.startsWith('/data');
+
+  const handleProfileClick = () => {
+    if (!hasAccessToken) {
+      window.location.assign('/login');
+    }
+  };
 
   return (
     <div className="flex h-screen flex-col overflow-hidden bg-gray-200">
@@ -45,6 +53,7 @@ export default function MainLayout({
         searchSlot={showDataSearch ? <DataSourceSearchInput /> : undefined}
         onLogoClick={() => router.push('/analysis')}
         onNavClick={(href) => router.push(href)}
+        onProfileClick={handleProfileClick}
       />
       {children}
     </div>

--- a/apps/fe/src/app/login/route.ts
+++ b/apps/fe/src/app/login/route.ts
@@ -1,8 +1,6 @@
 import { NextResponse } from 'next/server';
-import { getApiBaseUrl } from '@/lib/apiBaseUrl';
+import { getOAuthLoginUrl } from '@/lib/authRedirect';
 
 export function GET() {
-  return NextResponse.redirect(
-    new URL('/oauth2/authorization/google', getApiBaseUrl()),
-  );
+  return NextResponse.redirect(getOAuthLoginUrl());
 }

--- a/apps/fe/src/app/page.tsx
+++ b/apps/fe/src/app/page.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import PriceIcon from '@/assets/icons/price.svg';
 import SuccessIcon from '@/assets/icons/success.svg';
-import { getOAuthLoginUrl } from '@/lib/authRedirect';
 import IntroCarousel from './_components/IntroCarousel';
 
 // 다색 일러스트는 SVGR 변환을 피하기 위해 public/ 정적 자산
@@ -104,7 +103,7 @@ export default function IntroPage() {
   const [scrolled, setScrolled] = useState(false);
 
   const goToLogin = () => {
-    window.location.assign(getOAuthLoginUrl());
+    router.push('/login');
   };
 
   // hero(=뷰포트 1개) 만큼 스크롤되면 헤더가 흰 배경 + 그림자로 전환됨

--- a/apps/fe/src/app/page.tsx
+++ b/apps/fe/src/app/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import PriceIcon from '@/assets/icons/price.svg';
 import SuccessIcon from '@/assets/icons/success.svg';
+import { getOAuthLoginUrl } from '@/lib/authRedirect';
 import IntroCarousel from './_components/IntroCarousel';
 
 // 다색 일러스트는 SVGR 변환을 피하기 위해 public/ 정적 자산
@@ -103,7 +104,7 @@ export default function IntroPage() {
   const [scrolled, setScrolled] = useState(false);
 
   const goToLogin = () => {
-    window.location.assign('/login');
+    window.location.assign(getOAuthLoginUrl());
   };
 
   // hero(=뷰포트 1개) 만큼 스크롤되면 헤더가 흰 배경 + 그림자로 전환됨

--- a/apps/fe/src/components/FileUploadModal/FileUploadModal.tsx
+++ b/apps/fe/src/components/FileUploadModal/FileUploadModal.tsx
@@ -74,12 +74,18 @@ export default function FileUploadModal({
           setProgress(100);
 
           void Promise.resolve(onUpload?.(selected))
-            .catch(() => undefined)
+            .catch((error) => {
+              onError?.(
+                error instanceof Error
+                  ? error.message
+                  : '파일 업로드에 실패했습니다.',
+              );
+            })
             .finally(reset);
         }
       }, SIM_TICK_MS);
     },
-    [clearTimer, onUpload, reset],
+    [clearTimer, onError, onUpload, reset],
   );
 
   const handleCancelFile = useCallback(() => {

--- a/apps/fe/src/components/FileUploadModal/FileUploadModal.tsx
+++ b/apps/fe/src/components/FileUploadModal/FileUploadModal.tsx
@@ -7,7 +7,7 @@ import Modal from '../Modal/Modal';
 export type FileUploadModalProps = {
   open: boolean;
   onClose: () => void;
-  onUpload?: (file: File) => void;
+  onUpload?: (file: File) => void | Promise<void>;
   validateFile?: (file: File) => string | null;
   onError?: (message: string) => void;
   accept?: string;
@@ -70,8 +70,12 @@ export default function FileUploadModal({
         setProgress(Math.min(p, 100));
 
         if (p >= 100) {
-          reset();
-          onUpload?.(selected);
+          clearTimer();
+          setProgress(100);
+
+          void Promise.resolve(onUpload?.(selected))
+            .catch(() => undefined)
+            .finally(reset);
         }
       }, SIM_TICK_MS);
     },

--- a/apps/fe/src/components/Header/Header.tsx
+++ b/apps/fe/src/components/Header/Header.tsx
@@ -118,9 +118,21 @@ export default function Header({
       <div className="ml-auto flex items-center gap-16">
         {searchSlot}
         {profileSlot ?? (
-          <button type="button" onClick={onProfileClick}>
-            <ProfileIcon />
-          </button>
+          <>
+            {onProfileClick ? (
+              <button
+                type="button"
+                onClick={onProfileClick}
+                aria-label="프로필"
+              >
+                <ProfileIcon />
+              </button>
+            ) : (
+              <span className="inline-flex" aria-label="프로필">
+                <ProfileIcon />
+              </span>
+            )}
+          </>
         )}
       </div>
     </header>

--- a/apps/fe/src/lib/authRedirect.ts
+++ b/apps/fe/src/lib/authRedirect.ts
@@ -1,0 +1,5 @@
+import { getApiBaseUrl } from './apiBaseUrl';
+
+export function getOAuthLoginUrl() {
+  return new URL('/oauth2/authorization/google', getApiBaseUrl()).toString();
+}

--- a/apps/fe/src/lib/dateTime.ts
+++ b/apps/fe/src/lib/dateTime.ts
@@ -1,9 +1,14 @@
 const DATE_TIME_FORMATTER = new Intl.DateTimeFormat('ko-KR', {
   dateStyle: 'medium',
   timeStyle: 'short',
+  timeZone: 'Asia/Seoul',
 });
 
-export function formatDateTime(value: string) {
+/**
+ * ISO-8601 날짜/시간 문자열을 DATE_TIME_FORMATTER로 표시용 문자열로 변환합니다.
+ * 유효하지 않은 값은 '-'를 반환합니다.
+ */
+export function formatDateTime(value: string): string {
   const date = new Date(value);
 
   if (Number.isNaN(date.getTime())) return '-';

--- a/apps/fe/src/lib/dateTime.ts
+++ b/apps/fe/src/lib/dateTime.ts
@@ -1,0 +1,12 @@
+const DATE_TIME_FORMATTER = new Intl.DateTimeFormat('ko-KR', {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+});
+
+export function formatDateTime(value: string) {
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) return '-';
+
+  return DATE_TIME_FORMATTER.format(date);
+}


### PR DESCRIPTION
﻿## 요약
- DataSource Swagger 스펙에 맞춰 목록 조회, CSV 업로드, 다건 삭제, 상세 조회, 단건 삭제 API를 연결했습니다.
- 상세 화면은 단건 조회 응답의 CSV preview를 미리보기 테이블로 렌더링하도록 바꿨습니다.

## 변경 사항
- [x] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `C:\Users\user\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe .\node_modules\eslint\bin\eslint.js .`
  - `C:\Users\user\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe .\node_modules\typescript\bin\tsc --noEmit`
  - `NEXT_PUBLIC_API_URL=https://api-stg.asklogue.co C:\Users\user\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe .\node_modules\next\dist\bin\next build --webpack`
  - Playwright 렌더 확인: `http://localhost:3002/data`

## 스크린샷/로그 (선택)
- `/data` 비로그인 상태 렌더 확인 완료

## 롤백/리스크
- 리스크 요인: 인증 토큰이 없으면 API 요청을 보내지 않고 안내 메시지를 표시합니다. 실제 업로드/삭제 성공 플로우는 staging 인증 세션에서 추가 확인이 필요합니다.
- 롤백 방법: 이 PR revert

## 관련 이슈
Closes #130


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 데이터소스 목록 조회·상세 조회, 파일 업로드 및 단건/복수 삭제 기능 추가
  * 업로드된 파일의 표 형태 미리보기(헤더/행 표시, 빈값 처리) 추가
  * 상세 페이지에서 채팅 이동·삭제 모달 연동 및 상태별 렌더링 추가

* **Improvements**
  * 업로드 모달의 동기/비동기 처리 안정화 및 오류/재설정 흐름 개선
  * 목록·상세의 로딩/오류/권한 분기, 토스트 알림 및 날짜/시간 표시 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/26-ewha-capstone-logue/logue/pull/132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->