### PR TITLE
feat: 사용자 API 연결

### DIFF
--- a/apps/fe/src/apis/user.ts
+++ b/apps/fe/src/apis/user.ts
@@ -9,6 +9,11 @@ export type GetUserInfoResponse = {
   profileImageUrl: string | null;
 };
 
+export const userKeys = {
+  all: ['user'] as const,
+  me: () => [...userKeys.all, 'me'] as const,
+};
+
 export async function getMyInfo() {
   const { data } =
     await instance.get<ApiResponse<GetUserInfoResponse>>('/api/user/me');

--- a/apps/fe/src/app/(main)/analysis/[id]/page.tsx
+++ b/apps/fe/src/app/(main)/analysis/[id]/page.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { use, useEffect, useState, type ReactNode } from 'react';
-import { useSearchParams } from 'next/navigation';
 import { ChatBubble } from '@/components';
 import PromptInput, { type PromptInputValue } from '../_components/PromptInput';
+import { readAnalysisDraft } from '../_lib/analysisDraftStorage';
 import AnalysisResult from './_components/AnalysisResult';
 import AnalyzingIndicator from './_components/AnalyzingIndicator';
 import DataTablePreview from './_components/DataTablePreview';
@@ -19,6 +19,7 @@ type Message = {
   role: 'user' | 'bot';
   /** 봇은 카드 등 ReactNode, 사용자는 문자열을 사용 */
   content: ReactNode;
+  fileName?: string | null;
 };
 
 // TODO: 실제 API 응답 시간에 맞춰 제거. 현재는 로딩 UI 데모용 시뮬레이션 시간.
@@ -34,18 +35,35 @@ export default function AnalysisChatPage({
 }) {
   // TODO: id 로 분석 데이터 fetch
   const { id } = use(params);
-  void id;
-
-  const searchParams = useSearchParams();
-  const initialPrompt = searchParams.get('q') ?? DEFAULT_PROMPT;
 
   const [messages, setMessages] = useState<Message[]>(() => [
-    { id: 'init-user', role: 'user', content: initialPrompt },
+    { id: 'init-user', role: 'user', content: DEFAULT_PROMPT },
   ]);
   // CSV 분석 완료 여부 — 좌측 데이터 표 vs 로딩 화면 토글에 사용
   const [isCsvAnalyzed, setIsCsvAnalyzed] = useState(false);
   // 분석 중 인디케이터 표시 여부 (CSV 단계 + 질문 단계 동안 true)
   const [isAnalyzing, setIsAnalyzing] = useState(true);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      const draft = readAnalysisDraft(id);
+      if (!draft) return;
+
+      setMessages((prev) =>
+        prev.map((msg) =>
+          msg.id === 'init-user'
+            ? {
+                ...msg,
+                content: draft.prompt,
+                fileName: draft.fileName,
+              }
+            : msg,
+        ),
+      );
+    }, 0);
+
+    return () => window.clearTimeout(timer);
+  }, [id]);
 
   // 최초 진입 — CSV 분석 시뮬레이션
   // TODO: 실제 API 호출(파일 업로드 + 분석)로 교체
