### PR TITLE
fix: FileAnalysisRequest.requestId 타입 String 으로 변경 (#176)

### DIFF
--- a/apps/be/src/main/java/com/capstone/logue/anal/dto/fastapi/request/FileAnalysisRequest.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/dto/fastapi/request/FileAnalysisRequest.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * FastAPI POST /v1/llm/data-sources/analyze 요청 DTO입니다.
  */
 public record FileAnalysisRequest (
-    Long requestId,
+    String requestId,
 
     DataSourceMetaInfo dataSource,
 

--- a/apps/be/src/main/java/com/capstone/logue/anal/service/FileAnalysisAsyncService.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/service/FileAnalysisAsyncService.java
@@ -177,7 +177,7 @@ public class FileAnalysisAsyncService {
      */
     private FileAnalysisRequest buildRequest(Long jobId, DataSource dataSource) {
         return fileAnalysisRequestBuilder.build(
-                jobId,
+                String.valueOf(jobId),
                 dataSource.getId(),
                 dataSource.getFileName(),
                 dataSource.getRowCount(),

--- a/apps/be/src/main/java/com/capstone/logue/anal/service/FileAnalysisRequestBuilder.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/service/FileAnalysisRequestBuilder.java
@@ -35,7 +35,7 @@ public class FileAnalysisRequestBuilder {
      * @return FastAPI 전송용 {@link FileAnalysisRequest}
      */
     public FileAnalysisRequest build(
-            Long requestId,
+            String requestId,
             Long dataSourceId,
             String fileName,
             int rowCount,


### PR DESCRIPTION
## 요약
- BE → AI(`POST /v1/llm/data-sources/analyze`) 호출이 422 (`request_id: Input should be a valid string`) 로 거부되던 문제 수정. `FileAnalysisRequest.requestId` 만 `Long` 으로 선언되어 있어 AI 스키마(`str`) 와 타입 불일치였음. 호출 체인(record → builder → service) 3 곳을 atomic 으로 String 으로 정렬

## 변경 사항
- [x] 버그 수정

## 테스트
- [ ] 로컬 테스트 완료
- 테스트 방법:
  - 재배포 후 stg 에서 CSV 업로드 → conversation → analysisFlow 생성
  - `GET .../summary/status` 폴링 시 `FAILED` 즉시 안 되고 `QUEUED/RUNNING/SUCCESS` 로 흐르는지
  - BE 로그에 `HttpClientErrorException$UnprocessableEntity` 없는지

## 스크린샷/로그 (선택)
이전 (round 3):
```
422 Unprocessable Entity on POST request for "https://ai.asklogue.co/v1/llm/data-sources/analyze":
{"request_id":null,"error_code":"REQUEST_VALIDATION_FAILED",
 "details":[{"field":"request_id","reason":"Input should be a valid string"}]}
```

## 정합성 추가 점검 결과 (참고)
이슈 본문 작업 범위로 BE↔AI FastAPI DTO 전체 정합성 다시 훑었고, 실제 문제는 위 한 곳뿐이었음
- snake_case 직렬화: `AppConfig.fastApiRestTemplate` 의 `SnakeCaseStrategy` 가 이미 적용되어 있어 추가 작업 0
- 누락/이상 필드: BE request 16종 + response 14종 모두 AI `apps/ai/schemas/*` 와 매칭 OK
- `requestId` 타입: `QuestionAnalysisRequest`, `AnalysisSummaryRequest` 와 모든 response 는 처음부터 `String` 이었고 오직 `FileAnalysisRequest` 만 `Long`

## 롤백/리스크
- 리스크 포인트:
  - `FileAnalysisRequestBuilder.build` 시그니처가 `Long → String` 으로 바뀌어 추가 호출부가 있었다면 컴파일 깨짐. 현재 호출부는 `FileAnalysisAsyncService.buildRequest` 1 곳뿐이라 영향 없음
- 롤백 방법: 이 PR revert (다시 422 로 복귀)

## 관련 이슈
Closes #176