### PR TITLE
feat: FE Codex 스킬 설정 추가

### DIFF
--- a/apps/fe/.codex/skills/logue-fe-api-integration/SKILL.md
+++ b/apps/fe/.codex/skills/logue-fe-api-integration/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: logue-fe-api-integration
+description: FE-only Logue API integration guardrails for apps/fe. Use when Codex adds, edits, reviews, or debugs frontend API wiring in apps/fe, including src/apis modules, src/lib/axios.ts, axios or fetch calls, ApiResponse and unwrapApiResponse usage, auth token handling, API error handling, TanStack Query useQuery/useMutation query keys, cache invalidation, and loading/error/empty states. Do not use for pure UI, CSS, Storybook-only, static component, backend, or AI work.
+---
+
+# Logue FE API Integration
+
+## Scope
+
+Use this skill only for Logue frontend work under `apps/fe/**` when the task touches server communication or frontend server-state behavior.
+
+Do not apply this skill to `apps/be/**`, `apps/ai/**`, docs-only work, pure UI styling, Storybook-only changes, or static component work that does not call or model an API.
+
+## Existing FE Contracts
+
+- Prefer the existing `src/lib/axios.ts` instance for HTTP calls. Add a new client only when the existing instance cannot support the request, and make that reason explicit.
+- Keep API base URL behavior in `src/lib/apiBaseUrl.ts`; do not duplicate environment fallback logic in endpoint modules or components.
+- Keep the response envelope pattern in `src/apis/types.ts`: type endpoint responses as `ApiResponse<T>` and return `unwrapApiResponse(data)` from API functions.
+- Keep auth token reads, writes, and 401 token clearing in `src/lib/auth.ts`, `src/providers/AuthProvider.tsx`, and `src/lib/axios.ts` unless the task explicitly changes auth behavior.
+- Use TanStack Query through the existing `QueryProvider` defaults; override query options locally only when the user-visible behavior requires it.
+
+## API Layer Workflow
+
+1. Inspect the nearest existing `src/apis/*` module and the consuming page/component before adding code.
+2. Put endpoint functions plus request/response DTO types in the domain API module. Keep components from constructing URLs or parsing envelope responses.
+3. Return domain data from API functions, not raw Axios responses, unless the caller truly needs headers or status.
+4. Add a query key factory beside the API module when keys will be reused, invalidated, or shared across pages. A single one-off query may keep an inline key.
+5. For mutations, define the smallest correct `invalidateQueries` target from the affected query key factory.
+6. In consuming UI, cover loading, empty, error, disabled, and pending states for every reachable server-state branch.
+
+## Error Handling Check
+
+- Distinguish envelope failures (`success: false`) from Axios/network/timeout/auth failures.
+- If UI needs an error message, code, status, or field errors from API failures, add or extend a small FE-side normalizer before components depend on transport-specific shapes.
+- Do not let components branch on `error.response.data`, `AxiosError`, or raw unknown error objects except inside a normalizer.
+- Do not introduce a global toast system or app-wide error boundary for a single local mutation message.
+- Do not add refresh-token retry flow unless there is a confirmed frontend contract for the endpoint and token lifecycle.
+
+## Abstraction Guard
+
+- Do not extract a custom query hook just because a single page has one simple query.
+- Do not add a new API client, request wrapper, cache layer, MSW setup, or test harness for speculative future endpoints.
+- Prefer extending existing local patterns such as `instance`, `ApiResponse`, `unwrapApiResponse`, and domain query key factories.
+- Add abstraction only when it removes repeated API behavior with the same meaning, reduces component coupling to transport details, or matches an established local pattern.
+- Keep fixed product copy for simple local failures when the server error detail is not user-actionable.
+
+## Finish Checklist
+
+- Confirm endpoint functions do not bypass the shared API layer without a concrete reason.
+- Confirm authenticated queries use an appropriate `enabled` condition.
+- Confirm query keys and invalidation targets are stable and scoped.
+- Confirm components do not parse raw transport errors.
+- Run the most relevant FE check for the touched surface, usually `yarn lint` for API wiring and a focused test/build check when one exists.

--- a/apps/fe/.codex/skills/logue-fe-api-integration/agents/openai.yaml
+++ b/apps/fe/.codex/skills/logue-fe-api-integration/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Logue FE API Integration"
+  short_description: "FE-only API integration guardrails for Logue"
+  default_prompt: "Use $logue-fe-api-integration to add or review a Logue FE API integration."


### PR DESCRIPTION
﻿## 요약
- FE 전용 Codex API 연동 스킬을 추가했습니다.
- 추후 FE 스킬 추가 시 `apps/fe/.codex/skills` 구조를 재사용할 수 있도록 에이전트 메타 설정을 함께 추가했습니다.

## 변경 사항
- [x] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `git diff --cached --check`

## 스크린샷/로그 (선택)
- 해당 없음

## 롤백/리스크
- 리스크 요인: 런타임 FE 코드 변경이 없어 낮음
- 롤백 방법: 이 PR에서 추가한 `apps/fe/.codex/skills/logue-fe-api-integration` 디렉터리를 제거

## 관련 이슈
Closes #138


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 프론트엔드 API 통합 스킬 가이드 문서 추가. API 호출, 서버 상태 관리, 에러 처리 및 검증 규칙에 대한 가이드라인 포함.

* **Chores**
  * 프론트엔드 API 통합 기능을 위한 에이전트 메타데이터 및 가드레일 설정 추가.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/26-ewha-capstone-logue/logue/pull/139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->