@@ -71,7 +89,12 @@ export default function AnalysisChatPage({
     const userMsgId = `user-${Date.now()}`;
     setMessages((prev) => [
       ...prev,
-      { id: userMsgId, role: 'user', content: value.prompt },
+      {
+        id: userMsgId,
+        role: 'user',
+        content: value.prompt,
+        fileName: value.file?.name ?? null,
+      },
     ]);
     setIsAnalyzing(true);
 
@@ -119,7 +142,15 @@ export default function AnalysisChatPage({
               const isUser = msg.role === 'user';
               if (isUser) {
                 return (
-                  <ChatBubble key={msg.id} role="user">
+                  <ChatBubble
+                    key={msg.id}
+                    role="user"
+                    file={
+                      msg.fileName
+                        ? { name: msg.fileName, status: 'uploaded' }
+                        : undefined
+                    }
+                  >
                     {msg.content}
                   </ChatBubble>
                 );

--- a/apps/fe/src/app/(main)/analysis/_lib/analysisDraftStorage.ts
+++ b/apps/fe/src/app/(main)/analysis/_lib/analysisDraftStorage.ts
@@ -1,0 +1,52 @@
+export type AnalysisDraft = {
+  prompt: string;
+  fileName: string | null;
+};
+
+const ANALYSIS_DRAFT_STORAGE_PREFIX = 'logue:analysis-draft:';
+
+function getSessionStorage() {
+  if (typeof window === 'undefined') return null;
+
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+function getAnalysisDraftStorageKey(analysisId: string) {
+  return `${ANALYSIS_DRAFT_STORAGE_PREFIX}${analysisId}`;
+}
+
+export function saveAnalysisDraft(analysisId: string, draft: AnalysisDraft) {
+  const storage = getSessionStorage();
+  if (!storage) return;
+
+  storage.setItem(
+    getAnalysisDraftStorageKey(analysisId),
+    JSON.stringify(draft),
+  );
+}
+
+export function readAnalysisDraft(analysisId: string): AnalysisDraft | null {
+  const storage = getSessionStorage();
+  if (!storage) return null;
+
+  const rawDraft = storage.getItem(getAnalysisDraftStorageKey(analysisId));
+  if (!rawDraft) return null;
+
+  try {
+    const parsed = JSON.parse(rawDraft) as Partial<AnalysisDraft>;
+    const prompt = typeof parsed.prompt === 'string' ? parsed.prompt : '';
+
+    if (!prompt.trim()) return null;
+
+    return {
+      prompt,
+      fileName: typeof parsed.fileName === 'string' ? parsed.fileName : null,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/apps/fe/src/app/(main)/analysis/_lib/analysisDraftStorage.ts
+++ b/apps/fe/src/app/(main)/analysis/_lib/analysisDraftStorage.ts
@@ -23,17 +23,27 @@ export function saveAnalysisDraft(analysisId: string, draft: AnalysisDraft) {
   const storage = getSessionStorage();
   if (!storage) return;
 
-  storage.setItem(
-    getAnalysisDraftStorageKey(analysisId),
-    JSON.stringify(draft),
-  );
+  try {
+    storage.setItem(
+      getAnalysisDraftStorageKey(analysisId),
+      JSON.stringify(draft),
+    );
+  } catch {
+    return;
+  }
 }
 
 export function readAnalysisDraft(analysisId: string): AnalysisDraft | null {
   const storage = getSessionStorage();
   if (!storage) return null;
 
-  const rawDraft = storage.getItem(getAnalysisDraftStorageKey(analysisId));
+  let rawDraft: string | null = null;
+  try {
+    rawDraft = storage.getItem(getAnalysisDraftStorageKey(analysisId));
+  } catch {
+    return null;
+  }
+
   if (!rawDraft) return null;
 
   try {

--- a/apps/fe/src/app/(main)/analysis/page.tsx
+++ b/apps/fe/src/app/(main)/analysis/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
-import { getMyInfo } from '@/apis/user';
+import { getMyInfo, userKeys } from '@/apis/user';
 import { ToastAlert } from '@/components';
 import { validateCsvFile } from '@/lib/fileValidation';
 import { useAuthSession } from '@/providers/AuthProvider';
@@ -29,7 +29,7 @@ export default function AnalysisPage() {
     isError: isUserInfoError,
     isLoading: isUserInfoLoading,
   } = useQuery({
-    queryKey: ['user', 'me'],
+    queryKey: userKeys.me(),
     queryFn: getMyInfo,
     enabled: hasAccessToken,
     staleTime: USER_INFO_STALE_TIME,

--- a/apps/fe/src/app/(main)/analysis/page.tsx
+++ b/apps/fe/src/app/(main)/analysis/page.tsx
@@ -10,6 +10,7 @@ import { useAuthSession } from '@/providers/AuthProvider';
 import GreetingSection from './_components/GreetingSection';
 import PromptInput, { type PromptInputValue } from './_components/PromptInput';
 import SampleDataSection from './_components/SampleDataSection';
+import { saveAnalysisDraft } from './_lib/analysisDraftStorage';
 
 const FALLBACK_USER_NAME = '사용자';
 const USER_INFO_STALE_TIME = 5 * 60 * 1000;
@@ -56,11 +57,11 @@ export default function AnalysisPage() {
     // TODO: 분석 생성 API 호출 후 응답 id 로 교체
     // e.g. const { id } = await createAnalysis({ prompt: value.prompt, file: value.file });
     const tempId = `tmp-${Date.now()}`;
-    const params = new URLSearchParams();
-    if (value.prompt) params.set('q', value.prompt);
-    if (value.file?.name) params.set('file', value.file.name);
-    const qs = params.toString();
-    router.push(`/analysis/${tempId}${qs ? `?${qs}` : ''}`);
+    saveAnalysisDraft(tempId, {
+      prompt: value.prompt,
+      fileName: value.file?.name ?? null,
+    });
+    router.push(`/analysis/${tempId}`);
   };
 
   const handlePromptError = (message: string) => {

--- a/apps/fe/src/app/(main)/data/page.tsx
+++ b/apps/fe/src/app/(main)/data/page.tsx
@@ -119,9 +119,9 @@ export default function DataPage() {
     showToast('파일이 삭제되었습니다', 'success');
   };
 
-  const handleChat = (id: string) => {
+  const handleChat = () => {
     // TODO: 해당 데이터로 분석 채팅 시작 (별도 페이지에서 처리 가능)
-    void id;
+    return;
   };
 
   const goToDetail = (id: string) => {
@@ -192,11 +192,19 @@ export default function DataPage() {
                 <tr
                   key={row.id}
                   onClick={() => goToDetail(row.id)}
-                  className="cursor-pointer border-t border-gray-200 transition-colors hover:bg-gray-100"
+                  onKeyDown={(event) => {
+                    if (event.key !== 'Enter' && event.key !== ' ') return;
+                    event.preventDefault();
+                    goToDetail(row.id);
+                  }}
+                  tabIndex={0}
+                  role="button"
+                  className="cursor-pointer border-t border-gray-200 transition-colors hover:bg-gray-100 focus-visible:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-orange-500"
                 >
                   <td
                     className="py-16 pl-24"
                     onClick={(e) => e.stopPropagation()}
+                    onKeyDown={(e) => e.stopPropagation()}
                   >
                     <Checkbox
                       checked={checked}
@@ -212,13 +220,13 @@ export default function DataPage() {
                   >
                     <button
                       type="button"
-                      onClick={() => handleChat(row.id)}
-                      className="inline-flex items-center gap-4 rounded-full border border-gray-300 bg-white px-12 py-6 text-body4 text-gray-700 transition-colors hover:bg-gray-100"
+                      disabled
+                      aria-disabled="true"
+                      title="준비 중인 기능입니다."
+                      onClick={handleChat}
+                      className="inline-flex cursor-not-allowed items-center gap-4 rounded-full border border-gray-200 bg-gray-100 px-12 py-6 text-body4 text-gray-400"
                     >
-                      <ChatIcon
-                        aria-hidden
-                        className="icon-12 text-orange-500"
-                      />
+                      <ChatIcon aria-hidden className="icon-12 text-gray-400" />
                       <span>채팅</span>
                     </button>
                   </td>

--- a/apps/fe/src/app/(main)/layout.tsx
+++ b/apps/fe/src/app/(main)/layout.tsx
@@ -1,17 +1,23 @@
 'use client';
 
+import type { CSSProperties } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { usePathname, useRouter } from 'next/navigation';
+import { getMyInfo, userKeys, type GetUserInfoResponse } from '@/apis/user';
 import { Header, type NavItem } from '@/components';
 import FileIcon from '@/assets/icons/file.svg';
 import GTapIcon from '@/assets/icons/G-tap.svg';
 import GHistoryIcon from '@/assets/icons/G-history.svg';
 import SearchIcon from '@/assets/icons/search.svg';
+import { useAuthSession } from '@/providers/AuthProvider';
 
 const NAV_ITEMS: NavItem[] = [
   { label: '파일분석', href: '/analysis', Icon: FileIcon },
   { label: '데이터 소스', href: '/data', Icon: GTapIcon },
   { label: '히스토리', href: '/history', Icon: GHistoryIcon },
 ];
+
+const USER_INFO_STALE_TIME = 5 * 60 * 1000;
 
 function DataSourceSearchInput() {
   // TODO: URL searchParams 연동 / 디바운스 등
@@ -27,6 +33,61 @@ function DataSourceSearchInput() {
   );
 }
 
+function getUserInitial(user: GetUserInfoResponse | undefined) {
+  return user?.name?.trim().slice(0, 1).toUpperCase() || 'U';
+}
+
+function getProfileImageStyle(
+  profileImageUrl: string | null | undefined,
+): CSSProperties | undefined {
+  const imageUrl = profileImageUrl?.trim();
+  if (!imageUrl) return undefined;
+
+  return {
+    backgroundImage: `url("${imageUrl.replace(/["\\]/g, '\\$&')}")`,
+  };
+}
+
+function UserProfileSlot({
+  user,
+  isLoading,
+  isError,
+}: {
+  user: GetUserInfoResponse | undefined;
+  isLoading: boolean;
+  isError: boolean;
+}) {
+  if (isLoading) {
+    return (
+      <span
+        aria-label="Loading profile"
+        className="inline-flex h-36 w-36 animate-pulse rounded-full bg-gray-300"
+      />
+    );
+  }
+
+  const profileImageStyle = getProfileImageStyle(user?.profileImageUrl);
+
+  return (
+    <span
+      aria-label={
+        isError
+          ? 'Profile unavailable'
+          : user?.name
+            ? `${user.name} profile`
+            : 'Profile'
+      }
+      title={isError ? undefined : user?.email}
+      style={profileImageStyle}
+      className={`inline-flex h-36 w-36 items-center justify-center overflow-hidden rounded-full bg-gray-300 text-body3 font-semibold text-gray-700 ${
+        profileImageStyle ? 'bg-cover bg-center text-transparent' : ''
+      }`.trim()}
+    >
+      {getUserInitial(user)}
+    </span>
+  );
+}
+
 export default function MainLayout({
   children,
 }: {
@@ -34,17 +95,37 @@ export default function MainLayout({
 }) {
   const router = useRouter();
   const pathname = usePathname();
+  const { hasAccessToken } = useAuthSession();
+  const {
+    data: myInfo,
+    isError: isUserInfoError,
+    isLoading: isUserInfoLoading,
+  } = useQuery({
+    queryKey: userKeys.me(),
+    queryFn: getMyInfo,
+    enabled: hasAccessToken,
+    staleTime: USER_INFO_STALE_TIME,
+  });
 
   const showDataSearch = pathname.startsWith('/data');
+  const profileSlot = hasAccessToken ? (
+    <UserProfileSlot
+      user={myInfo}
+      isLoading={isUserInfoLoading}
+      isError={isUserInfoError}
+    />
+  ) : undefined;
 
   return (
     <div className="flex h-screen flex-col overflow-hidden bg-gray-200">
       <Header
         navItems={NAV_ITEMS}
         activeHref={pathname}
+        profileSlot={profileSlot}
         searchSlot={showDataSearch ? <DataSourceSearchInput /> : undefined}
         onLogoClick={() => router.push('/analysis')}
         onNavClick={(href) => router.push(href)}
+        onProfileClick={() => router.push('/login')}
       />
       {children}
     </div>

--- a/apps/fe/src/providers/AuthProvider.tsx
+++ b/apps/fe/src/providers/AuthProvider.tsx
@@ -8,7 +8,7 @@ import {
   useState,
   type ReactNode,
 } from 'react';
-import { usePathname, useRouter } from 'next/navigation';
+import { usePathname } from 'next/navigation';
 import {
   ACCESS_TOKEN_STORAGE_KEY,
   AUTH_TOKENS_CHANGED_EVENT,
@@ -47,8 +47,11 @@ function shouldRedirectAuthenticatedUser(pathname: string) {
   return AUTH_ENTRY_PATHS.has(pathname);
 }
 
+function replaceLocation(pathname: string) {
+  window.location.replace(pathname);
+}
+
 export default function AuthProvider({ children }: { children: ReactNode }) {
-  const router = useRouter();
   const pathname = usePathname();
   const [hasAccessToken, setHasAccessToken] = useState(false);
 
@@ -67,7 +70,8 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
     if (redirectedTokens) {
       setAuthTokens(redirectedTokens);
       removeTokenParamsFromCurrentUrl(currentUrl);
-      router.replace(AUTH_REDIRECT_PATH);
+      replaceLocation(AUTH_REDIRECT_PATH);
+      return;
     }
 
     const nextHasAccessToken = syncAccessToken();
@@ -77,7 +81,8 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
       nextHasAccessToken &&
       shouldRedirectAuthenticatedUser(pathname)
     ) {
-      router.replace(AUTH_REDIRECT_PATH);
+      replaceLocation(AUTH_REDIRECT_PATH);
+      return;
     }
 
     const handleStorage = (event: StorageEvent) => {
@@ -97,7 +102,7 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
       window.removeEventListener(AUTH_TOKENS_CHANGED_EVENT, syncAccessToken);
       window.removeEventListener('storage', handleStorage);
     };
-  }, [pathname, router]);
+  }, [pathname]);
 
   const value = useMemo(
     () => ({

--- a/apps/fe/src/providers/AuthProvider.tsx
+++ b/apps/fe/src/providers/AuthProvider.tsx
@@ -8,6 +8,7 @@ import {
   useState,
   type ReactNode,
 } from 'react';
+import { useRouter } from 'next/navigation';
 import {
   ACCESS_TOKEN_STORAGE_KEY,
   AUTH_TOKENS_CHANGED_EVENT,
@@ -17,6 +18,8 @@ import {
   readAuthTokensFromSearchParams,
   setAuthTokens,
 } from '@/lib/auth';
+
+const AUTH_REDIRECT_PATH = '/analysis';
 
 type AuthContextValue = {
   hasAccessToken: boolean;
@@ -40,6 +43,7 @@ function removeTokenParamsFromCurrentUrl(url: URL) {
 }
 
 export default function AuthProvider({ children }: { children: ReactNode }) {
+  const router = useRouter();
   const [hasAccessToken, setHasAccessToken] = useState(
     () => typeof window !== 'undefined' && Boolean(getAccessToken()),
   );
@@ -57,6 +61,7 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
     if (redirectedTokens) {
       setAuthTokens(redirectedTokens);
       removeTokenParamsFromCurrentUrl(currentUrl);
+      router.replace(AUTH_REDIRECT_PATH);
     }
 
     syncAccessToken();
@@ -78,7 +83,7 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
       window.removeEventListener(AUTH_TOKENS_CHANGED_EVENT, syncAccessToken);
       window.removeEventListener('storage', handleStorage);
     };
-  }, []);
+  }, [router]);
 
   const value = useMemo(
     () => ({

--- a/apps/fe/src/providers/AuthProvider.tsx
+++ b/apps/fe/src/providers/AuthProvider.tsx
@@ -8,7 +8,7 @@ import {
   useState,
   type ReactNode,
 } from 'react';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import {
   ACCESS_TOKEN_STORAGE_KEY,
   AUTH_TOKENS_CHANGED_EVENT,
@@ -20,6 +20,7 @@ import {
 } from '@/lib/auth';
 
 const AUTH_REDIRECT_PATH = '/analysis';
+const AUTH_ENTRY_PATHS = new Set(['/', '/login']);
 
 type AuthContextValue = {
   hasAccessToken: boolean;
@@ -42,15 +43,20 @@ function removeTokenParamsFromCurrentUrl(url: URL) {
   );
 }
 
+function shouldRedirectAuthenticatedUser(pathname: string) {
+  return AUTH_ENTRY_PATHS.has(pathname);
+}
+
 export default function AuthProvider({ children }: { children: ReactNode }) {
   const router = useRouter();
-  const [hasAccessToken, setHasAccessToken] = useState(
-    () => typeof window !== 'undefined' && Boolean(getAccessToken()),
-  );
+  const pathname = usePathname();
+  const [hasAccessToken, setHasAccessToken] = useState(false);
 
   useEffect(() => {
     const syncAccessToken = () => {
-      setHasAccessToken(Boolean(getAccessToken()));
+      const nextHasAccessToken = Boolean(getAccessToken());
+      setHasAccessToken(nextHasAccessToken);
+      return nextHasAccessToken;
     };
 
     const currentUrl = new URL(window.location.href);
@@ -64,7 +70,15 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
       router.replace(AUTH_REDIRECT_PATH);
     }
 
-    syncAccessToken();
+    const nextHasAccessToken = syncAccessToken();
+
+    if (
+      !redirectedTokens &&
+      nextHasAccessToken &&
+      shouldRedirectAuthenticatedUser(pathname)
+    ) {
+      router.replace(AUTH_REDIRECT_PATH);
+    }
 
     const handleStorage = (event: StorageEvent) => {
       if (
@@ -83,7 +97,7 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
       window.removeEventListener(AUTH_TOKENS_CHANGED_EVENT, syncAccessToken);
       window.removeEventListener('storage', handleStorage);
     };
-  }, [router]);
+  }, [pathname, router]);
 
   const value = useMemo(
     () => ({


### PR DESCRIPTION
## 요약
- 사용자 정보 조회 API를 공통 API 레이어와 메인 화면 프로필/분석 페이지 사용자명 조회에 연결했습니다.

## 변경 사항
- [x] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - yarn lint
  - NEXT_PUBLIC_API_URL을 staging API URL로 설정 후 yarn build

## 스크린샷/로그 (선택)
- 없음

## 롤백/리스크
- 리스크 포인트: 로그인 토큰이 있는 사용자에게만 `/api/user/me` 요청이 발생하며, API 실패 시 헤더 프로필은 기본 이니셜 fallback으로 표시됩니다.
- 롤백 방법: 해당 커밋을 revert하면 기존 정적 프로필 아이콘/분석 페이지 query key 사용으로 복구됩니다.

## 관련 이슈
Closes #134

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 헤더에 사용자 프로필(이니셜·이미지) 표시 추가
  * 분석 생성 시 임시 드래프트를 세션에 저장하고 해당 임시 ID로 이동
  * 채팅 페이지가 드래프트로 초기화되어 파일명과 함께 메시지 표시

* **Bug Fixes**
  * 인증 토큰 처리 및 리다이렉트 로직 안정화

* **Accessibility**
  * 데이터 목록 행에 키보드로 상세 진입 가능한 동작 추가 (Enter/Space)
  * 채팅 버튼은 준비 중으로 비활성 처리

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/26-ewha-capstone-logue/logue/pull/135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->