### PR TITLE
fix: 프로덕션 로그인 라우트 복구

### DIFF
--- a/apps/fe/README.md
+++ b/apps/fe/README.md
@@ -16,6 +16,13 @@ bun dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
+## Environment
+
+`NEXT_PUBLIC_API_URL` configures the backend API base URL.
+
+- Local development, test, and Vercel Preview default to `https://api-stg.asklogue.co` when unset.
+- Vercel Production builds must set `NEXT_PUBLIC_API_URL`; missing values intentionally fail.
+
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.

--- a/apps/fe/README.md
+++ b/apps/fe/README.md
@@ -20,8 +20,8 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 `NEXT_PUBLIC_API_URL` configures the backend API base URL.
 
-- Local development, test, and Vercel Preview default to `https://api-stg.asklogue.co` when unset.
-- Vercel Production builds must set `NEXT_PUBLIC_API_URL`; missing values intentionally fail.
+- Local development, test, Vercel Preview, and unset Production values default to `https://api-stg.asklogue.co`.
+- Set `NEXT_PUBLIC_API_URL` in Production when the frontend should target a different backend API host.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 

--- a/apps/fe/src/app/layout.tsx
+++ b/apps/fe/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import AuthProvider from '@/providers/AuthProvider';
 import QueryProvider from '@/providers/QueryProvider';
 import '@/styles/globals.css';
 
