### PR TITLE
fix: OAuth 로그인 계정 선택 반복 수정

### DIFF
--- a/apps/fe/src/app/login/route.ts
+++ b/apps/fe/src/app/login/route.ts
@@ -1,6 +1,16 @@
+import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
-import { getOAuthLoginUrl } from '@/lib/authRedirect';
+import {
+  getOAuthCallbackRedirectUrl,
+  getOAuthLoginUrl,
+} from '@/lib/authRedirect';
 
-export function GET() {
+export function GET(request: NextRequest) {
+  const callbackRedirectUrl = getOAuthCallbackRedirectUrl(request.nextUrl);
+
+  if (callbackRedirectUrl) {
+    return NextResponse.redirect(callbackRedirectUrl);
+  }
+
   return NextResponse.redirect(getOAuthLoginUrl());
 }

--- a/apps/fe/src/lib/authRedirect.test.ts
+++ b/apps/fe/src/lib/authRedirect.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { getOAuthCallbackRedirectUrl } from './authRedirect';
+
+describe('getOAuthCallbackRedirectUrl', () => {
+  it('moves tokenized login callbacks to the auth callback entry', () => {
+    const redirectUrl = getOAuthCallbackRedirectUrl(
+      new URL(
+        'https://www.asklogue.co/login?accessToken=%20access-token%20&refreshToken=%20refresh-token%20',
+      ),
+    );
+
+    expect(redirectUrl?.toString()).toBe(
+      'https://www.asklogue.co/?accessToken=access-token&refreshToken=refresh-token',
+    );
+  });
+
+  it('omits an empty refresh token', () => {
+    const redirectUrl = getOAuthCallbackRedirectUrl(
+      new URL('https://www.asklogue.co/login?accessToken=access-token'),
+    );
+
+    expect(redirectUrl?.toString()).toBe(
+      'https://www.asklogue.co/?accessToken=access-token',
+    );
+  });
+
+  it('keeps plain login requests on the OAuth start path', () => {
+    expect(
+      getOAuthCallbackRedirectUrl(new URL('https://www.asklogue.co/login')),
+    ).toBeNull();
+  });
+
+  it('rejects blank access token callbacks', () => {
+    expect(
+      getOAuthCallbackRedirectUrl(
+        new URL('https://www.asklogue.co/login?accessToken=%20'),
+      ),
+    ).toBeNull();
+  });
+});

--- a/apps/fe/src/lib/authRedirect.ts
+++ b/apps/fe/src/lib/authRedirect.ts
@@ -1,5 +1,23 @@
 import { getApiBaseUrl } from './apiBaseUrl';
 
+const AUTH_CALLBACK_PATH = '/';
+
 export function getOAuthLoginUrl() {
   return new URL('/oauth2/authorization/google', getApiBaseUrl()).toString();
+}
+
+export function getOAuthCallbackRedirectUrl(requestUrl: URL) {
+  const accessToken = requestUrl.searchParams.get('accessToken')?.trim();
+
+  if (!accessToken) return null;
+
+  const refreshToken = requestUrl.searchParams.get('refreshToken')?.trim();
+  const redirectUrl = new URL(AUTH_CALLBACK_PATH, requestUrl.origin);
+  redirectUrl.searchParams.set('accessToken', accessToken);
+
+  if (refreshToken) {
+    redirectUrl.searchParams.set('refreshToken', refreshToken);
+  }
+
+  return redirectUrl;
 }


### PR DESCRIPTION
﻿## 요약
- `/login?accessToken=...` 형태의 OAuth 콜백이 Google OAuth 시작점으로 다시 처리되는 흐름을 막았습니다.
- 토큰이 포함된 `/login` 요청은 `/`로 토큰을 보존해 넘기고, 기존 `AuthProvider`가 저장과 후속 이동을 처리하게 했습니다.

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩터링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `yarn test`
  - `yarn eslint src/app/login/route.ts src/lib/authRedirect.ts src/lib/authRedirect.test.ts`
  - `$env:NEXT_PUBLIC_API_URL='https://api-stg.asklogue.co'; yarn build`

## 스크린샷/로그 (선택)
- 해당 없음

## 롤백/리스크
- 리스크: 토큰이 붙은 `/login` 콜백만 별도 처리하며, 일반 `/login` OAuth 시작 동작은 유지됩니다.
- 롤백 방법: `src/app/login/route.ts`, `src/lib/authRedirect.ts`, `src/lib/authRedirect.test.ts` 변경을 되돌립니다.

## 관련 이슈
Closes #198
