### PR TITLE
fix: sort 파라미터 enum 불일치 시 에러 메시지에 허용값 명시

### DIFF
--- a/apps/be/src/main/java/com/capstone/logue/global/exception/GlobalExceptionHandler.java
+++ b/apps/be/src/main/java/com/capstone/logue/global/exception/GlobalExceptionHandler.java
@@ -16,6 +16,9 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 @Slf4j
 @RequiredArgsConstructor
 @RestControllerAdvice
@@ -59,6 +62,16 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<ApiResponse<Void>> handleArgumentTypeMismatch(MethodArgumentTypeMismatchException e) {
         log.warn("[ArgumentTypeMismatch] {}", e.getMessage());
+        Class<?> requiredType = e.getRequiredType();
+        if (requiredType != null && requiredType.isEnum()) {
+            String allowedValues = Arrays.stream(requiredType.getEnumConstants())
+                    .map(Object::toString)
+                    .collect(Collectors.joining(", "));
+            String message = String.format("잘못된 %s 값입니다. 허용값: %s", e.getName(), allowedValues);
+            return ResponseEntity
+                    .status(ErrorCode.INVALID_TYPE.getHttpStatus())
+                    .body(ApiResponse.error(ErrorCode.INVALID_TYPE, message));
+        }
         return ResponseEntity
                 .status(ErrorCode.INVALID_TYPE.getHttpStatus())
                 .body(ApiResponse.error(ErrorCode.INVALID_TYPE));

--- a/apps/be/src/main/java/com/capstone/logue/global/response/ApiResponse.java
+++ b/apps/be/src/main/java/com/capstone/logue/global/response/ApiResponse.java
@@ -36,4 +36,8 @@ public class ApiResponse<T> {
     public static ApiResponse<Void> error(ErrorCode errorCode) {
         return new ApiResponse<>(false, errorCode.getCode(), errorCode.getMessage(), null);
     }
+
+    public static ApiResponse<Void> error(ErrorCode errorCode, String message) {
+        return new ApiResponse<>(false, errorCode.getCode(), message, null);
+    }
 }


### PR DESCRIPTION
## 요약
- `?sort=INVALID` 등 잘못된 enum 값 입력 시 허용값을 메시지에 포함하도록 개선

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [ ] 로컬 테스트 완료
- 테스트 방법:
  - `GET /api/datasources?sort=INVALID` 요청 → 응답 메시지에 `허용값: LATEST, MOST_USED` 포함 확인
  - `GET /api/datasources?sort=LATEST` 정상 요청 → 200 확인

## 스크린샷/로그 (선택)
- 생략

## 롤백/리스크
- 리스크 포인트: enum 타입 파라미터 전체에 적용되므로 sort 외 다른 enum 파라미터도 영향받음 (의도된 동작)
- 롤백 방법: `handleArgumentTypeMismatch` 를 기존 `INVALID_TYPE` 고정 응답으로 복구

## 관련 이슈
Closes #183 
