### PR TITLE
fix: 분석에서 참조 중인 데이터 소스 삭제 시 500 → 409 (#166)

### DIFF
--- a/apps/be/src/main/java/com/capstone/logue/global/exception/ErrorCode.java
+++ b/apps/be/src/main/java/com/capstone/logue/global/exception/ErrorCode.java
@@ -32,6 +32,7 @@ public enum ErrorCode {
     DATASOURCE_STORAGE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "D004", "데이터 소스 파일 저장/읽기에 실패했습니다."),
     DATASOURCE_INVALID_PAGE_PARAM(HttpStatus.BAD_REQUEST, "D005", "잘못된 페이지 요청 파라미터입니다."),
     COLUMN_NOT_FOUND(HttpStatus.BAD_GATEWAY, "D006", "FastAPI 응답에 알 수 없는 컬럼명이 포함되어 있습니다."),
+    DATASOURCE_IN_USE(HttpStatus.CONFLICT, "D007", "분석 흐름에서 사용 중인 데이터 소스는 삭제할 수 없습니다."),
     SUMMARY_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "D101", "데이터 요약이 완료되지 않았습니다."),
     SUMMARY_NOT_STARTED(HttpStatus.BAD_REQUEST, "D102", "데이터 요약이 시작되지 않았습니다."),
 

--- a/apps/be/src/main/java/com/capstone/logue/global/exception/GlobalExceptionHandler.java
+++ b/apps/be/src/main/java/com/capstone/logue/global/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import com.capstone.logue.global.response.ApiResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
@@ -67,6 +68,14 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(ErrorCode.RESOURCE_NOT_FOUND.getHttpStatus())
                 .body(ApiResponse.error(ErrorCode.RESOURCE_NOT_FOUND));
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ApiResponse<Void>> handleDataIntegrityViolation(DataIntegrityViolationException e, HttpServletRequest request) {
+        log.warn("[DataIntegrityViolation] {} {} - {}", request.getMethod(), request.getRequestURI(), e.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.DATASOURCE_IN_USE.getHttpStatus())
+                .body(ApiResponse.error(ErrorCode.DATASOURCE_IN_USE));
     }
 
     @ExceptionHandler(Exception.class)


### PR DESCRIPTION
## 요약
- `analysis_flows` 에서 참조 중인 데이터 소스 삭제 시 발생하던 FK 위반(`DataIntegrityViolationException`)이 catch-all 로 떨어져 500 응답되던 문제를 409 + 명확한 메시지로 응답하도록 핸들러 추가

## 변경 사항
- [x] 버그 수정

## 테스트
- [ ] 로컬 테스트 완료
- 테스트 방법:
  - CSV 업로드 → conversation/analysisFlow 생성으로 datasource 참조 상태 만들기
  - `DELETE /api/datasources/{id}` 호출 → 409 + `D007` 응답 확인 (이전엔 500 C004)
  - 참조 없는 datasource 삭제는 정상 200 유지 확인

## 스크린샷/로그 (선택)
이전 (500):
```
[UnhandledException] could not execute statement
DataIntegrityViolationException: violates foreign key constraint
  "analysis_flows_data_source_id_fkey"
```

## 롤백/리스크
- 리스크 포인트:
  - `DataIntegrityViolationException` 은 datasource 외 다른 FK/unique 위반에서도 발생 가능. 현재 코드베이스에선 datasource 삭제 케이스만 확인되었으나, 향후 다른 FK 위반 시에도 `D007`(데이터 소스 사용 중) 으로 응답될 수 있음
  - 후속으로 케이스별 분기 또는 cascade/soft delete 정책 도입 검토 필요 (이슈 #166 작업 범위 항목 2/3)
- 롤백 방법: 이 PR revert (기존 catch-all 로 복귀, 다시 500 응답)

## 관련 이슈
Closes #166