### PR TITLE
fix: 빈 CSV(헤더만, rows=0) 업로드 시 200 반환

### DIFF
--- a/apps/be/src/main/java/com/capstone/logue/data/service/DataSourceService.java
+++ b/apps/be/src/main/java/com/capstone/logue/data/service/DataSourceService.java
@@ -80,6 +80,9 @@ public class DataSourceService {
         }
 
         FilePreview preview = csvParser.parse(new ByteArrayInputStream(bytes));
+        if (preview.rows().isEmpty()) {
+            throw new LogueException(ErrorCode.DATASOURCE_EMPTY_ROWS);
+        }
 
         String storageKey = storage.store(
                 userId,

--- a/apps/be/src/main/java/com/capstone/logue/global/exception/ErrorCode.java
+++ b/apps/be/src/main/java/com/capstone/logue/global/exception/ErrorCode.java
@@ -34,6 +34,7 @@ public enum ErrorCode {
     DATASOURCE_INVALID_PAGE_PARAM(HttpStatus.BAD_REQUEST, "D005", "잘못된 페이지 요청 파라미터입니다."),
     COLUMN_NOT_FOUND(HttpStatus.BAD_GATEWAY, "D006", "FastAPI 응답에 알 수 없는 컬럼명이 포함되어 있습니다."),
     DATASOURCE_IN_USE(HttpStatus.CONFLICT, "D007", "분석 흐름에서 사용 중인 데이터 소스는 삭제할 수 없습니다."),
+    DATASOURCE_EMPTY_ROWS(HttpStatus.BAD_REQUEST, "D008", "데이터 행이 없습니다. 최소 1개 이상의 데이터 행이 필요합니다."),
     SUMMARY_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "D101", "데이터 요약이 완료되지 않았습니다."),
     SUMMARY_NOT_STARTED(HttpStatus.BAD_REQUEST, "D102", "데이터 요약이 시작되지 않았습니다."),
 


### PR DESCRIPTION
## 요약
- 빈 CSV(헤더만, rows=0) 업로드 시 200 반환되던 문제를 업로드 단계에서 400으로 차단

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [ ] 로컬 테스트 완료
- 테스트 방법:

## 스크린샷/로그 (선택)
- 생략

## 롤백/리스크
- 리스크 포인트: 기존에 빈 CSV 업로드를 허용하던 동작에 의존하는 케이스 있을 경우 영향 (가능성 낮음)
- 롤백 방법: `DataSourceService.upload()` 내 `rowCount` 검증 코드 제거

## 관련 이슈
Closes #182
