### PR TITLE
fix: 정적 리소스 미존재 요청을 404로 매핑해 알림 노이즈 제거 (#142)

### DIFF
--- a/apps/be/src/main/java/com/capstone/logue/global/exception/ErrorCode.java
+++ b/apps/be/src/main/java/com/capstone/logue/global/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     INVALID_TYPE(HttpStatus.BAD_REQUEST, "C002", "잘못된 타입입니다."),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C003", "지원하지 않는 HTTP 메서드입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C004", "서버 내부 오류가 발생했습니다."),
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "C005", "요청한 리소스를 찾을 수 없습니다."),
 
     // Auth
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "A001", "인증이 필요합니다."),

--- a/apps/be/src/main/java/com/capstone/logue/global/exception/GlobalExceptionHandler.java
+++ b/apps/be/src/main/java/com/capstone/logue/global/exception/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -58,6 +59,14 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(ErrorCode.METHOD_NOT_ALLOWED.getHttpStatus())
                 .body(ApiResponse.error(ErrorCode.METHOD_NOT_ALLOWED));
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleNoResourceFound(NoResourceFoundException e, HttpServletRequest request) {
+        log.warn("[NoResourceFound] {} {} - {}", request.getMethod(), request.getRequestURI(), e.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.RESOURCE_NOT_FOUND.getHttpStatus())
+                .body(ApiResponse.error(ErrorCode.RESOURCE_NOT_FOUND));
     }
 
     @ExceptionHandler(Exception.class)


### PR DESCRIPTION
## 요약
- 매핑 안 된 경로 요청이 500/C004로 잡혀서 디스코드 에러 알림이 폭주하던 문제 수정

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

`GlobalExceptionHandler`의 `Exception.class` fallback이 Spring의 `NoResourceFoundException`까지 잡아서 500/C004로 매핑하고 디스코드 알림까지 발화하던 케이스를 정정.

- `ErrorCode`에 `RESOURCE_NOT_FOUND(404, C005)` 추가
- `NoResourceFoundException` 전용 핸들러 추가 (404 반환, 디스코드 알림 미발송, warn 로그만 남김)

이후 `GET /`, `POST /`, `/favicon.ico`, `/apple-touch-icon*.png` 같은 외부 핑/봇 요청은 404로 떨어지고 알림 채널에는 안 올라옴.

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `cd apps/be && ./gradlew compileJava` BUILD SUCCESSFUL
  - 배포 후 stg에서 `curl -i https://<stg>/favicon.ico` → 404 응답 + 디스코드 알림 없음 확인 예정

## 스크린샷/로그 (선택)
배포 전 스테이지 알림 채널에 같은 예외가 10~20분 간격으로 반복 발화 중. 배포 후 끊기는 것으로 검증.

## 롤백/리스크
- 리스크: 핸들러 우선순위 변경 없이 새 핸들러만 추가한 것이라 기존 5xx 흐름에는 영향 없음. C005가 새로 노출되지만 클라이언트가 별도로 파싱하는 코드는 없음.
- 롤백: `git revert <commit>` 후 푸시.

## 관련 이슈
Closes #142