### PR TITLE
fix: 필수 query param 누락/타입 미스매치 시 500 → 400 (#167)

### DIFF
--- a/apps/be/src/main/java/com/capstone/logue/global/exception/ErrorCode.java
+++ b/apps/be/src/main/java/com/capstone/logue/global/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C003", "지원하지 않는 HTTP 메서드입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C004", "서버 내부 오류가 발생했습니다."),
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "C005", "요청한 리소스를 찾을 수 없습니다."),
+    MISSING_REQUEST_PARAMETER(HttpStatus.BAD_REQUEST, "C006", "필수 요청 파라미터가 누락되었습니다."),
 
     // Auth
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "A001", "인증이 필요합니다."),

--- a/apps/be/src/main/java/com/capstone/logue/global/exception/GlobalExceptionHandler.java
+++ b/apps/be/src/main/java/com/capstone/logue/global/exception/GlobalExceptionHandler.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @Slf4j
@@ -53,6 +54,14 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(ErrorCode.MISSING_REQUEST_PARAMETER.getHttpStatus())
                 .body(ApiResponse.error(ErrorCode.MISSING_REQUEST_PARAMETER));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiResponse<Void>> handleArgumentTypeMismatch(MethodArgumentTypeMismatchException e) {
+        log.warn("[ArgumentTypeMismatch] {}", e.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.INVALID_TYPE.getHttpStatus())
+                .body(ApiResponse.error(ErrorCode.INVALID_TYPE));
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)

--- a/apps/be/src/main/java/com/capstone/logue/global/exception/GlobalExceptionHandler.java
+++ b/apps/be/src/main/java/com/capstone/logue/global/exception/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
@@ -44,6 +45,14 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(ErrorCode.INVALID_INPUT.getHttpStatus())
                 .body(ApiResponse.error(ErrorCode.INVALID_INPUT));
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMissingRequestParameter(MissingServletRequestParameterException e) {
+        log.warn("[MissingRequestParameter] {}", e.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.MISSING_REQUEST_PARAMETER.getHttpStatus())
+                .body(ApiResponse.error(ErrorCode.MISSING_REQUEST_PARAMETER));
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)


### PR DESCRIPTION
## 요약
- required 로 선언된 query param 이 누락되거나 타입이 안 맞을 때 catch-all 로 떨어져 500 응답되던 문제를 400 + 명확한 코드로 응답하도록 핸들러 추가

## 변경 사항
- [x] 버그 수정

## 테스트
- [ ] 로컬 테스트 완료
- 테스트 방법:
  - `GET /api/datasources` (page/size 누락) → 400 + `C006` (이전 500 C004)
  - `DELETE /api/datasources` (id 누락) → 400 + `C006`
  - `GET /api/datasources/abc` (타입 미스매치) → 400 + `C002`
  - 정상 호출은 영향 없는지 확인

## 스크린샷/로그 (선택)
이전 (500):
```
[UnhandledException] Required request parameter 'page' for method parameter type int is not present
org.springframework.web.bind.MissingServletRequestParameterException
```

## 롤백/리스크
- 리스크 포인트:
  - 핸들러는 catch-all 보다 먼저 매칭되도록 위치만 추가했고 기존 ErrorCode/메시지 형식 유지. 기존 응답 포맷 깨질 위험 낮음
  - 응답 메시지가 고정 문구라 어떤 파라미터가 누락됐는지 클라이언트는 모름. 필요 시 후속으로 ApiResponse 확장(동적 메시지)
- 롤백 방법: 이 PR revert (catch-all 로 복귀, 다시 500)

## 관련 이슈
Closes #167