@@ -15,7 +16,9 @@ export default function RootLayout({
   return (
     <html lang="ko" className="h-full antialiased">
       <body className="min-h-full flex flex-col">
-        <QueryProvider>{children}</QueryProvider>
+        <QueryProvider>
+          <AuthProvider>{children}</AuthProvider>
+        </QueryProvider>
       </body>
     </html>
   );

--- a/apps/fe/src/app/login/route.ts
+++ b/apps/fe/src/app/login/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server';
+import { getApiBaseUrl } from '@/lib/apiBaseUrl';
+
+export function GET() {
+  return NextResponse.redirect(
+    new URL('/oauth2/authorization/google', getApiBaseUrl()),
+  );
+}

--- a/apps/fe/src/app/page.tsx
+++ b/apps/fe/src/app/page.tsx
@@ -102,6 +102,10 @@ export default function IntroPage() {
   const router = useRouter();
   const [scrolled, setScrolled] = useState(false);
 
+  const goToLogin = () => {
+    window.location.assign('/login');
+  };
+
   // hero(=뷰포트 1개) 만큼 스크롤되면 헤더가 흰 배경 + 그림자로 전환됨
   useEffect(() => {
     const update = () => {
@@ -168,7 +172,7 @@ export default function IntroPage() {
         <div className="ml-auto flex items-center gap-20">
           <button
             type="button"
-            onClick={() => router.push('/login')}
+            onClick={goToLogin}
             className={`text-body2 underline underline-offset-2 transition-colors ${
               scrolled
                 ? 'text-gray-900 hover:text-gray-700'
@@ -179,7 +183,7 @@ export default function IntroPage() {
           </button>
           <button
             type="button"
-            onClick={() => router.push('/onboarding')}
+            onClick={goToLogin}
             className={`rounded-full px-20 py-8 text-body2 font-medium transition-colors ${
               scrolled
                 ? 'bg-orange-500 text-white hover:bg-orange-600'

--- a/apps/fe/src/lib/apiBaseUrl.ts
+++ b/apps/fe/src/lib/apiBaseUrl.ts
@@ -1,27 +1,9 @@
 export const DEV_API_BASE_URL = 'https://api-stg.asklogue.co';
 
-function getDeploymentEnvironment() {
-  return process.env.NEXT_PUBLIC_VERCEL_ENV ?? process.env.VERCEL_ENV;
-}
-
-function shouldRequireApiUrl() {
-  const deploymentEnvironment = getDeploymentEnvironment();
-
-  if (deploymentEnvironment) {
-    return deploymentEnvironment === 'production';
-  }
-
-  return process.env.NODE_ENV === 'production';
-}
-
 export function getApiBaseUrl() {
   const apiUrl = process.env.NEXT_PUBLIC_API_URL?.trim();
 
   if (apiUrl) return apiUrl;
-
-  if (shouldRequireApiUrl()) {
-    throw new Error('NEXT_PUBLIC_API_URL must be set in production');
-  }
 
   return DEV_API_BASE_URL;
 }

--- a/apps/fe/src/lib/apiBaseUrl.ts
+++ b/apps/fe/src/lib/apiBaseUrl.ts
@@ -1,0 +1,27 @@
+export const DEV_API_BASE_URL = 'https://api-stg.asklogue.co';
+
+function getDeploymentEnvironment() {
+  return process.env.NEXT_PUBLIC_VERCEL_ENV ?? process.env.VERCEL_ENV;
+}
+
+function shouldRequireApiUrl() {
+  const deploymentEnvironment = getDeploymentEnvironment();
+
+  if (deploymentEnvironment) {
+    return deploymentEnvironment === 'production';
+  }
+
+  return process.env.NODE_ENV === 'production';
+}
+
+export function getApiBaseUrl() {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL?.trim();
+
+  if (apiUrl) return apiUrl;
+
+  if (shouldRequireApiUrl()) {
+    throw new Error('NEXT_PUBLIC_API_URL must be set in production');
+  }
+
+  return DEV_API_BASE_URL;
+}

--- a/apps/fe/src/lib/auth.ts
+++ b/apps/fe/src/lib/auth.ts
@@ -1,0 +1,103 @@
+export type AuthTokens = {
+  accessToken: string;
+  refreshToken?: string | null;
+};
+
+export const ACCESS_TOKEN_STORAGE_KEY = 'accessToken';
+export const REFRESH_TOKEN_STORAGE_KEY = 'refreshToken';
+export const LEGACY_ACCESS_TOKEN_STORAGE_KEY = 'token';
+export const AUTH_TOKENS_CHANGED_EVENT = 'logue:auth-tokens-changed';
+
+function getOptionalLocalStorage() {
+  if (typeof window === 'undefined') return null;
+
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function getRequiredLocalStorage() {
+  if (typeof window === 'undefined') {
+    throw new Error('localStorage is not available outside the browser');
+  }
+
+  return window.localStorage;
+}
+
+function notifyAuthTokensChanged() {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new Event(AUTH_TOKENS_CHANGED_EVENT));
+}
+
+function getStorageItem(key: string) {
+  const storage = getOptionalLocalStorage();
+  if (!storage) return null;
+
+  try {
+    return storage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function setStorageItem(key: string, value: string) {
+  const storage = getRequiredLocalStorage();
+  storage.setItem(key, value);
+}
+
+function removeStorageItem(key: string) {
+  const storage = getRequiredLocalStorage();
+  storage.removeItem(key);
+}
+
+export function getAccessToken() {
+  return (
+    getStorageItem(ACCESS_TOKEN_STORAGE_KEY) ??
+    getStorageItem(LEGACY_ACCESS_TOKEN_STORAGE_KEY)
+  );
+}
+
+export function getRefreshToken() {
+  return getStorageItem(REFRESH_TOKEN_STORAGE_KEY);
+}
+
+export function setAuthTokens(tokens: AuthTokens) {
+  const accessToken = tokens.accessToken.trim();
+  const refreshToken = tokens.refreshToken?.trim();
+
+  if (!accessToken) return;
+
+  setStorageItem(ACCESS_TOKEN_STORAGE_KEY, accessToken);
+  setStorageItem(LEGACY_ACCESS_TOKEN_STORAGE_KEY, accessToken);
+
+  if (refreshToken) {
+    setStorageItem(REFRESH_TOKEN_STORAGE_KEY, refreshToken);
+  } else {
+    removeStorageItem(REFRESH_TOKEN_STORAGE_KEY);
+  }
+
+  notifyAuthTokensChanged();
+}
+
+export function clearAuthTokens() {
+  removeStorageItem(ACCESS_TOKEN_STORAGE_KEY);
+  removeStorageItem(REFRESH_TOKEN_STORAGE_KEY);
+  removeStorageItem(LEGACY_ACCESS_TOKEN_STORAGE_KEY);
+  notifyAuthTokensChanged();
+}
+
+export function readAuthTokensFromSearchParams(
+  searchParams: URLSearchParams,
+): AuthTokens | null {
+  const accessToken = searchParams.get('accessToken')?.trim();
+  const refreshToken = searchParams.get('refreshToken')?.trim();
+
+  if (!accessToken) return null;
+
+  return {
+    accessToken,
+    refreshToken,
+  };
+}

--- a/apps/fe/src/lib/axios.ts
+++ b/apps/fe/src/lib/axios.ts
@@ -1,19 +1,24 @@
 import axios from 'axios';
+import { clearAuthTokens, getAccessToken } from './auth';
+import { getApiBaseUrl } from './apiBaseUrl';
+
+const API_BASE_URL = getApiBaseUrl();
 
 const instance = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_URL,
+  baseURL: API_BASE_URL,
   timeout: 10000,
   headers: {
-    'Content-Type': 'application/json',
+    Accept: 'application/json',
   },
 });
 
 instance.interceptors.request.use((config) => {
-  const token =
-    typeof window !== 'undefined' ? localStorage.getItem('token') : null;
+  const token = getAccessToken();
+
   if (token) {
     config.headers.Authorization = `Bearer ${token}`;
   }
+
   return config;
 });
 
@@ -21,8 +26,9 @@ instance.interceptors.response.use(
   (response) => response,
   (error) => {
     if (error.response?.status === 401) {
-      // TODO: 토큰 만료 처리 (리다이렉트 등)
+      clearAuthTokens();
     }
+
     return Promise.reject(error);
   },
 );

--- a/apps/fe/src/providers/AuthProvider.tsx
+++ b/apps/fe/src/providers/AuthProvider.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+import {
+  ACCESS_TOKEN_STORAGE_KEY,
+  AUTH_TOKENS_CHANGED_EVENT,
+  LEGACY_ACCESS_TOKEN_STORAGE_KEY,
+  REFRESH_TOKEN_STORAGE_KEY,
+  getAccessToken,
+  readAuthTokensFromSearchParams,
+  setAuthTokens,
+} from '@/lib/auth';
+
+type AuthContextValue = {
+  hasAccessToken: boolean;
+};
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+function removeTokenParamsFromCurrentUrl(url: URL) {
+  const shouldReplace =
+    url.searchParams.has('accessToken') || url.searchParams.has('refreshToken');
+
+  if (!shouldReplace) return;
+
+  url.searchParams.delete('accessToken');
+  url.searchParams.delete('refreshToken');
+  window.history.replaceState(
+    window.history.state,
+    '',
+    `${url.pathname}${url.search}${url.hash}`,
+  );
+}
+
+export default function AuthProvider({ children }: { children: ReactNode }) {
+  const [hasAccessToken, setHasAccessToken] = useState(
+    () => typeof window !== 'undefined' && Boolean(getAccessToken()),
+  );
+
+  useEffect(() => {
+    const syncAccessToken = () => {
+      setHasAccessToken(Boolean(getAccessToken()));
+    };
+
+    const currentUrl = new URL(window.location.href);
+    const redirectedTokens = readAuthTokensFromSearchParams(
+      currentUrl.searchParams,
+    );
+
+    if (redirectedTokens) {
+      setAuthTokens(redirectedTokens);
+      removeTokenParamsFromCurrentUrl(currentUrl);
+    }
+
+    syncAccessToken();
+
+    const handleStorage = (event: StorageEvent) => {
+      if (
+        event.key === ACCESS_TOKEN_STORAGE_KEY ||
+        event.key === REFRESH_TOKEN_STORAGE_KEY ||
+        event.key === LEGACY_ACCESS_TOKEN_STORAGE_KEY
+      ) {
+        syncAccessToken();
+      }
+    };
+
+    window.addEventListener(AUTH_TOKENS_CHANGED_EVENT, syncAccessToken);
+    window.addEventListener('storage', handleStorage);
+
+    return () => {
+      window.removeEventListener(AUTH_TOKENS_CHANGED_EVENT, syncAccessToken);
+      window.removeEventListener('storage', handleStorage);
+    };
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      hasAccessToken,
+    }),
+    [hasAccessToken],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuthSession() {
+  const context = useContext(AuthContext);
+
+  if (!context) {
+    throw new Error('useAuthSession must be used within AuthProvider');
+  }
+
+  return context;
+}


### PR DESCRIPTION
﻿## 요약
- 프로덕션 FE에서 `/login`이 404가 나던 문제를 해결하고 OAuth 콜백 토큰 저장 흐름을 main에 복구했습니다.

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [x] 문서
- [ ] 테스트
- [ ] 기타

- `/login` route handler를 추가해 BE Google OAuth 진입점으로 리다이렉트합니다.
- 로그인/회원가입 버튼을 동일하게 `/login` OAuth 진입으로 연결합니다.
- OAuth redirect query의 `accessToken`/`refreshToken`을 localStorage에 저장하고 URL에서 제거하는 AuthProvider를 연결합니다.
- `NEXT_PUBLIC_API_URL`이 없을 때도 `https://api-stg.asklogue.co`로 폴백해 Preview와 Production 런타임 모두 `/login`이 동작하도록 했습니다.

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `NEXT_PUBLIC_VERCEL_ENV=preview yarn build`
  - `NEXT_PUBLIC_API_URL=https://api-stg.asklogue.co yarn build`
  - `NEXT_PUBLIC_API_URL`/`VERCEL_ENV` 없이 `yarn build` → `/login` route 포함 확인
  - `yarn eslint src/app/login/route.ts src/lib/apiBaseUrl.ts src/lib/auth.ts src/providers/AuthProvider.tsx src/app/layout.tsx src/app/page.tsx src/lib/axios.ts`
  - `next start` production 시뮬레이션(`NEXT_PUBLIC_VERCEL_ENV=production`, `NEXT_PUBLIC_API_URL` 미설정) 후 `curl -I /login` → `307 Temporary Redirect`, `location: https://api-stg.asklogue.co/oauth2/authorization/google`
  - 참고: `yarn lint` 전체 실행은 기존 Storybook/Prettier 오류로 실패했습니다. 이번 변경 파일 대상 lint는 통과했습니다.

## 스크린샷/로그 (선택)
- production 런타임 시뮬레이션 결과: `/` 200, `/login` 307 → `https://api-stg.asklogue.co/oauth2/authorization/google`

## 롤백/리스크
- 리스크 포인트: `NEXT_PUBLIC_API_URL`이 없으면 Production도 stg API로 폴백합니다. 추후 prod BE API host가 확정되면 Vercel Production env에 명시적으로 설정해야 합니다.
- 롤백 방법: 이 PR 머지 커밋을 revert합니다.

## 관련 이슈
Closes #149
