### PR TITLE
fix: AnalService summary 조회/취소 시 잘못된 repository 메서드 호출 수정 (#165)

### DIFF
--- a/apps/be/src/main/java/com/capstone/logue/anal/service/AnalService.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/service/AnalService.java
@@ -175,7 +175,7 @@ public class AnalService {
                 .orElseThrow(() -> new LogueException(ErrorCode.DATASOURCE_NOT_FOUND));
 
         AiTaggingJob job = aiTaggingJobRepository
-                .findTopByConversationIdAndStageOrderByCreatedAtDesc(analysisFlowId, JobStage.DATA_STATUS)
+                .findTopByAnalysisFlowIdAndStageOrderByCreatedAtDescIdDesc(analysisFlowId, JobStage.DATA_STATUS)
                 .orElseThrow(() -> new LogueException(ErrorCode.JOB_NOT_FOUND));
 
         if (job.getStatus() != JobStatus.SUCCESS) {
@@ -231,8 +231,8 @@ public class AnalService {
         validateConversationAccess(conversationId, analysisFlowId);
 
         AiTaggingJob job = aiTaggingJobRepository
-                .findTopByConversationIdAndStageOrderByCreatedAtDesc(analysisFlowId, JobStage.DATA_STATUS)
-                .orElseThrow(() -> new LogueException(ErrorCode.INTERNAL_SERVER_ERROR));
+                .findTopByAnalysisFlowIdAndStageOrderByCreatedAtDescIdDesc(analysisFlowId, JobStage.DATA_STATUS)
+                .orElseThrow(() -> new LogueException(ErrorCode.JOB_NOT_FOUND));
 
         return new GetSummaryStatusResponse(job.getStatus().name());
     }
@@ -251,8 +251,8 @@ public class AnalService {
         validateConversationAccess(conversationId, analysisFlowId);
 
         AiTaggingJob job = aiTaggingJobRepository
-                .findTopByConversationIdAndStageOrderByCreatedAtDesc(analysisFlowId, JobStage.DATA_STATUS)
-                .orElseThrow(() -> new LogueException(ErrorCode.INTERNAL_SERVER_ERROR));
+                .findTopByAnalysisFlowIdAndStageOrderByCreatedAtDescIdDesc(analysisFlowId, JobStage.DATA_STATUS)
+                .orElseThrow(() -> new LogueException(ErrorCode.JOB_NOT_FOUND));
 
         if (job.getStatus() != JobStatus.QUEUED && job.getStatus() != JobStatus.RUNNING) {
             throw new LogueException(ErrorCode.SUMMARY_NOT_STARTED);


### PR DESCRIPTION
## 요약
- AnalService에서 summary 조회/취소 시 conversationId로 job을 잘못 조회하던 버그 수정

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [ ] 로컬 테스트 완료
- 테스트 방법:
  1. CSV 업로드 후 conversation 생성 (id=N)
  2. analysisFlows 두 번 생성 → flow=1, flow=2
  3. `GET .../analysisFlows/2/summary/status` 폴링
  4. 기존: 500 C004 / 수정 후: 200 + status 정상 반환 확인

## 스크린샷/로그 (선택)
- 필요한 경우 첨부

## 롤백/리스크
- 리스크 포인트: 낮음 — repository 메서드 교체만으로 다른 로직 변경 없음
- 롤백 방법: 세 줄 revert 후 재배포

## 관련 이슈
Closes #165 
