### PR TITLE
refactor: FE 잔여 리팩토링 백로그 반영

### DIFF
--- a/apps/fe/src/app/(main)/analysis/[id]/_components/CriterionSelect.tsx
+++ b/apps/fe/src/app/(main)/analysis/[id]/_components/CriterionSelect.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useEffect, useId, useRef, useState } from 'react';
 import ArrowDownIcon from '@/assets/icons/arrow-down.svg';
+import { useListboxDropdown } from '@/hooks/useListboxDropdown';
 
 type CommonProps = {
   options: string[];
@@ -26,22 +26,19 @@ type MultiProps = CommonProps & {
 export type CriterionSelectProps = SingleProps | MultiProps;
 
 export default function CriterionSelect(props: CriterionSelectProps) {
-  const [open, setOpen] = useState(false);
-  const rootRef = useRef<HTMLDivElement>(null);
-  const buttonRef = useRef<HTMLButtonElement>(null);
-  const listboxId = useId();
-
-  // 바깥 클릭 시 닫기
-  useEffect(() => {
-    if (!open) return;
-    const onMouseDown = (e: MouseEvent) => {
-      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    };
-    window.addEventListener('mousedown', onMouseDown);
-    return () => window.removeEventListener('mousedown', onMouseDown);
-  }, [open]);
+  const optionFocusSelector = props.multi
+    ? '[role="option"]:not([aria-disabled="true"])'
+    : '[role="option"]:not([disabled]):not([aria-disabled="true"])';
+  const {
+    buttonRef,
+    closeAndFocusButton,
+    handleButtonKeyDown,
+    handleListboxKeyDown,
+    listboxId,
+    open,
+    rootRef,
+    setOpen,
+  } = useListboxDropdown({ optionSelector: optionFocusSelector });
 
   const buttonLabel = props.multi
     ? props.values.length === 0
@@ -50,9 +47,6 @@ export default function CriterionSelect(props: CriterionSelectProps) {
         ? props.values[0]
         : `${props.values[0]} 외 ${props.values.length - 1}`
     : props.value;
-  const optionFocusSelector = props.multi
-    ? '[role="option"]:not([aria-disabled="true"])'
-    : '[role="option"]:not([disabled]):not([aria-disabled="true"])';
 
   return (
     <div
@@ -66,28 +60,7 @@ export default function CriterionSelect(props: CriterionSelectProps) {
         aria-expanded={open}
         aria-controls={open ? listboxId : undefined}
         onClick={() => setOpen((v) => !v)}
-        onKeyDown={(event) => {
-          if (event.key === 'Escape') {
-            setOpen(false);
-            return;
-          }
-
-          if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return;
-
-          event.preventDefault();
-          setOpen(true);
-          window.requestAnimationFrame(() => {
-            const options =
-              rootRef.current?.querySelectorAll<HTMLElement>(
-                optionFocusSelector,
-              );
-            const target =
-              event.key === 'ArrowUp'
-                ? options?.[options.length - 1]
-                : options?.[0];
-            target?.focus();
-          });
-        }}
+        onKeyDown={handleButtonKeyDown}
         className="inline-flex min-w-[12rem] items-center justify-between gap-8 rounded-12 border border-gray-300 bg-white px-12 py-8 text-body2 text-gray-900 transition-colors hover:bg-gray-100"
       >
         <span>{buttonLabel}</span>
@@ -104,57 +77,7 @@ export default function CriterionSelect(props: CriterionSelectProps) {
           id={listboxId}
           role="listbox"
           aria-multiselectable={props.multi ? true : undefined}
-          onKeyDown={(event) => {
-            if (event.key === 'Escape') {
-              setOpen(false);
-              buttonRef.current?.focus();
-              return;
-            }
-
-            if (
-              event.key !== 'ArrowDown' &&
-              event.key !== 'ArrowUp' &&
-              event.key !== 'Home' &&
-              event.key !== 'End'
-            ) {
-              return;
-            }
-
-            const options =
-              rootRef.current?.querySelectorAll<HTMLElement>(
-                optionFocusSelector,
-              );
-            if (!options?.length) return;
-
-            event.preventDefault();
-
-            const optionList = Array.from(options);
-            const activeIndex = optionList.findIndex(
-              (option) => option === document.activeElement,
-            );
-            const lastIndex = optionList.length - 1;
-
-            if (event.key === 'Home') {
-              optionList[0].focus();
-              return;
-            }
-
-            if (event.key === 'End') {
-              optionList[lastIndex].focus();
-              return;
-            }
-
-            const nextIndex =
-              event.key === 'ArrowDown'
-                ? activeIndex >= lastIndex
-                  ? 0
-                  : activeIndex + 1
-                : activeIndex <= 0
-                  ? lastIndex
-                  : activeIndex - 1;
-
-            optionList[nextIndex].focus();
-          }}
+          onKeyDown={handleListboxKeyDown}
           className="absolute left-0 z-10 mt-4 w-max min-w-full overflow-hidden rounded-12 border border-gray-300 bg-white shadow-[0_0.4rem_1.2rem_rgba(0,0,0,0.08)]"
         >
           {props.multi && props.headerLabel && (
@@ -225,8 +148,7 @@ export default function CriterionSelect(props: CriterionSelectProps) {
                 aria-selected={selected}
                 onClick={() => {
                   props.onChange(opt);
-                  setOpen(false);
-                  buttonRef.current?.focus();
+                  closeAndFocusButton();
                 }}
                 className={`block w-full px-12 py-8 text-left text-body2 transition-colors hover:bg-gray-100 ${
                   selected ? 'text-orange-500' : 'text-gray-900'

--- a/apps/fe/src/app/(main)/analysis/[id]/_hooks/useAnalysisChat.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_hooks/useAnalysisChat.ts
@@ -1,0 +1,736 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { useSearchParams } from 'next/navigation';
+import {
+  analysisQueryKeys,
+  createQuestion,
+  getCriteria,
+  getCriteriaStatus,
+  getResult,
+  getResultStatus,
+  getSummary,
+  getSummaryStatus,
+  updateCriteria,
+  type AnalysisJobStatus,
+  type GetQuestionCriteriaResponse,
+  type GetQuestionResultResponse,
+  type GetSummaryResponse,
+  type QuestionCriteriaParams,
+  type QuestionResultParams,
+  type UpdateQuestionCriteriaRequest,
+} from '@/apis/analysis';
+import {
+  dataSourceKeys,
+  getDataSource,
+  type FilePreview,
+} from '@/apis/datasource';
+import { getApiErrorMessage } from '@/apis/errors';
+import { useToast } from '@/hooks/useToast';
+import {
+  hasAnalysisStartPayloadConsumed,
+  markAnalysisStartPayloadConsumed,
+  readAnalysisStartPayload,
+  type AnalysisStartPayload,
+} from '@/lib/analysisStartPayload';
+import type { PromptInputValue } from '../../_components/PromptInput';
+import type { ColumnCandidate } from '../_components/AnalysisResult';
+import type { DataTableColumn } from '../_components/DataTablePreview';
+
+export type CriteriaInitialMode = 'normal' | 'edit';
+
+export type ChatMessage =
+  | {
+      id: string;
+      role: 'user';
+      content: string;
+      fileName?: string | null;
+    }
+  | {
+      id: string;
+      role: 'bot';
+      kind: 'criteria';
+      criteria: GetQuestionCriteriaResponse;
+      initialMode?: CriteriaInitialMode;
+    }
+  | {
+      id: string;
+      role: 'bot';
+      kind: 'verification';
+      result: GetQuestionResultResponse;
+    }
+  | {
+      id: string;
+      role: 'bot';
+      kind: 'notice';
+      content: string;
+      tone?: 'default' | 'error';
+    };
+
+const DEFAULT_PROMPT = 'CSV 파일을 분석해주세요';
+const STATUS_POLL_INTERVAL_MS = 1500;
+const QUESTION_ANALYSIS_TIMEOUT_MS = 120000;
+const RESULT_ANALYSIS_TIMEOUT_MS = 120000;
+const INVALID_ROUTE_MESSAGE = '분석 정보를 찾지 못했어요. 다시 시작해 주세요.';
+const SUMMARY_NOT_READY_MESSAGE = 'CSV 데이터 요약이 끝난 뒤 질문할 수 있어요.';
+const GET_SUMMARY_ERROR_MESSAGE =
+  'CSV 데이터 요약을 불러오지 못했어요. 잠시 후 다시 시도해 주세요.';
+const CREATE_QUESTION_ERROR_MESSAGE =
+  '질문 분석을 시작하지 못했어요. 잠시 후 다시 시도해 주세요.';
+const GET_CRITERIA_ERROR_MESSAGE =
+  '분석 기준을 불러오지 못했어요. 잠시 후 다시 시도해 주세요.';
+const UPDATE_CRITERIA_ERROR_MESSAGE =
+  '분석 기준을 확정하지 못했어요. 잠시 후 다시 시도해 주세요.';
+const GET_RESULT_ERROR_MESSAGE =
+  '최종 분석 결과를 불러오지 못했어요. 잠시 후 다시 시도해 주세요.';
+
+const SUMMARY_WARNING_MESSAGE_MAP: Record<string, string> = {
+  date_field_conflict:
+    '날짜 기준을 하나로 정할 수 없어요. 어떤 날짜를 기준으로 볼지 선택해 주세요.',
+};
+
+type QuestionAnalysisVariables = {
+  targetConversationId: number;
+  targetAnalysisFlowId: number;
+  question: string;
+};
+
+type UpdateCriteriaVariables = {
+  targetConversationId: number;
+  targetAnalysisFlowId: number;
+  messageId: number;
+  request: UpdateQuestionCriteriaRequest;
+};
+
+type ResultAnalysisVariables = {
+  targetConversationId: number;
+  targetAnalysisFlowId: number;
+  messageId: number;
+  analysisCriteriaId: number;
+};
+
+function parsePositiveNumber(value: string | null | undefined) {
+  if (!value) return null;
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+function compactStrings(values: Array<string | null | undefined>) {
+  return values
+    .map((value) => value?.trim())
+    .filter((value): value is string => Boolean(value));
+}
+
+export function uniqueStrings(values: Array<string | null | undefined>) {
+  return Array.from(new Set(compactStrings(values)));
+}
+
+function shouldPollJobStatus(status?: AnalysisJobStatus) {
+  return (
+    !status ||
+    status === 'QUEUED' ||
+    status === 'RUNNING' ||
+    status === 'RETRYING'
+  );
+}
+
+function isFailedJobStatus(status?: AnalysisJobStatus) {
+  return status === 'FAILED' || status === 'CANCELED' || status === 'CANCELLED';
+}
+
+function wait(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForCriteriaSuccess(params: QuestionCriteriaParams) {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < QUESTION_ANALYSIS_TIMEOUT_MS) {
+    const { status } = await getCriteriaStatus(params);
+
+    if (status === 'SUCCESS') return;
+    if (isFailedJobStatus(status)) {
+      throw new Error(GET_CRITERIA_ERROR_MESSAGE);
+    }
+
+    await wait(STATUS_POLL_INTERVAL_MS);
+  }
+
+  throw new Error(GET_CRITERIA_ERROR_MESSAGE);
+}
+
+async function waitForResultSuccess(params: QuestionResultParams) {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < RESULT_ANALYSIS_TIMEOUT_MS) {
+    const { status } = await getResultStatus(params);
+
+    if (status === 'SUCCESS') return;
+    if (isFailedJobStatus(status)) {
+      throw new Error(GET_RESULT_ERROR_MESSAGE);
+    }
+
+    await wait(STATUS_POLL_INTERVAL_MS);
+  }
+
+  throw new Error(GET_RESULT_ERROR_MESSAGE);
+}
+
+function createPreviewTable(preview?: FilePreview | null) {
+  if (!preview || preview.headers.length === 0) return null;
+
+  const columns: DataTableColumn[] = preview.headers.map((header, index) => ({
+    key: `col-${index}`,
+    label: header || `컬럼 ${index + 1}`,
+  }));
+  const rows = preview.rows.map((row) =>
+    columns.reduce<Record<string, string>>((acc, column, index) => {
+      acc[column.key] = row[index] ?? '';
+      return acc;
+    }, {}),
+  );
+
+  return { columns, rows };
+}
+
+export function createSummaryCandidates(summary: GetSummaryResponse) {
+  const groups = [
+    { name: '데이터 기준', values: summary.dataCriteria },
+    { name: '지표', values: summary.measure },
+    { name: '차원', values: summary.dimension },
+    { name: '상태 조건', values: summary.statusCondition },
+    { name: '플래그', values: summary.flag },
+    { name: '식별 기준', values: summary.idCriteria },
+  ];
+
+  return groups.flatMap<ColumnCandidate>((group) =>
+    group.values.map((value) => ({
+      name: group.name,
+      example: value,
+    })),
+  );
+}
+
+function mapSummaryWarning(value: string) {
+  const normalized = value.trim();
+  return SUMMARY_WARNING_MESSAGE_MAP[normalized] ?? normalized;
+}
+
+export function createSummaryWarnings(summary?: GetSummaryResponse) {
+  const warning = summary?.sourceDataWarning?.trim();
+  if (!warning) return [];
+
+  return warning.split('\n').map(mapSummaryWarning).filter(Boolean);
+}
+
+function getSummaryColumnOptions(summary?: GetSummaryResponse) {
+  if (!summary) return [];
+
+  return uniqueStrings([
+    ...summary.dataCriteria,
+    ...summary.measure,
+    ...summary.dimension,
+    ...summary.statusCondition,
+    ...summary.flag,
+    ...summary.idCriteria,
+  ]);
+}
+
+function createMessageId(prefix: string) {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+export function useAnalysisChat(routeConversationId: string) {
+  const searchParams = useSearchParams();
+  const conversationId = parsePositiveNumber(routeConversationId);
+  const analysisFlowId = parsePositiveNumber(
+    searchParams.get('analysisFlowId'),
+  );
+  const dataSourceId = parsePositiveNumber(searchParams.get('dataSourceId'));
+  const routeReady = conversationId !== null && analysisFlowId !== null;
+
+  const [startPayload, setStartPayload] = useState<AnalysisStartPayload>(
+    () => ({
+      prompt: DEFAULT_PROMPT,
+      fileName: null,
+    }),
+  );
+  const [messages, setMessages] = useState<ChatMessage[]>(() => [
+    {
+      id: 'init-user',
+      role: 'user',
+      content: DEFAULT_PROMPT,
+      fileName: null,
+    },
+  ]);
+  const { toast, showToast } = useToast();
+  const [hasStartedInitialQuestion, setHasStartedInitialQuestion] =
+    useState(false);
+  const [hasResolvedStartPayload, setHasResolvedStartPayload] = useState(false);
+  const [canAutoStartInitialQuestion, setCanAutoStartInitialQuestion] =
+    useState(false);
+  const openNextCriteriaInEditRef = useRef(false);
+  const readStartPayloadConversationIdRef = useRef<number | null>(null);
+  const questionSubmissionLockedRef = useRef(false);
+  const criteriaSubmissionLockedRef = useRef(false);
+
+  const initialPrompt = startPayload.prompt || DEFAULT_PROMPT;
+  const fileName = startPayload.fileName ?? null;
+
+  const dataSourceQuery = useQuery({
+    queryKey: dataSourceKeys.detail(dataSourceId ?? 0),
+    queryFn: () => {
+      if (dataSourceId === null) throw new Error(INVALID_ROUTE_MESSAGE);
+      return getDataSource(dataSourceId);
+    },
+    enabled: dataSourceId !== null,
+  });
+
+  const summaryStatusQuery = useQuery({
+    queryKey: analysisQueryKeys.summaryStatus(
+      conversationId ?? 0,
+      analysisFlowId ?? 0,
+    ),
+    queryFn: () => {
+      if (conversationId === null || analysisFlowId === null) {
+        throw new Error(INVALID_ROUTE_MESSAGE);
+      }
+
+      return getSummaryStatus({ conversationId, analysisFlowId });
+    },
+    enabled: routeReady,
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+
+      if (query.state.error || !status) return false;
+
+      return shouldPollJobStatus(status) ? STATUS_POLL_INTERVAL_MS : false;
+    },
+  });
+  const summaryStatus = summaryStatusQuery.data?.status;
+
+  const summaryQuery = useQuery({
+    queryKey: analysisQueryKeys.summary(
+      conversationId ?? 0,
+      analysisFlowId ?? 0,
+    ),
+    queryFn: () => {
+      if (conversationId === null || analysisFlowId === null) {
+        throw new Error(INVALID_ROUTE_MESSAGE);
+      }
+
+      return getSummary({ conversationId, analysisFlowId });
+    },
+    enabled: routeReady && summaryStatus === 'SUCCESS',
+  });
+
+  const {
+    mutate: mutateQuestionAnalysis,
+    isPending: isQuestionAnalysisPending,
+  } = useMutation({
+    mutationFn: async ({
+      targetConversationId,
+      targetAnalysisFlowId,
+      question,
+    }: QuestionAnalysisVariables) => {
+      const createdQuestion = await createQuestion(
+        {
+          conversationId: targetConversationId,
+          analysisFlowId: targetAnalysisFlowId,
+        },
+        { question },
+      );
+      const criteriaParams = {
+        conversationId: targetConversationId,
+        analysisFlowId: targetAnalysisFlowId,
+        messageId: createdQuestion.messageId,
+      };
+
+      await waitForCriteriaSuccess(criteriaParams);
+      return getCriteria(criteriaParams);
+    },
+  });
+
+  const updateCriteriaMutation = useMutation({
+    mutationFn: ({
+      targetConversationId,
+      targetAnalysisFlowId,
+      messageId,
+      request,
+    }: UpdateCriteriaVariables) =>
+      updateCriteria(
+        {
+          conversationId: targetConversationId,
+          analysisFlowId: targetAnalysisFlowId,
+          messageId,
+        },
+        request,
+      ),
+  });
+
+  const resultAnalysisMutation = useMutation({
+    mutationFn: async ({
+      targetConversationId,
+      targetAnalysisFlowId,
+      messageId,
+      analysisCriteriaId,
+    }: ResultAnalysisVariables) => {
+      const resultParams = {
+        conversationId: targetConversationId,
+        analysisFlowId: targetAnalysisFlowId,
+        messageId,
+        analysisCriteriaId,
+      };
+
+      await waitForResultSuccess(resultParams);
+      return getResult(resultParams);
+    },
+  });
+
+  const appendNotice = useCallback(
+    (content: string, tone: 'default' | 'error' = 'default') => {
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: createMessageId('notice'),
+          role: 'bot',
+          kind: 'notice',
+          content,
+          tone,
+        },
+      ]);
+    },
+    [setMessages],
+  );
+
+  const startQuestion = useCallback(
+    (question: string, appendUserMessage = true) => {
+      if (questionSubmissionLockedRef.current) return;
+
+      if (conversationId === null || analysisFlowId === null) {
+        showToast(INVALID_ROUTE_MESSAGE);
+        appendNotice(INVALID_ROUTE_MESSAGE, 'error');
+        return;
+      }
+
+      const normalizedQuestion = question.trim();
+      if (!normalizedQuestion) return;
+
+      questionSubmissionLockedRef.current = true;
+
+      if (appendUserMessage) {
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: createMessageId('user'),
+            role: 'user',
+            content: normalizedQuestion,
+          },
+        ]);
+      }
+
+      mutateQuestionAnalysis(
+        {
+          targetConversationId: conversationId,
+          targetAnalysisFlowId: analysisFlowId,
+          question: normalizedQuestion,
+        },
+        {
+          onSuccess: (criteria) => {
+            questionSubmissionLockedRef.current = false;
+            const initialMode: CriteriaInitialMode =
+              openNextCriteriaInEditRef.current ? 'edit' : 'normal';
+            openNextCriteriaInEditRef.current = false;
+            setMessages((prev) => [
+              ...prev,
+              {
+                id: `criteria-${criteria.messageId}`,
+                role: 'bot',
+                kind: 'criteria',
+                criteria,
+                initialMode,
+              },
+            ]);
+          },
+          onError: (error) => {
+            questionSubmissionLockedRef.current = false;
+            openNextCriteriaInEditRef.current = false;
+            const message = getApiErrorMessage(
+              error,
+              CREATE_QUESTION_ERROR_MESSAGE,
+            );
+            showToast(message);
+            appendNotice(message, 'error');
+          },
+        },
+      );
+    },
+    [
+      analysisFlowId,
+      appendNotice,
+      conversationId,
+      mutateQuestionAnalysis,
+      setMessages,
+      showToast,
+    ],
+  );
+
+  const startInitialQuestion = useCallback(
+    (initialMode: CriteriaInitialMode = 'normal') => {
+      if (
+        hasStartedInitialQuestion ||
+        !hasResolvedStartPayload ||
+        !canAutoStartInitialQuestion ||
+        conversationId === null
+      ) {
+        return;
+      }
+
+      markAnalysisStartPayloadConsumed(conversationId);
+      setCanAutoStartInitialQuestion(false);
+      setHasStartedInitialQuestion(true);
+      openNextCriteriaInEditRef.current = initialMode === 'edit';
+      startQuestion(initialPrompt, false);
+    },
+    [
+      canAutoStartInitialQuestion,
+      conversationId,
+      hasResolvedStartPayload,
+      hasStartedInitialQuestion,
+      initialPrompt,
+      setCanAutoStartInitialQuestion,
+      setHasStartedInitialQuestion,
+      startQuestion,
+    ],
+  );
+
+  function handleSubmit(value: PromptInputValue) {
+    if (!summaryQuery.data) {
+      showToast(SUMMARY_NOT_READY_MESSAGE);
+      return;
+    }
+
+    if (conversationId !== null) {
+      markAnalysisStartPayloadConsumed(conversationId);
+    }
+    setCanAutoStartInitialQuestion(false);
+    setHasStartedInitialQuestion(true);
+    openNextCriteriaInEditRef.current = false;
+    startQuestion(value.prompt);
+  }
+
+  function handleConfirmCriteria(
+    messageId: number,
+    request: UpdateQuestionCriteriaRequest,
+  ) {
+    if (criteriaSubmissionLockedRef.current) return;
+
+    if (conversationId === null || analysisFlowId === null) {
+      showToast(INVALID_ROUTE_MESSAGE);
+      return;
+    }
+
+    criteriaSubmissionLockedRef.current = true;
+
+    updateCriteriaMutation.mutate(
+      {
+        targetConversationId: conversationId,
+        targetAnalysisFlowId: analysisFlowId,
+        messageId,
+        request,
+      },
+      {
+        onSuccess: ({ analysisCriteriaId }) => {
+          appendNotice('분석 기준을 확정했어요.');
+          resultAnalysisMutation.mutate(
+            {
+              targetConversationId: conversationId,
+              targetAnalysisFlowId: analysisFlowId,
+              messageId,
+              analysisCriteriaId,
+            },
+            {
+              onSuccess: (result) => {
+                criteriaSubmissionLockedRef.current = false;
+                setMessages((prev) => [
+                  ...prev,
+                  {
+                    id: `result-${result.resultId}`,
+                    role: 'bot',
+                    kind: 'verification',
+                    result,
+                  },
+                ]);
+              },
+              onError: (error) => {
+                criteriaSubmissionLockedRef.current = false;
+                const message = getApiErrorMessage(
+                  error,
+                  GET_RESULT_ERROR_MESSAGE,
+                );
+                showToast(message);
+                appendNotice(message, 'error');
+              },
+            },
+          );
+        },
+        onError: (error) => {
+          criteriaSubmissionLockedRef.current = false;
+          const message = getApiErrorMessage(
+            error,
+            UPDATE_CRITERIA_ERROR_MESSAGE,
+          );
+          showToast(message);
+          appendNotice(message, 'error');
+        },
+      },
+    );
+  }
+
+  useEffect(() => {
+    if (
+      conversationId !== null &&
+      readStartPayloadConversationIdRef.current === conversationId
+    ) {
+      return;
+    }
+
+    setHasResolvedStartPayload(false);
+    setCanAutoStartInitialQuestion(false);
+
+    const timer = window.setTimeout(() => {
+      if (conversationId === null) {
+        setStartPayload({ prompt: DEFAULT_PROMPT, fileName: null });
+        setHasResolvedStartPayload(true);
+        return;
+      }
+
+      readStartPayloadConversationIdRef.current = conversationId;
+
+      const storedPayload = readAnalysisStartPayload(conversationId);
+      const canAutoStart =
+        storedPayload !== null &&
+        !hasAnalysisStartPayloadConsumed(conversationId);
+
+      setStartPayload({
+        prompt: storedPayload?.prompt || DEFAULT_PROMPT,
+        fileName: storedPayload?.fileName ?? null,
+      });
+      setCanAutoStartInitialQuestion(canAutoStart);
+      setHasResolvedStartPayload(true);
+    }, 0);
+
+    return () => window.clearTimeout(timer);
+  }, [conversationId]);
+
+  useEffect(() => {
+    if (!hasResolvedStartPayload) return;
+
+    const timer = window.setTimeout(() => {
+      setMessages((prev) =>
+        prev.map((message) =>
+          message.id === 'init-user' && message.role === 'user'
+            ? {
+                ...message,
+                content: initialPrompt,
+                fileName,
+              }
+            : message,
+        ),
+      );
+    }, 0);
+
+    return () => window.clearTimeout(timer);
+  }, [fileName, hasResolvedStartPayload, initialPrompt]);
+
+  useEffect(() => {
+    if (
+      !summaryQuery.data ||
+      hasStartedInitialQuestion ||
+      !hasResolvedStartPayload ||
+      !canAutoStartInitialQuestion
+    ) {
+      return;
+    }
+    if (createSummaryWarnings(summaryQuery.data).length > 0) return;
+
+    const timer = window.setTimeout(() => {
+      startInitialQuestion();
+    }, 0);
+
+    return () => window.clearTimeout(timer);
+  }, [
+    canAutoStartInitialQuestion,
+    hasResolvedStartPayload,
+    hasStartedInitialQuestion,
+    startInitialQuestion,
+    summaryQuery.data,
+  ]);
+
+  const summary = summaryQuery.data;
+  const summaryColumnOptions = getSummaryColumnOptions(summary);
+  const summaryPending =
+    routeReady &&
+    !summaryStatusQuery.isError &&
+    !summaryQuery.isError &&
+    !summary &&
+    !isFailedJobStatus(summaryStatus);
+  const summaryErrorMessage = !routeReady
+    ? INVALID_ROUTE_MESSAGE
+    : summaryStatusQuery.isError
+      ? getApiErrorMessage(summaryStatusQuery.error, GET_SUMMARY_ERROR_MESSAGE)
+      : summaryQuery.isError
+        ? getApiErrorMessage(summaryQuery.error, GET_SUMMARY_ERROR_MESSAGE)
+        : isFailedJobStatus(summaryStatus)
+          ? 'CSV 데이터 요약에 실패했어요. 파일을 확인하고 다시 시도해 주세요.'
+          : null;
+  const shouldShowAnalyzing =
+    summaryPending ||
+    isQuestionAnalysisPending ||
+    updateCriteriaMutation.isPending ||
+    resultAnalysisMutation.isPending;
+  const analyzingMessage = summaryPending
+    ? 'CSV 데이터를 분석 중이에요'
+    : updateCriteriaMutation.isPending
+      ? '분석 기준을 확정 중이에요'
+      : resultAnalysisMutation.isPending
+        ? '최종 분석 결과를 생성 중이에요'
+        : '질문을 분석 중이에요';
+  const inputDisabled =
+    !summary ||
+    isQuestionAnalysisPending ||
+    updateCriteriaMutation.isPending ||
+    resultAnalysisMutation.isPending;
+  const summaryWarnings = createSummaryWarnings(summary);
+  const summaryActionDisabled =
+    hasStartedInitialQuestion ||
+    !hasResolvedStartPayload ||
+    !canAutoStartInitialQuestion ||
+    isQuestionAnalysisPending ||
+    updateCriteriaMutation.isPending;
+  const criteriaSubmitting =
+    updateCriteriaMutation.isPending || resultAnalysisMutation.isPending;
+  const [initialMessage, ...restMessages] = messages;
+
+  return {
+    analyzingMessage,
+    criteriaSubmitting,
+    handleConfirmCriteria,
+    handleSubmit,
+    initialMessage,
+    inputDisabled,
+    isDataSourceLoading: dataSourceQuery.isLoading,
+    previewTable: createPreviewTable(dataSourceQuery.data?.preview),
+    restMessages,
+    shouldShowAnalyzing,
+    startInitialQuestion,
+    summary,
+    summaryActionDisabled,
+    summaryColumnOptions,
+    summaryErrorMessage,
+    summaryWarnings,
+    toast,
+  };
+}

--- a/apps/fe/src/app/(main)/analysis/[id]/_hooks/useAnalysisChat.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_hooks/useAnalysisChat.ts
@@ -506,20 +506,30 @@ export function useAnalysisChat(routeConversationId: string) {
     ],
   );
 
-  function handleSubmit(value: PromptInputValue) {
-    if (!summaryQuery.data) {
-      showToast(SUMMARY_NOT_READY_MESSAGE);
-      return;
-    }
+  const handleSubmit = useCallback(
+    (value: PromptInputValue) => {
+      if (!summaryQuery.data) {
+        showToast(SUMMARY_NOT_READY_MESSAGE);
+        return;
+      }
 
-    if (conversationId !== null) {
-      markAnalysisStartPayloadConsumed(conversationId);
-    }
-    setCanAutoStartInitialQuestion(false);
-    setHasStartedInitialQuestion(true);
-    openNextCriteriaInEditRef.current = false;
-    startQuestion(value.prompt);
-  }
+      if (conversationId !== null) {
+        markAnalysisStartPayloadConsumed(conversationId);
+      }
+      setCanAutoStartInitialQuestion(false);
+      setHasStartedInitialQuestion(true);
+      openNextCriteriaInEditRef.current = false;
+      startQuestion(value.prompt);
+    },
+    [
+      conversationId,
+      setCanAutoStartInitialQuestion,
+      setHasStartedInitialQuestion,
+      showToast,
+      startQuestion,
+      summaryQuery.data,
+    ],
+  );
 
   function handleConfirmCriteria(
     messageId: number,

--- a/apps/fe/src/app/(main)/analysis/[id]/page.tsx
+++ b/apps/fe/src/app/(main)/analysis/[id]/page.tsx
@@ -1,257 +1,23 @@
 'use client';
 
-import { use, useCallback, useEffect, useRef, useState } from 'react';
-import { useMutation, useQuery } from '@tanstack/react-query';
-import { useSearchParams } from 'next/navigation';
-import {
-  analysisQueryKeys,
-  createQuestion,
-  getCriteria,
-  getCriteriaStatus,
-  getResult,
-  getResultStatus,
-  getSummary,
-  getSummaryStatus,
-  updateCriteria,
-  type AnalysisJobStatus,
-  type GetQuestionCriteriaResponse,
-  type GetQuestionResultResponse,
-  type GetSummaryResponse,
-  type QuestionCriteriaParams,
-  type QuestionResultParams,
-  type UpdateQuestionCriteriaRequest,
-} from '@/apis/analysis';
-import {
-  dataSourceKeys,
-  getDataSource,
-  type FilePreview,
-} from '@/apis/datasource';
-import { getApiErrorMessage } from '@/apis/errors';
+import { use, useState } from 'react';
 import { ChatBubble, ToastAlert } from '@/components';
-import { useToast } from '@/hooks/useToast';
-import {
-  hasAnalysisStartPayloadConsumed,
-  markAnalysisStartPayloadConsumed,
-  readAnalysisStartPayload,
-  type AnalysisStartPayload,
-} from '@/lib/analysisStartPayload';
-import PromptInput, { type PromptInputValue } from '../_components/PromptInput';
-import AnalysisResult, {
-  type ColumnCandidate,
-} from './_components/AnalysisResult';
+import PromptInput from '../_components/PromptInput';
+import AnalysisResult from './_components/AnalysisResult';
 import AnalyzingIndicator from './_components/AnalyzingIndicator';
-import DataTablePreview, {
-  type DataTableColumn,
-} from './_components/DataTablePreview';
+import DataTablePreview from './_components/DataTablePreview';
 import LoadingDataPreview from './_components/LoadingDataPreview';
 import QuestionAnalysisResult from './_components/QuestionAnalysisResult';
 import ResizableSplit from './_components/ResizableSplit';
 import VerificationResult from './_components/VerificationResult';
+import {
+  createSummaryCandidates,
+  uniqueStrings,
+  useAnalysisChat,
+  type ChatMessage,
+} from './_hooks/useAnalysisChat';
 
 type PageParams = { id: string };
-type CriteriaInitialMode = 'normal' | 'edit';
-
-type ChatMessage =
-  | {
-      id: string;
-      role: 'user';
-      content: string;
-      fileName?: string | null;
-    }
-  | {
-      id: string;
-      role: 'bot';
-      kind: 'criteria';
-      criteria: GetQuestionCriteriaResponse;
-      initialMode?: CriteriaInitialMode;
-    }
-  | {
-      id: string;
-      role: 'bot';
-      kind: 'verification';
-      result: GetQuestionResultResponse;
-    }
-  | {
-      id: string;
-      role: 'bot';
-      kind: 'notice';
-      content: string;
-      tone?: 'default' | 'error';
-    };
-
-const DEFAULT_PROMPT = 'CSV 파일을 분석해주세요';
-const STATUS_POLL_INTERVAL_MS = 1500;
-const QUESTION_ANALYSIS_TIMEOUT_MS = 120000;
-const RESULT_ANALYSIS_TIMEOUT_MS = 120000;
-const INVALID_ROUTE_MESSAGE = '분석 정보를 찾지 못했어요. 다시 시작해 주세요.';
-const SUMMARY_NOT_READY_MESSAGE = 'CSV 데이터 요약이 끝난 뒤 질문할 수 있어요.';
-const GET_SUMMARY_ERROR_MESSAGE =
-  'CSV 데이터 요약을 불러오지 못했어요. 잠시 후 다시 시도해 주세요.';
-const CREATE_QUESTION_ERROR_MESSAGE =
-  '질문 분석을 시작하지 못했어요. 잠시 후 다시 시도해 주세요.';
-const GET_CRITERIA_ERROR_MESSAGE =
-  '분석 기준을 불러오지 못했어요. 잠시 후 다시 시도해 주세요.';
-const UPDATE_CRITERIA_ERROR_MESSAGE =
-  '분석 기준을 확정하지 못했어요. 잠시 후 다시 시도해 주세요.';
-const GET_RESULT_ERROR_MESSAGE =
-  '최종 분석 결과를 불러오지 못했어요. 잠시 후 다시 시도해 주세요.';
-
-const SUMMARY_WARNING_MESSAGE_MAP: Record<string, string> = {
-  date_field_conflict:
-    '날짜 기준을 하나로 정할 수 없어요. 어떤 날짜를 기준으로 볼지 선택해 주세요.',
-};
-
-type QuestionAnalysisVariables = {
-  targetConversationId: number;
-  targetAnalysisFlowId: number;
-  question: string;
-};
-
-type UpdateCriteriaVariables = {
-  targetConversationId: number;
-  targetAnalysisFlowId: number;
-  messageId: number;
-  request: UpdateQuestionCriteriaRequest;
-};
-
-type ResultAnalysisVariables = {
-  targetConversationId: number;
-  targetAnalysisFlowId: number;
-  messageId: number;
-  analysisCriteriaId: number;
-};
-
-function parsePositiveNumber(value: string | null | undefined) {
-  if (!value) return null;
-
-  const parsed = Number(value);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
-}
-
-function compactStrings(values: Array<string | null | undefined>) {
-  return values
-    .map((value) => value?.trim())
-    .filter((value): value is string => Boolean(value));
-}
-
-function uniqueStrings(values: Array<string | null | undefined>) {
-  return Array.from(new Set(compactStrings(values)));
-}
-
-function shouldPollJobStatus(status?: AnalysisJobStatus) {
-  return (
-    !status ||
-    status === 'QUEUED' ||
-    status === 'RUNNING' ||
-    status === 'RETRYING'
-  );
-}
-
-function isFailedJobStatus(status?: AnalysisJobStatus) {
-  return status === 'FAILED' || status === 'CANCELED' || status === 'CANCELLED';
-}
-
-function wait(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-async function waitForCriteriaSuccess(params: QuestionCriteriaParams) {
-  const startedAt = Date.now();
-
-  while (Date.now() - startedAt < QUESTION_ANALYSIS_TIMEOUT_MS) {
-    const { status } = await getCriteriaStatus(params);
-
-    if (status === 'SUCCESS') return;
-    if (isFailedJobStatus(status)) {
-      throw new Error(GET_CRITERIA_ERROR_MESSAGE);
-    }
-
-    await wait(STATUS_POLL_INTERVAL_MS);
-  }
-
-  throw new Error(GET_CRITERIA_ERROR_MESSAGE);
-}
-
-async function waitForResultSuccess(params: QuestionResultParams) {
-  const startedAt = Date.now();
-
-  while (Date.now() - startedAt < RESULT_ANALYSIS_TIMEOUT_MS) {
-    const { status } = await getResultStatus(params);
-
-    if (status === 'SUCCESS') return;
-    if (isFailedJobStatus(status)) {
-      throw new Error(GET_RESULT_ERROR_MESSAGE);
-    }
-
-    await wait(STATUS_POLL_INTERVAL_MS);
-  }
-
-  throw new Error(GET_RESULT_ERROR_MESSAGE);
-}
-
-function createPreviewTable(preview?: FilePreview | null) {
-  if (!preview || preview.headers.length === 0) return null;
-
-  const columns: DataTableColumn[] = preview.headers.map((header, index) => ({
-    key: `col-${index}`,
-    label: header || `컬럼 ${index + 1}`,
-  }));
-  const rows = preview.rows.map((row) =>
-    columns.reduce<Record<string, string>>((acc, column, index) => {
-      acc[column.key] = row[index] ?? '';
-      return acc;
-    }, {}),
-  );
-
-  return { columns, rows };
-}
-
-function createSummaryCandidates(summary: GetSummaryResponse) {
-  const groups = [
-    { name: '데이터 기준', values: summary.dataCriteria },
-    { name: '지표', values: summary.measure },
-    { name: '차원', values: summary.dimension },
-    { name: '상태 조건', values: summary.statusCondition },
-    { name: '플래그', values: summary.flag },
-    { name: '식별 기준', values: summary.idCriteria },
-  ];
-
-  return groups.flatMap<ColumnCandidate>((group) =>
-    group.values.map((value) => ({
-      name: group.name,
-      example: value,
-    })),
-  );
-}
-
-function mapSummaryWarning(value: string) {
-  const normalized = value.trim();
-  return SUMMARY_WARNING_MESSAGE_MAP[normalized] ?? normalized;
-}
-
-function createSummaryWarnings(summary?: GetSummaryResponse) {
-  const warning = summary?.sourceDataWarning?.trim();
-  if (!warning) return [];
-
-  return warning.split('\n').map(mapSummaryWarning).filter(Boolean);
-}
-
-function getSummaryColumnOptions(summary?: GetSummaryResponse) {
-  if (!summary) return [];
-
-  return uniqueStrings([
-    ...summary.dataCriteria,
-    ...summary.measure,
-    ...summary.dimension,
-    ...summary.statusCondition,
-    ...summary.flag,
-    ...summary.idCriteria,
-  ]);
-}
-
-function createMessageId(prefix: string) {
-  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-}
 
 export default function AnalysisChatPage({
   params,
@@ -259,494 +25,28 @@ export default function AnalysisChatPage({
   params: Promise<PageParams>;
 }) {
   const { id } = use(params);
-  const searchParams = useSearchParams();
-  const conversationId = parsePositiveNumber(id);
-  const analysisFlowId = parsePositiveNumber(
-    searchParams.get('analysisFlowId'),
-  );
-  const dataSourceId = parsePositiveNumber(searchParams.get('dataSourceId'));
-  const routeReady = conversationId !== null && analysisFlowId !== null;
-
-  const [startPayload, setStartPayload] = useState<AnalysisStartPayload>(
-    () => ({
-      prompt: DEFAULT_PROMPT,
-      fileName: null,
-    }),
-  );
-  const [messages, setMessages] = useState<ChatMessage[]>(() => [
-    {
-      id: 'init-user',
-      role: 'user',
-      content: DEFAULT_PROMPT,
-      fileName: null,
-    },
-  ]);
-  const { toast, showToast } = useToast();
   const [isChatCollapsed, setIsChatCollapsed] = useState(false);
-  const [hasStartedInitialQuestion, setHasStartedInitialQuestion] =
-    useState(false);
-  const [hasResolvedStartPayload, setHasResolvedStartPayload] = useState(false);
-  const [canAutoStartInitialQuestion, setCanAutoStartInitialQuestion] =
-    useState(false);
-  const openNextCriteriaInEditRef = useRef(false);
-  const readStartPayloadConversationIdRef = useRef<number | null>(null);
-  const questionSubmissionLockedRef = useRef(false);
-  const criteriaSubmissionLockedRef = useRef(false);
-
-  const initialPrompt = startPayload.prompt || DEFAULT_PROMPT;
-  const fileName = startPayload.fileName ?? null;
-
-  const dataSourceQuery = useQuery({
-    queryKey: dataSourceKeys.detail(dataSourceId ?? 0),
-    queryFn: () => {
-      if (dataSourceId === null) throw new Error(INVALID_ROUTE_MESSAGE);
-      return getDataSource(dataSourceId);
-    },
-    enabled: dataSourceId !== null,
-  });
-
-  const summaryStatusQuery = useQuery({
-    queryKey: analysisQueryKeys.summaryStatus(
-      conversationId ?? 0,
-      analysisFlowId ?? 0,
-    ),
-    queryFn: () => {
-      if (conversationId === null || analysisFlowId === null) {
-        throw new Error(INVALID_ROUTE_MESSAGE);
-      }
-
-      return getSummaryStatus({ conversationId, analysisFlowId });
-    },
-    enabled: routeReady,
-    refetchInterval: (query) => {
-      const status = query.state.data?.status;
-
-      if (query.state.error || !status) return false;
-
-      return shouldPollJobStatus(status) ? STATUS_POLL_INTERVAL_MS : false;
-    },
-  });
-  const summaryStatus = summaryStatusQuery.data?.status;
-
-  const summaryQuery = useQuery({
-    queryKey: analysisQueryKeys.summary(
-      conversationId ?? 0,
-      analysisFlowId ?? 0,
-    ),
-    queryFn: () => {
-      if (conversationId === null || analysisFlowId === null) {
-        throw new Error(INVALID_ROUTE_MESSAGE);
-      }
-
-      return getSummary({ conversationId, analysisFlowId });
-    },
-    enabled: routeReady && summaryStatus === 'SUCCESS',
-  });
-
-  const {
-    mutate: mutateQuestionAnalysis,
-    isPending: isQuestionAnalysisPending,
-  } = useMutation({
-    mutationFn: async ({
-      targetConversationId,
-      targetAnalysisFlowId,
-      question,
-    }: QuestionAnalysisVariables) => {
-      const createdQuestion = await createQuestion(
-        {
-          conversationId: targetConversationId,
-          analysisFlowId: targetAnalysisFlowId,
-        },
-        { question },
-      );
-      const criteriaParams = {
-        conversationId: targetConversationId,
-        analysisFlowId: targetAnalysisFlowId,
-        messageId: createdQuestion.messageId,
-      };
-
-      await waitForCriteriaSuccess(criteriaParams);
-      return getCriteria(criteriaParams);
-    },
-  });
-
-  const updateCriteriaMutation = useMutation({
-    mutationFn: ({
-      targetConversationId,
-      targetAnalysisFlowId,
-      messageId,
-      request,
-    }: UpdateCriteriaVariables) =>
-      updateCriteria(
-        {
-          conversationId: targetConversationId,
-          analysisFlowId: targetAnalysisFlowId,
-          messageId,
-        },
-        request,
-      ),
-  });
-
-  const resultAnalysisMutation = useMutation({
-    mutationFn: async ({
-      targetConversationId,
-      targetAnalysisFlowId,
-      messageId,
-      analysisCriteriaId,
-    }: ResultAnalysisVariables) => {
-      const resultParams = {
-        conversationId: targetConversationId,
-        analysisFlowId: targetAnalysisFlowId,
-        messageId,
-        analysisCriteriaId,
-      };
-
-      await waitForResultSuccess(resultParams);
-      return getResult(resultParams);
-    },
-  });
-
-  const appendNotice = useCallback(
-    (content: string, tone: 'default' | 'error' = 'default') => {
-      setMessages((prev) => [
-        ...prev,
-        {
-          id: createMessageId('notice'),
-          role: 'bot',
-          kind: 'notice',
-          content,
-          tone,
-        },
-      ]);
-    },
-    [setMessages],
-  );
-
-  const startQuestion = useCallback(
-    (question: string, appendUserMessage = true) => {
-      if (questionSubmissionLockedRef.current) return;
-
-      if (conversationId === null || analysisFlowId === null) {
-        showToast(INVALID_ROUTE_MESSAGE);
-        appendNotice(INVALID_ROUTE_MESSAGE, 'error');
-        return;
-      }
-
-      const normalizedQuestion = question.trim();
-      if (!normalizedQuestion) return;
-
-      questionSubmissionLockedRef.current = true;
-
-      if (appendUserMessage) {
-        setMessages((prev) => [
-          ...prev,
-          {
-            id: createMessageId('user'),
-            role: 'user',
-            content: normalizedQuestion,
-          },
-        ]);
-      }
-
-      mutateQuestionAnalysis(
-        {
-          targetConversationId: conversationId,
-          targetAnalysisFlowId: analysisFlowId,
-          question: normalizedQuestion,
-        },
-        {
-          onSuccess: (criteria) => {
-            questionSubmissionLockedRef.current = false;
-            const initialMode: CriteriaInitialMode =
-              openNextCriteriaInEditRef.current ? 'edit' : 'normal';
-            openNextCriteriaInEditRef.current = false;
-            setMessages((prev) => [
-              ...prev,
-              {
-                id: `criteria-${criteria.messageId}`,
-                role: 'bot',
-                kind: 'criteria',
-                criteria,
-                initialMode,
-              },
-            ]);
-          },
-          onError: (error) => {
-            questionSubmissionLockedRef.current = false;
-            openNextCriteriaInEditRef.current = false;
-            const message = getApiErrorMessage(
-              error,
-              CREATE_QUESTION_ERROR_MESSAGE,
-            );
-            showToast(message);
-            appendNotice(message, 'error');
-          },
-        },
-      );
-    },
-    [
-      analysisFlowId,
-      appendNotice,
-      conversationId,
-      mutateQuestionAnalysis,
-      setMessages,
-      showToast,
-    ],
-  );
-
-  const startInitialQuestion = useCallback(
-    (initialMode: CriteriaInitialMode = 'normal') => {
-      if (
-        hasStartedInitialQuestion ||
-        !hasResolvedStartPayload ||
-        !canAutoStartInitialQuestion ||
-        conversationId === null
-      ) {
-        return;
-      }
-
-      markAnalysisStartPayloadConsumed(conversationId);
-      setCanAutoStartInitialQuestion(false);
-      setHasStartedInitialQuestion(true);
-      openNextCriteriaInEditRef.current = initialMode === 'edit';
-      startQuestion(initialPrompt, false);
-    },
-    [
-      canAutoStartInitialQuestion,
-      conversationId,
-      hasResolvedStartPayload,
-      hasStartedInitialQuestion,
-      initialPrompt,
-      setCanAutoStartInitialQuestion,
-      setHasStartedInitialQuestion,
-      startQuestion,
-    ],
-  );
-
-  function handleSubmit(value: PromptInputValue) {
-    if (!summaryQuery.data) {
-      showToast(SUMMARY_NOT_READY_MESSAGE);
-      return;
-    }
-
-    if (conversationId !== null) {
-      markAnalysisStartPayloadConsumed(conversationId);
-    }
-    setCanAutoStartInitialQuestion(false);
-    setHasStartedInitialQuestion(true);
-    openNextCriteriaInEditRef.current = false;
-    startQuestion(value.prompt);
-  }
-
-  function handleConfirmCriteria(
-    messageId: number,
-    request: UpdateQuestionCriteriaRequest,
-  ) {
-    if (criteriaSubmissionLockedRef.current) return;
-
-    if (conversationId === null || analysisFlowId === null) {
-      showToast(INVALID_ROUTE_MESSAGE);
-      return;
-    }
-
-    criteriaSubmissionLockedRef.current = true;
-
-    updateCriteriaMutation.mutate(
-      {
-        targetConversationId: conversationId,
-        targetAnalysisFlowId: analysisFlowId,
-        messageId,
-        request,
-      },
-      {
-        onSuccess: ({ analysisCriteriaId }) => {
-          appendNotice('분석 기준이 확정되었어요.');
-          resultAnalysisMutation.mutate(
-            {
-              targetConversationId: conversationId,
-              targetAnalysisFlowId: analysisFlowId,
-              messageId,
-              analysisCriteriaId,
-            },
-            {
-              onSuccess: (result) => {
-                criteriaSubmissionLockedRef.current = false;
-                setMessages((prev) => [
-                  ...prev,
-                  {
-                    id: `result-${result.resultId}`,
-                    role: 'bot',
-                    kind: 'verification',
-                    result,
-                  },
-                ]);
-              },
-              onError: (error) => {
-                criteriaSubmissionLockedRef.current = false;
-                const message = getApiErrorMessage(
-                  error,
-                  GET_RESULT_ERROR_MESSAGE,
-                );
-                showToast(message);
-                appendNotice(message, 'error');
-              },
-            },
-          );
-        },
-        onError: (error) => {
-          criteriaSubmissionLockedRef.current = false;
-          const message = getApiErrorMessage(
-            error,
-            UPDATE_CRITERIA_ERROR_MESSAGE,
-          );
-          showToast(message);
-          appendNotice(message, 'error');
-        },
-      },
-    );
-  }
-
-  useEffect(() => {
-    if (
-      conversationId !== null &&
-      readStartPayloadConversationIdRef.current === conversationId
-    ) {
-      return;
-    }
-
-    setHasResolvedStartPayload(false);
-    setCanAutoStartInitialQuestion(false);
-
-    const timer = window.setTimeout(() => {
-      if (conversationId === null) {
-        setStartPayload({ prompt: DEFAULT_PROMPT, fileName: null });
-        setHasResolvedStartPayload(true);
-        return;
-      }
-
-      readStartPayloadConversationIdRef.current = conversationId;
-
-      const storedPayload = readAnalysisStartPayload(conversationId);
-      const canAutoStart =
-        storedPayload !== null &&
-        !hasAnalysisStartPayloadConsumed(conversationId);
-
-      setStartPayload({
-        prompt: storedPayload?.prompt || DEFAULT_PROMPT,
-        fileName: storedPayload?.fileName ?? null,
-      });
-      setCanAutoStartInitialQuestion(canAutoStart);
-      setHasResolvedStartPayload(true);
-    }, 0);
-
-    return () => window.clearTimeout(timer);
-  }, [conversationId]);
-
-  useEffect(() => {
-    if (!hasResolvedStartPayload) return;
-
-    const timer = window.setTimeout(() => {
-      setMessages((prev) =>
-        prev.map((message) =>
-          message.id === 'init-user' && message.role === 'user'
-            ? {
-                ...message,
-                content: initialPrompt,
-                fileName,
-              }
-            : message,
-        ),
-      );
-    }, 0);
-
-    return () => window.clearTimeout(timer);
-  }, [fileName, hasResolvedStartPayload, initialPrompt]);
-
-  useEffect(() => {
-    if (
-      !summaryQuery.data ||
-      hasStartedInitialQuestion ||
-      !hasResolvedStartPayload ||
-      !canAutoStartInitialQuestion
-    ) {
-      return;
-    }
-    if (createSummaryWarnings(summaryQuery.data).length > 0) return;
-
-    const timer = window.setTimeout(() => {
-      startInitialQuestion();
-    }, 0);
-
-    return () => window.clearTimeout(timer);
-  }, [
-    hasResolvedStartPayload,
-    hasStartedInitialQuestion,
-    canAutoStartInitialQuestion,
-    startInitialQuestion,
-    summaryQuery.data,
-  ]);
-
-  const previewTable = createPreviewTable(dataSourceQuery.data?.preview);
-  const summaryColumnOptions = getSummaryColumnOptions(summaryQuery.data);
-  const summaryPending =
-    routeReady &&
-    !summaryStatusQuery.isError &&
-    !summaryQuery.isError &&
-    !summaryQuery.data &&
-    !isFailedJobStatus(summaryStatus);
-  const summaryErrorMessage = !routeReady
-    ? INVALID_ROUTE_MESSAGE
-    : summaryStatusQuery.isError
-      ? getApiErrorMessage(summaryStatusQuery.error, GET_SUMMARY_ERROR_MESSAGE)
-      : summaryQuery.isError
-        ? getApiErrorMessage(summaryQuery.error, GET_SUMMARY_ERROR_MESSAGE)
-        : isFailedJobStatus(summaryStatus)
-          ? 'CSV 데이터 요약에 실패했어요. 파일을 확인한 뒤 다시 시도해 주세요.'
-          : null;
-  const shouldShowAnalyzing =
-    summaryPending ||
-    isQuestionAnalysisPending ||
-    updateCriteriaMutation.isPending ||
-    resultAnalysisMutation.isPending;
-  const analyzingMessage = summaryPending
-    ? 'CSV 데이터를 분석 중이에요'
-    : updateCriteriaMutation.isPending
-      ? '분석 기준을 확정 중이에요'
-      : resultAnalysisMutation.isPending
-        ? '최종 분석 결과를 생성 중이에요'
-        : '질문을 분석 중이에요';
-  const inputDisabled =
-    !summaryQuery.data ||
-    isQuestionAnalysisPending ||
-    updateCriteriaMutation.isPending ||
-    resultAnalysisMutation.isPending;
+  const chat = useAnalysisChat(id);
 
   const renderSummaryMessage = () => {
-    if (!summaryQuery.data) return null;
+    if (!chat.summary) return null;
 
-    const warnings = createSummaryWarnings(summaryQuery.data);
-    const hasWarnings = warnings.length > 0;
-    const summaryActionDisabled =
-      hasStartedInitialQuestion ||
-      !hasResolvedStartPayload ||
-      !canAutoStartInitialQuestion ||
-      isQuestionAnalysisPending ||
-      updateCriteriaMutation.isPending;
+    const hasWarnings = chat.summaryWarnings.length > 0;
 
     return (
       <div key="summary" className="flex w-full justify-start">
         <div className="w-full max-w-[80%]">
           <AnalysisResult
-            rowCount={summaryQuery.data.rowCount}
-            columnCount={summaryQuery.data.columnCount}
-            candidates={createSummaryCandidates(summaryQuery.data)}
-            warnings={warnings}
+            rowCount={chat.summary.rowCount}
+            columnCount={chat.summary.columnCount}
+            candidates={createSummaryCandidates(chat.summary)}
+            warnings={chat.summaryWarnings}
             warningActions={
               hasWarnings
                 ? {
-                    disabled: summaryActionDisabled,
-                    onEdit: () => startInitialQuestion('edit'),
-                    onContinue: () => startInitialQuestion(),
+                    disabled: chat.summaryActionDisabled,
+                    onEdit: () => chat.startInitialQuestion('edit'),
+                    onContinue: () => chat.startInitialQuestion(),
                   }
                 : undefined
             }
@@ -757,11 +57,11 @@ export default function AnalysisChatPage({
   };
 
   const renderErrorMessage = () => {
-    if (!summaryErrorMessage) return null;
+    if (!chat.summaryErrorMessage) return null;
 
     return (
       <ChatBubble key="summary-error" role="bot">
-        <p className="text-error-500">{summaryErrorMessage}</p>
+        <p className="text-error-500">{chat.summaryErrorMessage}</p>
       </ChatBubble>
     );
   };
@@ -814,21 +114,18 @@ export default function AnalysisChatPage({
             criteria={message.criteria.criteria}
             initialMode={message.initialMode}
             baseDateColumnOptions={
-              summaryQuery.data?.dataCriteria.length
-                ? summaryQuery.data.dataCriteria
-                : summaryColumnOptions
+              chat.summary?.dataCriteria.length
+                ? chat.summary.dataCriteria
+                : chat.summaryColumnOptions
             }
-            groupByOptions={summaryColumnOptions}
+            groupByOptions={chat.summaryColumnOptions}
             sortByOptions={uniqueStrings([
-              ...(summaryQuery.data?.measure ?? []),
-              ...summaryColumnOptions,
+              ...(chat.summary?.measure ?? []),
+              ...chat.summaryColumnOptions,
             ])}
-            isSubmitting={
-              updateCriteriaMutation.isPending ||
-              resultAnalysisMutation.isPending
-            }
+            isSubmitting={chat.criteriaSubmitting}
             onContinue={(values) =>
-              handleConfirmCriteria(message.criteria.messageId, values)
+              chat.handleConfirmCriteria(message.criteria.messageId, values)
             }
           />
         </div>
@@ -836,19 +133,17 @@ export default function AnalysisChatPage({
     );
   };
 
-  const [initialMessage, ...restMessages] = messages;
-
   return (
     <ResizableSplit
       rightCollapsed={isChatCollapsed}
       onRightCollapsedChange={setIsChatCollapsed}
       left={
-        previewTable ? (
+        chat.previewTable ? (
           <DataTablePreview
-            columns={previewTable.columns}
-            rows={previewTable.rows}
+            columns={chat.previewTable.columns}
+            rows={chat.previewTable.rows}
           />
-        ) : dataSourceQuery.isLoading ? (
+        ) : chat.isDataSourceLoading ? (
           <LoadingDataPreview message="CSV 미리보기를 불러오는 중이에요" />
         ) : (
           <LoadingDataPreview />
@@ -857,14 +152,14 @@ export default function AnalysisChatPage({
       right={
         <div className="flex h-full min-h-0 flex-col">
           <div className="scrollbar-hide flex min-h-0 flex-1 flex-col gap-24 overflow-y-auto px-24 pt-32 pb-24">
-            {initialMessage ? renderMessage(initialMessage) : null}
+            {chat.initialMessage ? renderMessage(chat.initialMessage) : null}
             {renderSummaryMessage()}
             {renderErrorMessage()}
-            {restMessages.map(renderMessage)}
-            {shouldShowAnalyzing && (
+            {chat.restMessages.map(renderMessage)}
+            {chat.shouldShowAnalyzing && (
               <div className="flex w-full justify-start">
                 <div className="w-full max-w-[80%]">
-                  <AnalyzingIndicator message={analyzingMessage} />
+                  <AnalyzingIndicator message={chat.analyzingMessage} />
                 </div>
               </div>
             )}
@@ -873,14 +168,14 @@ export default function AnalysisChatPage({
           <div className="shrink-0 px-24 pt-12 pb-24">
             <PromptInput
               showFileAttach={false}
-              submitDisabled={inputDisabled}
-              onSubmit={handleSubmit}
+              submitDisabled={chat.inputDisabled}
+              onSubmit={chat.handleSubmit}
             />
           </div>
 
-          {toast && (
+          {chat.toast && (
             <div className="pointer-events-none fixed bottom-[4.4rem] left-1/2 z-[60] -translate-x-1/2">
-              <ToastAlert role="alert">{toast.message}</ToastAlert>
+              <ToastAlert role="alert">{chat.toast.message}</ToastAlert>
             </div>
           )}
         </div>

--- a/apps/fe/src/app/(main)/data/_components/SortDropdown.tsx
+++ b/apps/fe/src/app/(main)/data/_components/SortDropdown.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useEffect, useId, useRef, useState } from 'react';
 import DownIcon from '@/assets/icons/down.svg';
+import { useListboxDropdown } from '@/hooks/useListboxDropdown';
 
 export type SortOption<T extends string = string> = {
   value: T;
@@ -19,21 +19,16 @@ export default function SortDropdown<T extends string>({
   value,
   onChange,
 }: SortDropdownProps<T>) {
-  const [open, setOpen] = useState(false);
-  const rootRef = useRef<HTMLDivElement>(null);
-  const buttonRef = useRef<HTMLButtonElement>(null);
-  const listboxId = useId();
-
-  useEffect(() => {
-    if (!open) return;
-    const onMouseDown = (e: MouseEvent) => {
-      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    };
-    window.addEventListener('mousedown', onMouseDown);
-    return () => window.removeEventListener('mousedown', onMouseDown);
-  }, [open]);
+  const {
+    buttonRef,
+    closeAndFocusButton,
+    handleButtonKeyDown,
+    handleListboxKeyDown,
+    listboxId,
+    open,
+    rootRef,
+    setOpen,
+  } = useListboxDropdown();
 
   const selectedLabel = options.find((o) => o.value === value)?.label ?? '';
 
@@ -46,28 +41,7 @@ export default function SortDropdown<T extends string>({
         aria-expanded={open}
         aria-controls={open ? listboxId : undefined}
         onClick={() => setOpen((v) => !v)}
-        onKeyDown={(event) => {
-          if (event.key === 'Escape') {
-            setOpen(false);
-            return;
-          }
-
-          if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return;
-
-          event.preventDefault();
-          setOpen(true);
-          window.requestAnimationFrame(() => {
-            const options =
-              rootRef.current?.querySelectorAll<HTMLButtonElement>(
-                '[role="option"]:not([disabled])',
-              );
-            const target =
-              event.key === 'ArrowUp'
-                ? options?.[options.length - 1]
-                : options?.[0];
-            target?.focus();
-          });
-        }}
+        onKeyDown={handleButtonKeyDown}
         className="inline-flex min-w-[12rem] items-center justify-between gap-8 rounded-12 border border-gray-300 bg-white px-12 py-8 text-body4 text-gray-700 transition-colors hover:bg-gray-100"
       >
         <span>{selectedLabel}</span>
@@ -83,57 +57,7 @@ export default function SortDropdown<T extends string>({
         <div
           id={listboxId}
           role="listbox"
-          onKeyDown={(event) => {
-            if (event.key === 'Escape') {
-              setOpen(false);
-              buttonRef.current?.focus();
-              return;
-            }
-
-            if (
-              event.key !== 'ArrowDown' &&
-              event.key !== 'ArrowUp' &&
-              event.key !== 'Home' &&
-              event.key !== 'End'
-            ) {
-              return;
-            }
-
-            const options =
-              rootRef.current?.querySelectorAll<HTMLButtonElement>(
-                '[role="option"]:not([disabled])',
-              );
-            if (!options?.length) return;
-
-            event.preventDefault();
-
-            const optionList = Array.from(options);
-            const activeIndex = optionList.findIndex(
-              (option) => option === document.activeElement,
-            );
-            const lastIndex = optionList.length - 1;
-
-            if (event.key === 'Home') {
-              optionList[0].focus();
-              return;
-            }
-
-            if (event.key === 'End') {
-              optionList[lastIndex].focus();
-              return;
-            }
-
-            const nextIndex =
-              event.key === 'ArrowDown'
-                ? activeIndex >= lastIndex
-                  ? 0
-                  : activeIndex + 1
-                : activeIndex <= 0
-                  ? lastIndex
-                  : activeIndex - 1;
-
-            optionList[nextIndex].focus();
-          }}
+          onKeyDown={handleListboxKeyDown}
           className="absolute left-0 z-10 mt-4 min-w-[14rem] overflow-hidden rounded-12 border border-gray-300 bg-white py-8 shadow-[0_0.4rem_1.2rem_rgba(0,0,0,0.08)]"
         >
           {options.map((opt) => {
@@ -146,8 +70,7 @@ export default function SortDropdown<T extends string>({
                 aria-selected={selected}
                 onClick={() => {
                   onChange(opt.value);
-                  setOpen(false);
-                  buttonRef.current?.focus();
+                  closeAndFocusButton();
                 }}
                 className={`flex w-full items-center gap-12 px-16 py-12 text-left text-body4 transition-colors hover:bg-gray-100 ${
                   selected ? 'text-orange-500' : 'text-gray-500'

--- a/apps/fe/src/app/_components/IntroCards.tsx
+++ b/apps/fe/src/app/_components/IntroCards.tsx
@@ -1,21 +1,27 @@
 'use client';
 
+import type { CSSProperties } from 'react';
+
 export type SolutionCardProps = {
   title: string;
   desc: string;
   image: string;
 };
 
+function buildCardBackgroundStyle(image: string): CSSProperties {
+  return {
+    backgroundImage: `url(${image})`,
+    backgroundSize: 'cover',
+    backgroundPosition: 'center',
+    backgroundRepeat: 'no-repeat',
+  };
+}
+
 export function SolutionCard({ title, desc, image }: SolutionCardProps) {
   return (
     <div
       className="relative flex h-[30rem] w-[30rem] flex-col justify-end overflow-hidden rounded-12 p-20"
-      style={{
-        backgroundImage: `url(${image})`,
-        backgroundSize: 'cover',
-        backgroundPosition: 'center',
-        backgroundRepeat: 'no-repeat',
-      }}
+      style={buildCardBackgroundStyle(image)}
     >
       <div className="flex flex-col gap-4">
         <p className="whitespace-pre-line text-body2 font-semibold text-white">
@@ -39,12 +45,7 @@ export function NewsCard({ tag, title, image }: NewsCardProps) {
   return (
     <div
       className="relative flex h-[32rem] w-[60rem] flex-col justify-between overflow-hidden rounded-16 p-24"
-      style={{
-        backgroundImage: `url(${image})`,
-        backgroundSize: 'cover',
-        backgroundPosition: 'center',
-        backgroundRepeat: 'no-repeat',
-      }}
+      style={buildCardBackgroundStyle(image)}
     >
       <span className="inline-flex w-fit items-center rounded-full bg-white/90 px-12 py-4 text-body4 text-gray-900">
         {tag}

--- a/apps/fe/src/app/_components/IntroCards.tsx
+++ b/apps/fe/src/app/_components/IntroCards.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+export type SolutionCardProps = {
+  title: string;
+  desc: string;
+  image: string;
+};
+
+export function SolutionCard({ title, desc, image }: SolutionCardProps) {
+  return (
+    <div
+      className="relative flex h-[30rem] w-[30rem] flex-col justify-end overflow-hidden rounded-12 p-20"
+      style={{
+        backgroundImage: `url(${image})`,
+        backgroundSize: 'cover',
+        backgroundPosition: 'center',
+        backgroundRepeat: 'no-repeat',
+      }}
+    >
+      <div className="flex flex-col gap-4">
+        <p className="whitespace-pre-line text-body2 font-semibold text-white">
+          {title}
+        </p>
+        <p className="line-clamp-2 whitespace-pre-line text-body4 text-white/70">
+          {desc}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export type NewsCardProps = {
+  tag: string;
+  title: string;
+  image: string;
+};
+
+export function NewsCard({ tag, title, image }: NewsCardProps) {
+  return (
+    <div
+      className="relative flex h-[32rem] w-[60rem] flex-col justify-between overflow-hidden rounded-16 p-24"
+      style={{
+        backgroundImage: `url(${image})`,
+        backgroundSize: 'cover',
+        backgroundPosition: 'center',
+        backgroundRepeat: 'no-repeat',
+      }}
+    >
+      <span className="inline-flex w-fit items-center rounded-full bg-white/90 px-12 py-4 text-body4 text-gray-900">
+        {tag}
+      </span>
+      <p className="whitespace-pre-line text-body3 font-semibold text-white">
+        {title}
+      </p>
+    </div>
+  );
+}

--- a/apps/fe/src/app/_components/IntroCtaSection.tsx
+++ b/apps/fe/src/app/_components/IntroCtaSection.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import IntroStartButton from './IntroStartButton';
+
 const CTA_BG_IMAGE = '/illusts/intro/cta.png';
 
 export type IntroCtaSectionProps = {
@@ -37,13 +39,7 @@ export default function IntroCtaSection({ onStart }: IntroCtaSectionProps) {
             <br />
             AI 데이터 분석 파트너입니다.
           </h2>
-          <button
-            type="button"
-            onClick={onStart}
-            className="self-start rounded-full bg-orange-500 px-24 py-12 text-body2 font-semibold text-white transition-colors hover:bg-orange-600"
-          >
-            Logue 체험하기
-          </button>
+          <IntroStartButton onClick={onStart} />
         </div>
       </div>
     </section>

--- a/apps/fe/src/app/_components/IntroCtaSection.tsx
+++ b/apps/fe/src/app/_components/IntroCtaSection.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+const CTA_BG_IMAGE = '/illusts/intro/cta.png';
+
+export type IntroCtaSectionProps = {
+  onStart: () => void;
+};
+
+export default function IntroCtaSection({ onStart }: IntroCtaSectionProps) {
+  return (
+    <section className="bg-white px-[8rem] pb-[8rem]">
+      <div
+        className="relative h-[33.3rem]"
+        style={{
+          borderRadius: '2rem',
+          overflow: 'hidden',
+          isolation: 'isolate',
+        }}
+      >
+        <div
+          aria-hidden
+          style={{
+            position: 'absolute',
+            inset: 0,
+            borderRadius: 'inherit',
+            backgroundImage: `url(${CTA_BG_IMAGE})`,
+            backgroundPosition: 'center',
+            backgroundRepeat: 'no-repeat',
+          }}
+        />
+        <div
+          className="flex h-full flex-col justify-center gap-20 px-32 py-32"
+          style={{ position: 'relative', zIndex: 1 }}
+        >
+          <h2 className="text-head2 text-white">
+            Logue는 당신의 가장 스마트한
+            <br />
+            AI 데이터 분석 파트너입니다.
+          </h2>
+          <button
+            type="button"
+            onClick={onStart}
+            className="self-start rounded-full bg-orange-500 px-24 py-12 text-body2 font-semibold text-white transition-colors hover:bg-orange-600"
+          >
+            Logue 체험하기
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/fe/src/app/_components/IntroHeader.tsx
+++ b/apps/fe/src/app/_components/IntroHeader.tsx
@@ -31,8 +31,7 @@ export default function IntroHeader({
 }: IntroHeaderProps) {
   return (
     <header
-      style={{ position: 'fixed', top: 0, left: 0, right: 0, zIndex: 50 }}
-      className={`flex items-center px-32 py-16 transition-colors duration-200 ${
+      className={`fixed left-0 right-0 top-0 z-50 flex items-center px-32 py-16 transition-colors duration-200 ${
         scrolled
           ? 'bg-white shadow-[0_0.1rem_0.4rem_rgba(0,0,0,0.06)]'
           : 'bg-[rgba(17,17,17,0.20)] shadow-[0_0.1rem_1.2rem_rgba(252,131,32,0.20)] backdrop-blur-[0.71rem]'
@@ -41,6 +40,7 @@ export default function IntroHeader({
       <button
         type="button"
         onClick={onLogoClick}
+        aria-label="Logue 홈으로 이동"
         className="mr-24 flex shrink-0 items-center gap-8"
       >
         {/* eslint-disable-next-line @next/next/no-img-element */}

--- a/apps/fe/src/app/_components/IntroHeader.tsx
+++ b/apps/fe/src/app/_components/IntroHeader.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import PriceIcon from '@/assets/icons/price.svg';
+import SuccessIcon from '@/assets/icons/success.svg';
+
+const LOGO_SRC = '/illusts/logo.svg';
+
+type IntroNavItem = {
+  label: string;
+  href: string;
+  Icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+};
+
+const NAV_ITEMS: IntroNavItem[] = [
+  { label: '요금', href: '/pricing', Icon: PriceIcon },
+  { label: '서비스', href: '/service', Icon: SuccessIcon },
+];
+
+export type IntroHeaderProps = {
+  scrolled: boolean;
+  onLogoClick: () => void;
+  onLoginClick: () => void;
+  onNavClick: (href: string) => void;
+};
+
+export default function IntroHeader({
+  scrolled,
+  onLogoClick,
+  onLoginClick,
+  onNavClick,
+}: IntroHeaderProps) {
+  return (
+    <header
+      style={{ position: 'fixed', top: 0, left: 0, right: 0, zIndex: 50 }}
+      className={`flex items-center px-32 py-16 transition-colors duration-200 ${
+        scrolled
+          ? 'bg-white shadow-[0_0.1rem_0.4rem_rgba(0,0,0,0.06)]'
+          : 'bg-[rgba(17,17,17,0.20)] shadow-[0_0.1rem_1.2rem_rgba(252,131,32,0.20)] backdrop-blur-[0.71rem]'
+      }`}
+    >
+      <button
+        type="button"
+        onClick={onLogoClick}
+        className="mr-24 flex shrink-0 items-center gap-8"
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src={LOGO_SRC} alt="Logue" className="h-28 w-auto" />
+      </button>
+
+      <nav className="flex items-center gap-20">
+        {NAV_ITEMS.map((item) => (
+          <button
+            key={item.href}
+            type="button"
+            onClick={() => onNavClick(item.href)}
+            className="flex items-center gap-8"
+          >
+            <item.Icon
+              aria-hidden
+              className={`icon-20 transition-colors ${
+                scrolled ? 'text-gray-400' : 'text-white/60'
+              }`}
+            />
+            <span
+              className={`text-body2 transition-colors ${
+                scrolled ? 'text-gray-800' : 'text-white'
+              }`}
+            >
+              {item.label}
+            </span>
+          </button>
+        ))}
+      </nav>
+
+      <div className="ml-auto flex items-center gap-20">
+        <button
+          type="button"
+          onClick={onLoginClick}
+          className={`text-body2 underline underline-offset-2 transition-colors ${
+            scrolled
+              ? 'text-gray-900 hover:text-gray-700'
+              : 'text-white hover:text-white/80'
+          }`}
+        >
+          로그인
+        </button>
+        <button
+          type="button"
+          onClick={onLoginClick}
+          className={`rounded-full px-20 py-8 text-body2 font-medium transition-colors ${
+            scrolled
+              ? 'bg-orange-500 text-white hover:bg-orange-600'
+              : 'bg-white text-gray-900 hover:bg-gray-100'
+          }`}
+        >
+          회원가입
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/apps/fe/src/app/_components/IntroHeroSection.tsx
+++ b/apps/fe/src/app/_components/IntroHeroSection.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+const HERO_BG = `conic-gradient(
+  from -40deg at 81.42% 33.69%,
+  var(--color-orange-200) 6.43deg,
+  var(--color-orange-400) 13.69deg,
+  var(--color-orange-500) 19.25deg,
+  var(--color-gray-900) 37.76deg,
+  var(--color-gray-900) 46.89deg,
+  var(--color-orange-500) 152.33deg,
+  var(--color-orange-200) 184.34deg,
+  var(--color-orange-400) 197.66deg,
+  #5A4022 211.03deg,
+  var(--color-gray-900) 221.98deg,
+  #111111 242.38deg,
+  var(--color-gray-900) 254.14deg,
+  #604423 283.93deg,
+  #FFA947 342.71deg
+)`;
+
+export type IntroHeroSectionProps = {
+  onStart: () => void;
+};
+
+export default function IntroHeroSection({ onStart }: IntroHeroSectionProps) {
+  return (
+    <section
+      className="relative flex h-screen flex-col justify-center px-[8rem] text-white"
+      style={{ background: HERO_BG }}
+    >
+      <div className="flex max-w-5xl flex-col gap-32">
+        <div className="flex flex-col gap-12">
+          <h1 className="text-head1 leading-tight">
+            Logue는 당신의 가장 스마트한
+            <br />
+            AI 데이터 분석 파트너입니다.
+          </h1>
+          <p className="text-body2 text-gray-300">
+            당신의 업무 효율을 극대화하는 파트너, Logue.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onStart}
+          className="self-start rounded-full bg-orange-500 px-24 py-12 text-body2 font-semibold text-white transition-colors hover:bg-orange-600"
+        >
+          Logue 체험하기
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/apps/fe/src/app/_components/IntroHeroSection.tsx
+++ b/apps/fe/src/app/_components/IntroHeroSection.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import IntroStartButton from './IntroStartButton';
+
 const HERO_BG = `conic-gradient(
   from -40deg at 81.42% 33.69%,
   var(--color-orange-200) 6.43deg,
@@ -39,13 +41,7 @@ export default function IntroHeroSection({ onStart }: IntroHeroSectionProps) {
             당신의 업무 효율을 극대화하는 파트너, Logue.
           </p>
         </div>
-        <button
-          type="button"
-          onClick={onStart}
-          className="self-start rounded-full bg-orange-500 px-24 py-12 text-body2 font-semibold text-white transition-colors hover:bg-orange-600"
-        >
-          Logue 체험하기
-        </button>
+        <IntroStartButton onClick={onStart} />
       </div>
     </section>
   );

--- a/apps/fe/src/app/_components/IntroStartButton.tsx
+++ b/apps/fe/src/app/_components/IntroStartButton.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
+
+type IntroStartButtonProps = {
+  children?: ReactNode;
+} & ButtonHTMLAttributes<HTMLButtonElement>;
+
+export default function IntroStartButton({
+  children = 'Logue 체험하기',
+  className = '',
+  ...props
+}: IntroStartButtonProps) {
+  return (
+    <button
+      type="button"
+      className={`self-start rounded-full bg-orange-500 px-24 py-12 text-body2 font-semibold text-white transition-colors hover:bg-orange-600 ${className}`.trim()}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}

--- a/apps/fe/src/app/page.tsx
+++ b/apps/fe/src/app/page.tsx
@@ -2,47 +2,12 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import PriceIcon from '@/assets/icons/price.svg';
-import SuccessIcon from '@/assets/icons/success.svg';
+import { NewsCard, SolutionCard } from './_components/IntroCards';
 import IntroCarousel from './_components/IntroCarousel';
+import IntroCtaSection from './_components/IntroCtaSection';
+import IntroHeader from './_components/IntroHeader';
+import IntroHeroSection from './_components/IntroHeroSection';
 
-// 다색 일러스트는 SVGR 변환을 피하기 위해 public/ 정적 자산
-const LOGO_SRC = '/illusts/logo.svg';
-
-type IntroNavItem = {
-  label: string;
-  href: string;
-  Icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
-};
-
-const NAV_ITEMS: IntroNavItem[] = [
-  { label: '요금', href: '/pricing', Icon: PriceIcon },
-  { label: '서비스', href: '/service', Icon: SuccessIcon },
-];
-
-// 시안 conic-gradient 그대로 (from -40deg at 81.42% 33.69%)
-const HERO_BG = `conic-gradient(
-  from -40deg at 81.42% 33.69%,
-  var(--color-orange-200) 6.43deg,
-  var(--color-orange-400) 13.69deg,
-  var(--color-orange-500) 19.25deg,
-  var(--color-gray-900) 37.76deg,
-  var(--color-gray-900) 46.89deg,
-  var(--color-orange-500) 152.33deg,
-  var(--color-orange-200) 184.34deg,
-  var(--color-orange-400) 197.66deg,
-  #5A4022 211.03deg,
-  var(--color-gray-900) 221.98deg,
-  #111111 242.38deg,
-  var(--color-gray-900) 254.14deg,
-  #604423 283.93deg,
-  #FFA947 342.71deg
-)`;
-
-// 마지막 CTA 카드 배경
-const CTA_BG_IMAGE = '/illusts/intro/cta.png';
-
-// 솔루션 카드. (이미지 3장을 순환 매핑)
 const SOLUTION_CARDS = [
   {
     id: 'sol-1',
@@ -76,7 +41,6 @@ const SOLUTION_CARDS = [
   },
 ];
 
-// 최신 소식 카드. (이미지 1장 반복)
 const NEWS_CARDS = [
   {
     id: 'news-1',
@@ -106,10 +70,13 @@ export default function IntroPage() {
     window.location.assign('/login');
   };
 
-  // hero(=뷰포트 1개) 만큼 스크롤되면 헤더가 흰 배경 + 그림자로 전환됨
+  const goToAnalysis = () => {
+    router.push('/analysis');
+  };
+
   useEffect(() => {
     const update = () => {
-      const threshold = window.innerHeight - 80; // 헤더 높이 정도 미리 트리거
+      const threshold = window.innerHeight - 80;
       setScrolled(window.scrollY > threshold);
     };
     update();
@@ -123,105 +90,15 @@ export default function IntroPage() {
 
   return (
     <div className="flex min-h-screen flex-col">
-      {/* Header: hero 위에서는 반투명+블러, 스크롤 후엔 흰 배경 */}
-      <header
-        style={{ position: 'fixed', top: 0, left: 0, right: 0, zIndex: 50 }}
-        className={`flex items-center px-32 py-16 transition-colors duration-200 ${
-          scrolled
-            ? 'bg-white shadow-[0_0.1rem_0.4rem_rgba(0,0,0,0.06)]'
-            : 'bg-[rgba(17,17,17,0.20)] shadow-[0_0.1rem_1.2rem_rgba(252,131,32,0.20)] backdrop-blur-[0.71rem]'
-        }`}
-      >
-        {/* 로고 */}
-        <button
-          type="button"
-          onClick={() => router.push('/')}
-          className="mr-24 flex shrink-0 items-center gap-8"
-        >
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src={LOGO_SRC} alt="Logue" className="h-28 w-auto" />
-        </button>
+      <IntroHeader
+        scrolled={scrolled}
+        onLogoClick={() => router.push('/')}
+        onLoginClick={goToLogin}
+        onNavClick={(href) => router.push(href)}
+      />
 
-        {/* nav */}
-        <nav className="flex items-center gap-20">
-          {NAV_ITEMS.map((item) => (
-            <button
-              key={item.href}
-              type="button"
-              onClick={() => router.push(item.href)}
-              className="flex items-center gap-8"
-            >
-              <item.Icon
-                aria-hidden
-                className={`icon-20 transition-colors ${
-                  scrolled ? 'text-gray-400' : 'text-white/60'
-                }`}
-              />
-              <span
-                className={`text-body2 transition-colors ${
-                  scrolled ? 'text-gray-800' : 'text-white'
-                }`}
-              >
-                {item.label}
-              </span>
-            </button>
-          ))}
-        </nav>
+      <IntroHeroSection onStart={goToAnalysis} />
 
-        {/* 우측 액션 */}
-        <div className="ml-auto flex items-center gap-20">
-          <button
-            type="button"
-            onClick={goToLogin}
-            className={`text-body2 underline underline-offset-2 transition-colors ${
-              scrolled
-                ? 'text-gray-900 hover:text-gray-700'
-                : 'text-white hover:text-white/80'
-            }`}
-          >
-            로그인
-          </button>
-          <button
-            type="button"
-            onClick={goToLogin}
-            className={`rounded-full px-20 py-8 text-body2 font-medium transition-colors ${
-              scrolled
-                ? 'bg-orange-500 text-white hover:bg-orange-600'
-                : 'bg-white text-gray-900 hover:bg-gray-100'
-            }`}
-          >
-            회원가입
-          </button>
-        </div>
-      </header>
-
-      {/* Hero Section */}
-      <section
-        className="relative flex h-screen flex-col justify-center px-[8rem] text-white"
-        style={{ background: HERO_BG }}
-      >
-        <div className="flex max-w-5xl flex-col gap-32">
-          <div className="flex flex-col gap-12">
-            <h1 className="text-head1 leading-tight">
-              Logue는 당신의 가장 스마트한
-              <br />
-              AI 데이터 분석 파트너입니다.
-            </h1>
-            <p className="text-body2 text-gray-300">
-              당신의 업무 효율을 극대화하는 파트너, Logue.
-            </p>
-          </div>
-          <button
-            type="button"
-            onClick={() => router.push('/analysis')}
-            className="self-start rounded-full bg-orange-500 px-24 py-12 text-body2 font-semibold text-white transition-colors hover:bg-orange-600"
-          >
-            Logue 체험하기
-          </button>
-        </div>
-      </section>
-
-      {/* 스마트한 분석 솔루션 캐러셀 */}
       <div className="bg-white pt-[8rem] pb-[6rem]">
         <IntroCarousel
           description="데이터 분석의 복잡함을 고려한"
@@ -243,7 +120,6 @@ export default function IntroPage() {
         />
       </div>
 
-      {/* Logue의 최신 소식 캐러셀 */}
       <div className="bg-white pt-[6rem] pb-[8rem]">
         <IntroCarousel
           title={
@@ -264,110 +140,7 @@ export default function IntroPage() {
         />
       </div>
 
-      {/* 마지막 CTA */}
-      <section className="bg-white px-[8rem] pb-[8rem]">
-        <div
-          className="relative h-[33.3rem]"
-          style={{
-            borderRadius: '2rem',
-            overflow: 'hidden',
-            isolation: 'isolate',
-          }}
-        >
-          {/* 배경 이미지 레이어 */}
-          <div
-            aria-hidden
-            style={{
-              position: 'absolute',
-              inset: 0,
-              borderRadius: 'inherit',
-              backgroundImage: `url(${CTA_BG_IMAGE})`,
-              backgroundPosition: 'center',
-              backgroundRepeat: 'no-repeat',
-            }}
-          />
-          {/* 콘텐츠 레이어 */}
-          <div
-            className="flex h-full flex-col justify-center gap-20 px-32 py-32"
-            style={{ position: 'relative', zIndex: 1 }}
-          >
-            <h2 className="text-head2 text-white">
-              Logue는 당신의 가장 스마트한
-              <br />
-              AI 데이터 분석 파트너입니다.
-            </h2>
-            <button
-              type="button"
-              onClick={() => router.push('/analysis')}
-              className="self-start rounded-full bg-orange-500 px-24 py-12 text-body2 font-semibold text-white transition-colors hover:bg-orange-600"
-            >
-              Logue 체험하기
-            </button>
-          </div>
-        </div>
-      </section>
-    </div>
-  );
-}
-
-/** 스마트 솔루션 캐러셀의 작은 카드. 배경에 일러스트 이미지를 cover 로 깐다. */
-function SolutionCard({
-  title,
-  desc,
-  image,
-}: {
-  title: string;
-  desc: string;
-  image: string;
-}) {
-  return (
-    <div
-      className="relative flex h-[30rem] w-[30rem] flex-col justify-end overflow-hidden rounded-12 p-20"
-      style={{
-        backgroundImage: `url(${image})`,
-        backgroundSize: 'cover',
-        backgroundPosition: 'center',
-        backgroundRepeat: 'no-repeat',
-      }}
-    >
-      <div className="flex flex-col gap-4">
-        <p className="whitespace-pre-line text-body2 font-semibold text-white">
-          {title}
-        </p>
-        <p className="line-clamp-2 whitespace-pre-line text-body4 text-white/70">
-          {desc}
-        </p>
-      </div>
-    </div>
-  );
-}
-
-/** 최신 소식 캐러셀의 큰 카드. */
-function NewsCard({
-  tag,
-  title,
-  image,
-}: {
-  tag: string;
-  title: string;
-  image: string;
-}) {
-  return (
-    <div
-      className="relative flex h-[32rem] w-[60rem] flex-col justify-between overflow-hidden rounded-16 p-24"
-      style={{
-        backgroundImage: `url(${image})`,
-        backgroundSize: 'cover',
-        backgroundPosition: 'center',
-        backgroundRepeat: 'no-repeat',
-      }}
-    >
-      <span className="inline-flex w-fit items-center rounded-full bg-white/90 px-12 py-4 text-body4 text-gray-900">
-        {tag}
-      </span>
-      <p className="whitespace-pre-line text-body3 font-semibold text-white">
-        {title}
-      </p>
+      <IntroCtaSection onStart={goToAnalysis} />
     </div>
   );
 }

--- a/apps/fe/src/components/Dropdown/Dropdown.tsx
+++ b/apps/fe/src/components/Dropdown/Dropdown.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState, useRef, useEffect, useId, type ReactNode } from 'react';
+import { type ReactNode } from 'react';
+import { useListboxDropdown } from '@/hooks/useListboxDropdown';
 import DropdownDetails from '../DropdownDetails/DropdownDetails';
 
 export type DropdownOption = {
@@ -27,25 +28,20 @@ export default function Dropdown({
   className = '',
   helperText,
 }: DropdownProps) {
-  const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-  const buttonRef = useRef<HTMLButtonElement>(null);
-  const listboxId = useId();
+  const {
+    buttonRef,
+    closeAndFocusButton,
+    handleButtonKeyDown,
+    listboxId,
+    open,
+    rootRef,
+    setOpen,
+  } = useListboxDropdown();
 
   const selected = options.find((o) => o.value === value);
 
-  useEffect(() => {
-    function handleOutside(e: MouseEvent) {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    }
-    document.addEventListener('mousedown', handleOutside);
-    return () => document.removeEventListener('mousedown', handleOutside);
-  }, []);
-
   return (
-    <div ref={ref} className={`relative inline-block ${className}`.trim()}>
+    <div ref={rootRef} className={`relative inline-block ${className}`.trim()}>
       <button
         ref={buttonRef}
         type="button"
@@ -53,28 +49,7 @@ export default function Dropdown({
         aria-expanded={open}
         aria-controls={open ? listboxId : undefined}
         onClick={() => setOpen((prev) => !prev)}
-        onKeyDown={(event) => {
-          if (event.key === 'Escape') {
-            setOpen(false);
-            return;
-          }
-
-          if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return;
-
-          event.preventDefault();
-          setOpen(true);
-          window.requestAnimationFrame(() => {
-            const optionButtons =
-              ref.current?.querySelectorAll<HTMLButtonElement>(
-                '[role="option"]:not([disabled])',
-              );
-            const target =
-              event.key === 'ArrowUp'
-                ? optionButtons?.[optionButtons.length - 1]
-                : optionButtons?.[0];
-            target?.focus();
-          });
-        }}
+        onKeyDown={handleButtonKeyDown}
         className="inline-flex h-[3.4rem] items-center justify-center gap-12 rounded-8 border border-gray-800 bg-white pl-16 pr-12 text-body2 text-gray-800 transition-colors hover:border-gray-900"
       >
         {icon && <span className="shrink-0 [&>svg]:icon-16">{icon}</span>}
@@ -106,13 +81,9 @@ export default function Dropdown({
           helperText={helperText}
           onSelect={(nextValue) => {
             onChange?.(nextValue);
-            setOpen(false);
-            buttonRef.current?.focus();
+            closeAndFocusButton();
           }}
-          onEscape={() => {
-            setOpen(false);
-            buttonRef.current?.focus();
-          }}
+          onEscape={closeAndFocusButton}
           className="absolute left-0 top-full z-10 mt-4"
         />
       )}

--- a/apps/fe/src/hooks/useListboxDropdown.ts
+++ b/apps/fe/src/hooks/useListboxDropdown.ts
@@ -1,0 +1,138 @@
+'use client';
+
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from 'react';
+
+type UseListboxDropdownOptions = {
+  optionSelector?: string;
+};
+
+const DEFAULT_OPTION_SELECTOR =
+  '[role="option"]:not([disabled]):not([aria-disabled="true"])';
+
+export function useListboxDropdown({
+  optionSelector = DEFAULT_OPTION_SELECTOR,
+}: UseListboxDropdownOptions = {}) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const listboxId = useId();
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handleMouseDown = (event: MouseEvent) => {
+      if (rootRef.current?.contains(event.target as Node)) return;
+      setOpen(false);
+    };
+
+    window.addEventListener('mousedown', handleMouseDown);
+    return () => window.removeEventListener('mousedown', handleMouseDown);
+  }, [open]);
+
+  const getOptions = useCallback(
+    () =>
+      Array.from(
+        rootRef.current?.querySelectorAll<HTMLElement>(optionSelector) ?? [],
+      ),
+    [optionSelector],
+  );
+
+  const focusOption = useCallback(
+    (edge: 'first' | 'last') => {
+      window.requestAnimationFrame(() => {
+        const options = getOptions();
+        const target = edge === 'first' ? options[0] : options.at(-1);
+        target?.focus();
+      });
+    },
+    [getOptions],
+  );
+
+  const closeAndFocusButton = useCallback(() => {
+    setOpen(false);
+    buttonRef.current?.focus();
+  }, []);
+
+  const handleButtonKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLButtonElement>) => {
+      if (event.key === 'Escape') {
+        setOpen(false);
+        return;
+      }
+
+      if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return;
+
+      event.preventDefault();
+      setOpen(true);
+      focusOption(event.key === 'ArrowUp' ? 'last' : 'first');
+    },
+    [focusOption],
+  );
+
+  const handleListboxKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLElement>) => {
+      if (event.key === 'Escape') {
+        closeAndFocusButton();
+        return;
+      }
+
+      if (
+        event.key !== 'ArrowDown' &&
+        event.key !== 'ArrowUp' &&
+        event.key !== 'Home' &&
+        event.key !== 'End'
+      ) {
+        return;
+      }
+
+      const options = getOptions();
+      if (options.length === 0) return;
+
+      event.preventDefault();
+
+      if (event.key === 'Home') {
+        options[0].focus();
+        return;
+      }
+
+      if (event.key === 'End') {
+        options.at(-1)?.focus();
+        return;
+      }
+
+      const activeIndex = options.findIndex(
+        (option) => option === document.activeElement,
+      );
+      const lastIndex = options.length - 1;
+      const nextIndex =
+        event.key === 'ArrowDown'
+          ? activeIndex >= lastIndex
+            ? 0
+            : activeIndex + 1
+          : activeIndex <= 0
+            ? lastIndex
+            : activeIndex - 1;
+
+      options[nextIndex].focus();
+    },
+    [closeAndFocusButton, getOptions],
+  );
+
+  return {
+    buttonRef,
+    closeAndFocusButton,
+    handleButtonKeyDown,
+    handleListboxKeyDown,
+    listboxId,
+    open,
+    rootRef,
+    setOpen,
+  };
+}


### PR DESCRIPTION
﻿## 요약
- #191 위에 쌓는 스택 PR입니다. #191이 먼저 머지되면 이 PR은 `dev`로 리타겟하면 됩니다.
- 남은 리팩토링 백로그 중 실제 코드에 남아 있는 분석 채팅 컨테이너, 드롭다운 상호작용 로직, 랜딩 페이지 인라인 섹션을 분리했습니다.
- `BalloonLabel`/차트 중복 항목은 현재 코드 기준 `VerificationResult` 한 곳에만 남아 있어 별도 변경하지 않았습니다.

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `yarn lint`
  - `yarn test`
  - `NEXT_PUBLIC_API_URL=http://localhost:8080 yarn build`
  - Playwright smoke: `/`, `/data`, `/analysis/1?analysisFlowId=1&dataSourceId=1` 렌더 및 데이터 정렬 드롭다운 열림 확인

## 스크린샷/로그 (선택)
- 구조 리팩토링 중심이라 별도 첨부 없음

## 롤백/리스크
- 리스크 포인트: 분석 채팅 페이지의 상태/폴링 흐름을 훅으로 이동했으므로 질문 생성, 기준 확정, 결과 조회 플로우 회귀 확인이 필요합니다.
- 드롭다운 키보드 이동과 외부 클릭 닫힘은 공통 훅으로 이동되어 관련 UI 3곳을 함께 확인해야 합니다.
- 롤백 방법: 이 PR revert

## 관련 이슈
Refs #160
Refs #168
Refs #179


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 새로운 인트로/랜딩 페이지 디자인 추가 (헤더, 히어로 섹션, CTA 섹션, 카드 UI)
  * 분석 채팅 인터페이스의 상태 관리 개선

* **Improvements**
  * 드롭다운 및 리스트박스 컴포넌트의 키보드 네비게이션 강화
  * 드롭다운 열기/닫기 및 포커스 관리 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/26-ewha-capstone-logue/logue/pull/192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->