### PR TITLE
fix: OAuth 신규 회원 가입 후 온보딩으로 리다이렉트되지 않음 (#147)

### DIFF
--- a/apps/be/src/main/java/com/capstone/logue/auth/handler/OAuth2LoginSuccessHandler.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/handler/OAuth2LoginSuccessHandler.java
@@ -106,26 +106,28 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         String profileImageUrl = oAuth2UserInfo.getProfileImageUrl();
 
         // 신규 유저면 저장, 기존 유저면 그대로 조회
-        User user = userRepository.findByProviderUserId(providerUserId)
-                .orElseGet(() -> {
-                    log.info("신규 유저 저장. provider={}, providerUserId={}", provider, providerUserId);
-                    return userRepository.save(User.builder()
-                            .provider(provider)
-                            .providerUserId(providerUserId)
-                            .email(email)
-                            .name(name)
-                            .profileImageUrl(profileImageUrl)
-                            .build());
-                });
+        Optional<User> existingUser = userRepository.findByProviderUserId(providerUserId);
+        boolean isNewUser = existingUser.isEmpty();
+        User user = existingUser.orElseGet(() -> {
+            log.info("신규 유저 저장. provider={}, providerUserId={}", provider, providerUserId);
+            return userRepository.save(User.builder()
+                    .provider(provider)
+                    .providerUserId(providerUserId)
+                    .email(email)
+                    .name(name)
+                    .profileImageUrl(profileImageUrl)
+                    .build());
+        });
 
-        log.info("OAuth 로그인 성공. providerUserId = {}", providerUserId);
+        log.info("OAuth 로그인 성공. providerUserId = {}, isNewUser = {}", providerUserId, isNewUser);
         String accessToken = jwtProvider.generateToken(user.getId(), user.getEmail(), ACCESS_TOKEN_EXPIRATION_TIME);
         String refreshToken = jwtProvider.generateToken(user.getId(), user.getEmail(), REFRESH_TOKEN_EXPIRATION_TIME);
 
         refreshTokenService.saveRefreshToken(user.getId(), refreshToken);
 
+        String baseUri = isNewUser ? REDIRECT_URI_ONBOARDING : REDIRECT_URI_BASE;
         String redirectUrl = UriComponentsBuilder
-                .fromUriString(REDIRECT_URI_BASE)
+                .fromUriString(baseUri)
                 .queryParam("accessToken", accessToken)
                 .queryParam("refreshToken", refreshToken)
                 .build()

--- a/apps/be/src/main/resources/application-prod.properties
+++ b/apps/be/src/main/resources/application-prod.properties
@@ -41,6 +41,7 @@ spring.jwt.refresh-token.expiration-time=604800000
 
 # ??? ?? ? prod FE URL? ?????
 spring.jwt.redirect.base=https://asklogue.co
+spring.jwt.redirect.onboarding=https://asklogue.co/onboarding
 
 # ================================
 # OAuth2 - Google (Prod)

--- a/apps/be/src/main/resources/application-stg.properties
+++ b/apps/be/src/main/resources/application-stg.properties
@@ -33,6 +33,7 @@ spring.jwt.refresh-token.expiration-time=604800000
 
 # ??? ?? ? FE Preview URL? ?????
 spring.jwt.redirect.base=https://logue-git-dev-maetelson-s-projects.vercel.app
+spring.jwt.redirect.onboarding=https://logue-git-dev-maetelson-s-projects.vercel.app/onboarding
 
 # ================================
 # OAuth2 - Google


### PR DESCRIPTION
## 요약
- OAuth 신규 회원이 가입 후 메인 URL로 떨어지던 문제 수정. 신규 여부 분기 추가 + stg/prod 온보딩 URL 프로퍼티 추가.

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

1. `OAuth2LoginSuccessHandler` 분기 추가
   - 사용자 조회 결과를 `Optional<User>`로 받고 `boolean isNewUser` 보존
   - redirect 빌더가 `isNewUser ? REDIRECT_URI_ONBOARDING : REDIRECT_URI_BASE` 선택
   - 로그에 `isNewUser` 출력 (디버깅용)
2. stg/prod 프로퍼티에 `spring.jwt.redirect.onboarding` 추가
   - stg: `https://logue-git-dev-maetelson-s-projects.vercel.app/onboarding`
   - prod: `https://asklogue.co/onboarding`

## 테스트
- [x] 로컬 테스트 완료 (compileJava BUILD SUCCESSFUL)
- 테스트 방법:
  - stg 배포 후 가입 이력 없는 새 Google 계정으로 로그인 → 최종 URL이 `/onboarding`으로 끝나는지 확인
  - 이미 가입된 계정으로 로그인 → 기존대로 base URL로 가는지 확인
  - 양쪽 모두 query param `accessToken`/`refreshToken` 정상 부착 확인

## 스크린샷/로그 (선택)
배포 전 신규 가입 시 최종 URL이 `https://www.asklogue.co/?accessToken=...&refreshToken=...` 로 떨어지던 케이스. 배포 후 `/onboarding`으로 향하는 것으로 검증.

## 롤백/리스크
- 리스크: 거의 없음. 신규/기존 분기는 기존 흐름에 영향 없고, 프로퍼티는 add-only. 로그 출력에 `isNewUser` 추가됐는데 이건 분석에 도움됨.
- 사전 조건: stg/prod 모두 같은 PR에서 프로퍼티가 같이 들어가므로 코드만 머지돼서 신규 회원이 빈 URL로 가는 케이스는 발생하지 않음.
- 롤백: `git revert <commits>` 후 푸시.

## 관련 이슈
Closes #147

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * OAuth2 로그인 시 신규 사용자와 기존 사용자를 자동으로 구분합니다. 신규 사용자는 온보딩 페이지로, 기존 사용자는 메인 앱으로 리다이렉트됩니다.

* **Chores**
  * 환경별 온보딩 리다이렉트 URL 설정이 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/26-ewha-capstone-logue/logue/pull/148?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->