### PR TITLE
fix: 분석 화면 헤더 인증 동작 개선

### DIFF
--- a/apps/fe/src/app/(main)/layout.tsx
+++ b/apps/fe/src/app/(main)/layout.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { CSSProperties } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { usePathname, useRouter } from 'next/navigation';
 import { getMyInfo, userKeys, type GetUserInfoResponse } from '@/apis/user';
 import { Header, type NavItem } from '@/components';
@@ -9,6 +9,7 @@ import FileIcon from '@/assets/icons/file.svg';
 import GTapIcon from '@/assets/icons/G-tap.svg';
 import GHistoryIcon from '@/assets/icons/G-history.svg';
 import SearchIcon from '@/assets/icons/search.svg';
+import { clearAuthTokens } from '@/lib/auth';
 import { useAuthSession } from '@/providers/AuthProvider';
 
 const NAV_ITEMS: NavItem[] = [
@@ -95,6 +96,7 @@ export default function MainLayout({
 }) {
   const router = useRouter();
   const pathname = usePathname();
+  const queryClient = useQueryClient();
   const { hasAccessToken } = useAuthSession();
   const {
     data: myInfo,
@@ -108,12 +110,27 @@ export default function MainLayout({
   });
 
   const showDataSearch = pathname.startsWith('/data');
+  const handleLogout = () => {
+    clearAuthTokens();
+    queryClient.removeQueries({ queryKey: userKeys.me() });
+    router.replace('/');
+  };
+
   const profileSlot = hasAccessToken ? (
-    <UserProfileSlot
-      user={myInfo}
-      isLoading={isUserInfoLoading}
-      isError={isUserInfoError}
-    />
+    <div className="flex items-center gap-12">
+      <UserProfileSlot
+        user={myInfo}
+        isLoading={isUserInfoLoading}
+        isError={isUserInfoError}
+      />
+      <button
+        type="button"
+        onClick={handleLogout}
+        className="rounded-full border border-gray-300 px-12 py-8 text-body4 font-medium text-gray-700 transition-colors hover:border-orange-500 hover:text-orange-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-orange-500"
+      >
+        로그아웃
+      </button>
+    </div>
   ) : undefined;
 
   return (

--- a/apps/fe/src/app/(main)/layout.tsx
+++ b/apps/fe/src/app/(main)/layout.tsx
@@ -9,7 +9,7 @@ import FileIcon from '@/assets/icons/file.svg';
 import GTapIcon from '@/assets/icons/G-tap.svg';
 import GHistoryIcon from '@/assets/icons/G-history.svg';
 import SearchIcon from '@/assets/icons/search.svg';
-import { clearAuthTokens } from '@/lib/auth';
+import { clearAuthTokens, skipNextAuthEntryRedirect } from '@/lib/auth';
 import { useAuthSession } from '@/providers/AuthProvider';
 
 const NAV_ITEMS: NavItem[] = [
@@ -115,6 +115,10 @@ export default function MainLayout({
     queryClient.removeQueries({ queryKey: userKeys.me() });
     router.replace('/');
   };
+  const handleLogoClick = () => {
+    skipNextAuthEntryRedirect();
+    router.push('/');
+  };
 
   const profileSlot = hasAccessToken ? (
     <div className="flex items-center gap-12">
@@ -140,7 +144,7 @@ export default function MainLayout({
         activeHref={pathname}
         profileSlot={profileSlot}
         searchSlot={showDataSearch ? <DataSourceSearchInput /> : undefined}
-        onLogoClick={() => router.push('/analysis')}
+        onLogoClick={handleLogoClick}
         onNavClick={(href) => router.push(href)}
         onProfileClick={() => router.push('/login')}
       />

--- a/apps/fe/src/lib/auth.ts
+++ b/apps/fe/src/lib/auth.ts
@@ -7,12 +7,24 @@ export const ACCESS_TOKEN_STORAGE_KEY = 'accessToken';
 export const REFRESH_TOKEN_STORAGE_KEY = 'refreshToken';
 export const LEGACY_ACCESS_TOKEN_STORAGE_KEY = 'token';
 export const AUTH_TOKENS_CHANGED_EVENT = 'logue:auth-tokens-changed';
+const AUTH_ENTRY_REDIRECT_BYPASS_STORAGE_KEY =
+  'logue:auth-entry-redirect-bypass';
 
 function getOptionalLocalStorage() {
   if (typeof window === 'undefined') return null;
 
   try {
     return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function getOptionalSessionStorage() {
+  if (typeof window === 'undefined') return null;
+
+  try {
+    return window.sessionStorage;
   } catch {
     return null;
   }
@@ -86,6 +98,31 @@ export function clearAuthTokens() {
   removeStorageItem(REFRESH_TOKEN_STORAGE_KEY);
   removeStorageItem(LEGACY_ACCESS_TOKEN_STORAGE_KEY);
   notifyAuthTokensChanged();
+}
+
+export function skipNextAuthEntryRedirect() {
+  const storage = getOptionalSessionStorage();
+  if (!storage) return;
+
+  try {
+    storage.setItem(AUTH_ENTRY_REDIRECT_BYPASS_STORAGE_KEY, 'true');
+  } catch {
+    // Ignore browsers that block sessionStorage.
+  }
+}
+
+export function consumeAuthEntryRedirectBypass() {
+  const storage = getOptionalSessionStorage();
+  if (!storage) return false;
+
+  try {
+    const shouldBypass =
+      storage.getItem(AUTH_ENTRY_REDIRECT_BYPASS_STORAGE_KEY) === 'true';
+    storage.removeItem(AUTH_ENTRY_REDIRECT_BYPASS_STORAGE_KEY);
+    return shouldBypass;
+  } catch {
+    return false;
+  }
 }
 
 export function readAuthTokensFromSearchParams(

--- a/apps/fe/src/providers/AuthProvider.tsx
+++ b/apps/fe/src/providers/AuthProvider.tsx
@@ -14,6 +14,7 @@ import {
   AUTH_TOKENS_CHANGED_EVENT,
   LEGACY_ACCESS_TOKEN_STORAGE_KEY,
   REFRESH_TOKEN_STORAGE_KEY,
+  consumeAuthEntryRedirectBypass,
   getAccessToken,
   readAuthTokensFromSearchParams,
   setAuthTokens,
@@ -75,11 +76,15 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
     }
 
     const nextHasAccessToken = syncAccessToken();
+    const shouldBypassAuthEntryRedirect =
+      shouldRedirectAuthenticatedUser(pathname) &&
+      consumeAuthEntryRedirectBypass();
 
     if (
       !redirectedTokens &&
       nextHasAccessToken &&
-      shouldRedirectAuthenticatedUser(pathname)
+      shouldRedirectAuthenticatedUser(pathname) &&
+      !shouldBypassAuthEntryRedirect
     ) {
       replaceLocation(AUTH_REDIRECT_PATH);
       return;


### PR DESCRIPTION
﻿## 요약
- 분석 화면 헤더에 로그인 상태에서 사용할 수 있는 로그아웃 버튼을 추가했습니다.
- 헤더 로고 클릭 시 홈(`/`)으로 이동하고, 해당 클릭에 한해 인증 진입 리다이렉트를 건너뛰도록 처리했습니다.

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `yarn lint`
  - 로컬 브라우저에서 `/?accessToken=dev-token` 진입 후 `/analysis` 이동 확인
  - 분석 화면 헤더의 `로그아웃` 버튼 노출 확인
  - Logue 로고 클릭 후 `/`에 머무는지 확인

## 스크린샷/로그 (선택)
- 로컬 브라우저에서 로고 클릭 후 홈 화면 유지 확인

## 롤백/리스크
- 리스크 포인트: `sessionStorage`를 차단하는 브라우저에서는 bypass flag 저장이 실패할 수 있으며, 이 경우 기존 인증 리다이렉트 동작으로 fallback됩니다.
- 롤백 방법: 본 PR revert

## 관련 이슈
Closes #163


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 로그아웃 기능이 추가되었습니다.

* **개선 사항**
  * 로고 클릭 시 홈페이지로 이동하도록 변경되었습니다.
  * 인증 상태 관리가 개선되어 더욱 안정적인 사용자 경험을 제공합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/26-ewha-capstone-logue/logue/pull/164?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->