### PR TITLE
fix: 분석 결과/기준 조회 리포지토리 메서드명 정정 (#140)

### DIFF
--- a/apps/be/src/main/java/com/capstone/logue/anal/service/AnalysisResultService.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/service/AnalysisResultService.java
@@ -66,7 +66,7 @@ public class AnalysisResultService {
         AnalysisCriteria criteria = loadCriteria(flow, analysisCriteriaId);
 
         AiTaggingJob job = aiTaggingJobRepository
-                .findTopByMessageIdAndStageOrderByCreatedAtDesc(messageId, JobStage.ANALYSIS_RESULT)
+                .findTopByMessageIdAndStageOrderByCreatedAtDescIdDesc(messageId, JobStage.ANALYSIS_RESULT)
                 .orElseThrow(() -> new LogueException(ErrorCode.RESULT_NOT_FOUND));
 
         if (job.getStatus() != JobStatus.SUCCESS) {
@@ -115,7 +115,7 @@ public class AnalysisResultService {
         loadCriteria(flow, analysisCriteriaId);
 
         AiTaggingJob job = aiTaggingJobRepository
-                .findTopByMessageIdAndStageOrderByCreatedAtDesc(messageId, JobStage.ANALYSIS_RESULT)
+                .findTopByMessageIdAndStageOrderByCreatedAtDescIdDesc(messageId, JobStage.ANALYSIS_RESULT)
                 .orElseThrow(() -> new LogueException(ErrorCode.RESULT_NOT_FOUND));
 
         return new GetQuestionResultStatusResponse(job.getStatus().name());
@@ -133,7 +133,7 @@ public class AnalysisResultService {
         loadCriteria(flow, analysisCriteriaId);
 
         AiTaggingJob job = aiTaggingJobRepository
-                .findTopByMessageIdAndStageOrderByCreatedAtDesc(messageId, JobStage.ANALYSIS_RESULT)
+                .findTopByMessageIdAndStageOrderByCreatedAtDescIdDesc(messageId, JobStage.ANALYSIS_RESULT)
                 .orElseThrow(() -> new LogueException(ErrorCode.RESULT_NOT_FOUND));
 
         JobStatus status = job.getStatus();

--- a/apps/be/src/main/java/com/capstone/logue/anal/service/JobStateService.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/service/JobStateService.java
@@ -348,7 +348,7 @@ public class JobStateService {
 
         AnalysisFlow flow = job.getAnalysisFlow();
         AnalysisCriteria criteria = analysisCriteriaRepository
-                .findTopByAnalysisFlowIdOrderByCreatedAtDesc(flow.getId())
+                .findTopByAnalysisFlowIdOrderByCreatedAtDescIdDesc(flow.getId())
                 .orElseThrow(() -> new LogueException(ErrorCode.CRITERIA_NOT_FOUND));
 
         return new ResultJobContext(criteria, flow.getDataSource());

--- a/apps/be/src/test/java/com/capstone/logue/anal/service/AnalysisResultServiceTest.java
+++ b/apps/be/src/test/java/com/capstone/logue/anal/service/AnalysisResultServiceTest.java
@@ -142,7 +142,7 @@ class AnalysisResultServiceTest {
                 .id(JOB_ID).conversation(conversation).analysisFlow(flow).message(message)
                 .stage(JobStage.ANALYSIS_RESULT).status(JobStatus.SUCCESS)
                 .build();
-        when(aiTaggingJobRepository.findTopByMessageIdAndStageOrderByCreatedAtDesc(
+        when(aiTaggingJobRepository.findTopByMessageIdAndStageOrderByCreatedAtDescIdDesc(
                 MESSAGE_ID, JobStage.ANALYSIS_RESULT))
                 .thenReturn(Optional.of(job));
 
@@ -177,7 +177,7 @@ class AnalysisResultServiceTest {
                 .id(JOB_ID).conversation(conversation).analysisFlow(flow).message(message)
                 .stage(JobStage.ANALYSIS_RESULT).status(JobStatus.RUNNING)
                 .build();
-        when(aiTaggingJobRepository.findTopByMessageIdAndStageOrderByCreatedAtDesc(
+        when(aiTaggingJobRepository.findTopByMessageIdAndStageOrderByCreatedAtDescIdDesc(
                 MESSAGE_ID, JobStage.ANALYSIS_RESULT))
                 .thenReturn(Optional.of(job));
 
@@ -191,7 +191,7 @@ class AnalysisResultServiceTest {
     @DisplayName("getResult: Job 자체가 없으면 RESULT_NOT_FOUND")
     void getResult_jobNotFound() {
         stubAccess();
-        when(aiTaggingJobRepository.findTopByMessageIdAndStageOrderByCreatedAtDesc(
+        when(aiTaggingJobRepository.findTopByMessageIdAndStageOrderByCreatedAtDescIdDesc(
                 MESSAGE_ID, JobStage.ANALYSIS_RESULT))
                 .thenReturn(Optional.empty());
 
@@ -210,7 +210,7 @@ class AnalysisResultServiceTest {
                 .id(JOB_ID).conversation(conversation).analysisFlow(flow).message(message)
                 .stage(JobStage.ANALYSIS_RESULT).status(JobStatus.RUNNING)
                 .build();
-        when(aiTaggingJobRepository.findTopByMessageIdAndStageOrderByCreatedAtDesc(
+        when(aiTaggingJobRepository.findTopByMessageIdAndStageOrderByCreatedAtDescIdDesc(
                 MESSAGE_ID, JobStage.ANALYSIS_RESULT))
                 .thenReturn(Optional.of(job));
 
@@ -229,7 +229,7 @@ class AnalysisResultServiceTest {
                 .id(JOB_ID).conversation(conversation).analysisFlow(flow).message(message)
                 .stage(JobStage.ANALYSIS_RESULT).status(JobStatus.QUEUED)
                 .build();
-        when(aiTaggingJobRepository.findTopByMessageIdAndStageOrderByCreatedAtDesc(
+        when(aiTaggingJobRepository.findTopByMessageIdAndStageOrderByCreatedAtDescIdDesc(
                 MESSAGE_ID, JobStage.ANALYSIS_RESULT))
                 .thenReturn(Optional.of(job));
 
@@ -250,7 +250,7 @@ class AnalysisResultServiceTest {
                 .id(JOB_ID).conversation(conversation).analysisFlow(flow).message(message)
                 .stage(JobStage.ANALYSIS_RESULT).status(JobStatus.RUNNING)
                 .build();
-        when(aiTaggingJobRepository.findTopByMessageIdAndStageOrderByCreatedAtDesc(
+        when(aiTaggingJobRepository.findTopByMessageIdAndStageOrderByCreatedAtDescIdDesc(
                 MESSAGE_ID, JobStage.ANALYSIS_RESULT))
                 .thenReturn(Optional.of(job));
         doThrow(new RestClientException("boom")).when(fastApiClient).cancelAnalysis(JOB_ID);
@@ -271,7 +271,7 @@ class AnalysisResultServiceTest {
                 .id(JOB_ID).conversation(conversation).analysisFlow(flow).message(message)
                 .stage(JobStage.ANALYSIS_RESULT).status(JobStatus.SUCCESS)
                 .build();
-        when(aiTaggingJobRepository.findTopByMessageIdAndStageOrderByCreatedAtDesc(
+        when(aiTaggingJobRepository.findTopByMessageIdAndStageOrderByCreatedAtDescIdDesc(
                 MESSAGE_ID, JobStage.ANALYSIS_RESULT))
                 .thenReturn(Optional.of(job));
 


### PR DESCRIPTION
## 요약
- PR #90 머지 후 BE Deploy 워크플로가 `compileJava` 에러로 실패하던 문제 수정 (호출부를 실제 리포지토리 메서드명에 맞게 정정)

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

`AnalysisResultService` 3곳, `JobStateService` 1곳, `AnalysisResultServiceTest` 7곳에서 잘못 호출하던 메서드명을 정정:
- `AiTaggingJobRepository.findTopByMessageIdAndStageOrderByCreatedAtDesc` → `findTopByMessageIdAndStageOrderByCreatedAtDescIdDesc`
- `AnalysisCriteriaRepository.findTopByAnalysisFlowIdOrderByCreatedAtDesc` → `findTopByAnalysisFlowIdOrderByCreatedAtDescIdDesc`

PR #83 리뷰 반영(43d9472)에서 동일 시각 레코드 tie-breaker로 `IdDesc`를 추가했었는데, PR #90 호출부가 이전 이름을 그대로 사용해 컴파일이 실패하던 케이스입니다.

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `cd apps/be && ./gradlew compileJava compileTestJava -x test` → BUILD SUCCESSFUL

## 스크린샷/로그 (선택)
- 실패 run: https://github.com/26-ewha-capstone-logue/logue/actions/runs/26323360657

## 롤백/리스크
- 리스크 포인트: 호출부 메서드명 변경만 있고 시그니처/동작 동일 (tie-breaker 추가는 이미 PR #83에서 반영). 결과 조회 시 동일 `createdAt` 레코드가 있을 때 `id` 큰 쪽이 선택되는 동작이 적용됨.
- 롤백 방법: `git revert <commit>` 후 푸시. 단 dev 배포가 다시 깨지므로 권장하지 않음.

## 관련 이슈
Closes #140