### PR TITLE
fix: LiteLLM prompt를 파일로 넘겨 ARG_MAX 회피 (#151)

### DIFF
--- a/scripts/refactor-scan/call_litellm.sh
+++ b/scripts/refactor-scan/call_litellm.sh
@@ -10,24 +10,29 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 2
 fi
 
-prompt="$(cat)"
-if [[ -z "$prompt" ]]; then
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+prompt_file="$tmpdir/prompt"
+payload_file="$tmpdir/payload"
+body_file="$tmpdir/body"
+status_file="$tmpdir/status"
+
+cat > "$prompt_file"
+if [[ ! -s "$prompt_file" ]]; then
   echo "error: empty prompt on stdin" >&2
   exit 2
 fi
 
-payload="$(
-  jq -n \
-    --arg model "$LITELLM_MODEL" \
-    --arg content "$prompt" \
-    --argjson max_tokens "$LITELLM_MAX_TOKENS" \
-    '{
-      model: $model,
-      max_tokens: $max_tokens,
-      temperature: 0.2,
-      messages: [{role: "user", content: $content}]
-    }'
-)"
+jq -n \
+  --arg model "$LITELLM_MODEL" \
+  --rawfile content "$prompt_file" \
+  --argjson max_tokens "$LITELLM_MAX_TOKENS" \
+  '{
+    model: $model,
+    max_tokens: $max_tokens,
+    temperature: 0.2,
+    messages: [{role: "user", content: $content}]
+  }' > "$payload_file"
 
 endpoint="${LITELLM_BASE_URL%/}/v1/chat/completions"
 
@@ -45,11 +50,6 @@ if [[ ${#keys[@]} -eq 0 ]]; then
   exit 2
 fi
 
-tmpdir="$(mktemp -d)"
-trap 'rm -rf "$tmpdir"' EXIT
-body_file="$tmpdir/body"
-status_file="$tmpdir/status"
-
 call_once() {
   local key="$1"
   : >"$body_file"
@@ -63,7 +63,7 @@ call_once() {
       --write-out '%{http_code}' \
       --header "Authorization: Bearer $key" \
       --header 'Content-Type: application/json' \
-      --data "$payload" \
+      --data-binary @"$payload_file" \
       "$endpoint" 2>"$tmpdir/curl_err"
     echo "__exit:$?"
   )"


### PR DESCRIPTION
## 요약
- refactor-scan 워크플로의 `Call LiteLLM` 스텝이 `jq: Argument list too long` 으로 실패하던 문제 수정. prompt와 payload를 임시 파일로 넘겨 ARG_MAX 한계를 회피.

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

`scripts/refactor-scan/call_litellm.sh`:
- `tmpdir` 생성/trap을 스크립트 윗부분으로 옮기고 prompt/payload/body/status 모두 같은 디렉터리에 둠
- stdin은 변수 대신 `$tmpdir/prompt` 파일로 받음
- `jq -n --arg content "$prompt"` → `jq -n --rawfile content "$prompt_file"` 로 교체, payload는 `> "$payload_file"` 로 떨굼
- `curl --data "$payload"` → `curl --data-binary @"$payload_file"` 로 교체 (curl 쪽 ARG_MAX도 잠재 위험이라 동시 처리)
- 중복으로 선언되던 `tmpdir`/`trap`/`body_file`/`status_file` 한 곳으로 정리

## 테스트
- [x] 로컬 `bash -n` 문법 체크 통과
- 테스트 방법:
  - dev에 머지 후 다음 push 발생 시 `Refactor Scan` 워크플로의 `Call LiteLLM` 스텝이 통과하는지 확인
  - `workflow_dispatch`로 수동 실행 + `dry_run=true`로 안전하게 검증 가능
  - 큰 prompt(예: 200KB 이상)에서도 스크립트가 죽지 않는지 확인

## 스크린샷/로그 (선택)
실패 run 예시: https://github.com/26-ewha-capstone-logue/logue/actions/runs/26331556272
```
scripts/refactor-scan/call_litellm.sh: line 30: /usr/bin/jq: Argument list too long
```

## 롤백/리스크
- 리스크: 거의 없음. LiteLLM API 호출 페이로드 내용 자체는 동일하고, 데이터 전달 방식만 인자에서 파일로 변경. `--data-binary`는 `--data`와 달리 개행 변환을 안 하지만 JSON payload라 영향 없음.
- 롤백: `git revert <commit>` 후 푸시. 단 revert하면 동일 에러 재발.

## 관련 이슈
Closes #151