### PR TITLE
fix: AI Dockerfile에 누락된 모듈 디렉토리 COPY 추가

### DIFF
--- a/apps/ai/Dockerfile
+++ b/apps/ai/Dockerfile
@@ -8,6 +8,10 @@ COPY pyproject.toml uv.lock ./
 RUN uv sync --no-dev --frozen --no-cache
 
 COPY main.py .
+COPY core ./core
+COPY routers ./routers
+COPY schemas ./schemas
+COPY services ./services
 
 EXPOSE 8000
 


### PR DESCRIPTION
## 요약
- AI 컨테이너가 시작 즉시 `ModuleNotFoundError: No module named 'core'` 로 crash 하던 문제 수정. Dockerfile 이 `main.py` 만 복사하고 `core/`, `routers/`, `schemas/`, `services/` 디렉토리를 빠뜨려 발생

## 변경 사항
- [x] 버그 수정

## 테스트
- [ ] 로컬 테스트 완료
- 테스트 방법:
  - 로컬: `cd apps/ai && docker build -t logue-ai-local . && docker run --rm -p 8000:8000 logue-ai-local` 후 컨테이너가 crash 없이 떠 있는지 확인
  - 배포 후: `curl https://ai.asklogue.co/openapi.json` 로 `/v1/llm/data-sources/analyze`, `/v1/llm/analysis-criteria/resolve`, `/v1/llm/analysis-results/describe` 라우트가 노출되는지 확인
  - BE → AI 호출 정상화: BE 에서 새 AnalysisFlow 생성 후 summary status 가 `FAILED` 즉시 안 되고 `RUNNING/SUCCESS` 로 흐르는지 확인

## 스크린샷/로그 (선택)
ai-deploy 첫 성공 직후 컨테이너 crash 로그:
```
File "/app/main.py", line 13, in <module>
    from core.exception_handlers import register_exception_handlers
ModuleNotFoundError: No module named 'core'
```

## 롤백/리스크
- 리스크 포인트:
  - 명시적 COPY 만 추가했으므로 추후 `apps/ai/` 에 새 top-level 패키지가 생기면 Dockerfile 에도 같이 추가해야 함. 차후 `COPY . .` + `.dockerignore` 패턴으로 단순화 고려
  - 이미지 크기 약간 증가 (의도된 모듈만 포함이라 영향 작음)
- 롤백 방법: 이 PR revert (다시 ModuleNotFoundError 로 컨테이너 crash)

## 관련 이슈
- 관련 PR #173 (release: dev to main) — 머지되면 main 에 반영되어 ai-deploy 자동 트리거