### PR TITLE
fix: stg Redis 연결 실패로 OAuth 로그인 후 500 발생 (#145)

### DIFF
--- a/.github/workflows/be-deploy.yml
+++ b/.github/workflows/be-deploy.yml
@@ -89,9 +89,12 @@ jobs:
               "aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin $REGISTRY",
               "docker pull $IMAGE",
               "aws ssm get-parameters-by-path --region $AWS_REGION --path /logue/$ENV/ --recursive --with-decryption --output json --query 'Parameters[*]' | python3 -c \"import sys,json; params=json.load(sys.stdin); open('/tmp/.logue.env','w').write(''.join([p['Name'].split('/')[-1]+'='+p['Value']+chr(10) for p in params]))\"",
+              "set -a && . /tmp/.logue.env && set +a",
+              "docker network inspect logue-net >/dev/null 2>&1 || docker network create logue-net",
+              "docker ps --filter name=^redis\$ --format '{{.Names}}' | grep -q '^redis\$' || docker run -d --name redis --restart unless-stopped --network logue-net -v redis-data:/data redis:7-alpine redis-server --appendonly yes --requirepass \"\$REDIS_PASSWORD\"",
               "docker stop $CONTAINER_NAME 2>/dev/null || true",
               "docker rm   $CONTAINER_NAME 2>/dev/null || true",
-              "docker run -d --name $CONTAINER_NAME --restart unless-stopped -p $APP_PORT:8080 -e SPRING_PROFILES_ACTIVE=$ENV --env-file /tmp/.logue.env $IMAGE",
+              "docker run -d --name $CONTAINER_NAME --restart unless-stopped --network logue-net -p $APP_PORT:8080 -e SPRING_PROFILES_ACTIVE=$ENV --env-file /tmp/.logue.env $IMAGE",
               "rm -f /tmp/.logue.env",
               "docker image prune -f"
             ]

--- a/apps/be/src/main/resources/application-prod.properties
+++ b/apps/be/src/main/resources/application-prod.properties
@@ -69,5 +69,12 @@ logue.storage.s3.access-key=${LOGUE_STORAGE_S3_ACCESSKEY:}
 logue.storage.s3.secret-key=${LOGUE_STORAGE_S3_SECRETKEY:}
 
 # ================================
+# Redis
+# ================================
+spring.data.redis.host=${REDIS_HOST:localhost}
+spring.data.redis.port=${REDIS_PORT:6379}
+spring.data.redis.password=${REDIS_PASSWORD:}
+
+# ================================
 # Sentry
 # ================================

--- a/apps/be/src/main/resources/application-stg.properties
+++ b/apps/be/src/main/resources/application-stg.properties
@@ -58,6 +58,7 @@ logue.storage.s3.secret-key=${LOGUE_STORAGE_S3_SECRETKEY:}
 # ================================
 # Redis
 # ================================
-spring.data.redis.host=localhost
-spring.data.redis.port=6379
+spring.data.redis.host=${REDIS_HOST:localhost}
+spring.data.redis.port=${REDIS_PORT:6379}
+spring.data.redis.password=${REDIS_PASSWORD:}
 


### PR DESCRIPTION
## 요약
- stg에서 OAuth 로그인 콜백이 Redis 연결 실패로 500 떨어지던 문제 수정. properties를 환경변수로 빼고, BE deploy 파이프라인에 redis 컨테이너 + 공유 네트워크 단계를 추가.

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

1. `application-stg.properties` / `application-prod.properties` Redis 설정을 환경변수로 교체
   - `spring.data.redis.host=${REDIS_HOST:localhost}`
   - `spring.data.redis.port=${REDIS_PORT:6379}`
   - `spring.data.redis.password=${REDIS_PASSWORD:}`
2. `.github/workflows/be-deploy.yml` SSM 스크립트 갱신
   - `/tmp/.logue.env`를 source해서 `$REDIS_PASSWORD`를 셸에 노출
   - `logue-net` docker network 멱등 생성
   - `redis:7-alpine` 컨테이너 멱등 실행 (`--appendonly yes`, `redis-data` 볼륨 보존, `--requirepass`)
   - BE 컨테이너 `docker run`에 `--network logue-net` 추가

## 테스트
- [x] 로컬 테스트 완료 (compileJava BUILD SUCCESSFUL)
- 테스트 방법:
  - stg 배포 후 `/oauth2/authorization/google` 다시 시도 → 200 redirect + JWT 발급 확인
  - stg EC2에서 `docker exec -it redis redis-cli -a $REDIS_PASSWORD PING` → PONG 확인
  - BE 컨테이너에서 `redis:6379`로 연결 가능한지 확인

## 스크린샷/로그 (선택)
배포 전 동일 시간대 stg 로그에서 `RedisConnectionFailureException: Unable to connect to localhost/127.0.0.1:6379` 반복 확인. 배포 후 끊기는 것으로 검증.

## 롤백/리스크
- 리스크: 첫 배포 시 BE 컨테이너 네트워크 옵션이 바뀌어서 짧은 다운타임 가능. 호스트의 기존 `redis6-server`(Amazon Linux 패키지)가 떠있으면 컨테이너 redis와 포트 6379가 충돌할 수 있음. 배포 전에 stg EC2에서 `sudo systemctl stop redis6 && sudo systemctl disable redis6` 권장.
- 사전 작업: SSM Parameter Store `/logue/stg/`, `/logue/prod/`에 `REDIS_HOST=redis`, `REDIS_PORT=6379`, `REDIS_PASSWORD=<강한 비밀번호>` 등록 필수. 안 넣고 배포하면 redis가 빈 비번으로 떠서 BE 인증이 꼬임.
- 롤백: `git revert <commits>` 후 푸시. redis 데이터는 `redis-data` 볼륨에 남음.

## 관련 이슈
Closes #145