### PR TITLE
fix: CORS 허용 도메인을 asklogue.co로 갱신 (#157)

### DIFF
--- a/apps/be/src/main/java/com/capstone/logue/global/config/SecurityConfig.java
+++ b/apps/be/src/main/java/com/capstone/logue/global/config/SecurityConfig.java
@@ -46,7 +46,9 @@ public class SecurityConfig {
         config.setAllowedOriginPatterns(List.of(
                 "http://localhost:5173",
                 "http://localhost:3000",
-                "https://www.logue-kr.site"
+                "https://asklogue.co",
+                "https://www.asklogue.co",
+                "https://logue-git-dev-maetelson-s-projects.vercel.app"
         ));
         config.setAllowCredentials(true);
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));


### PR DESCRIPTION
## 요약
- BE CORS 허용 도메인을 신규 도메인(asklogue.co)으로 갱신해 prod에서 user API 호출이 막히던 문제 해소

## 변경 사항
- [x] 버그 수정

## 테스트
- [ ] 로컬 테스트 완료
- 테스트 방법:
  - 재배포 후 prod 환경에서 로그인 → user 정보 API 호출이 CORS 차단 없이 정상 응답 확인
  - 브라우저 콘솔에 CORS 에러 미발생 확인

## 스크린샷/로그 (선택)
- 필요한 경우 첨부

## 롤백/리스크
- 리스크 포인트:
  - www.asklogue.co가 실제 운영 도메인이 아닐 경우 무해하지만 불필요 항목으로 남음
  - Vercel preview 도메인은 PR별로 달라질 수 있어 위 한 개 외 preview는 여전히 차단됨
- 롤백 방법: 이 PR revert 후 재배포

## 관련 이슈
Closes #157