### PR TITLE
refactor: FE 리팩토링 백로그 정리

### DIFF
--- a/apps/fe/src/app/(main)/analysis/[id]/_components/CriterionSelect.tsx
+++ b/apps/fe/src/app/(main)/analysis/[id]/_components/CriterionSelect.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import ArrowDownIcon from '@/assets/icons/arrow-down.svg';
-import { useListboxDropdown } from '@/hooks/useListboxDropdown';
+import { ListboxDropdown } from '@/components';
 
 type CommonProps = {
   options: string[];
@@ -19,7 +19,7 @@ type MultiProps = CommonProps & {
   values: string[];
   maxSelect?: number;
   onChange: (next: string[]) => void;
-  /** 옵션 리스트 상단에 표시되는 헤더 (예: "최대 2개 선택") */
+  /** ?듭뀡 由ъ뒪???곷떒???쒖떆?섎뒗 ?ㅻ뜑 (?? "理쒕? 2媛??좏깮") */
   headerLabel?: string;
 };
 
@@ -29,137 +29,123 @@ export default function CriterionSelect(props: CriterionSelectProps) {
   const optionFocusSelector = props.multi
     ? '[role="option"]:not([aria-disabled="true"])'
     : '[role="option"]:not([disabled]):not([aria-disabled="true"])';
-  const {
-    buttonRef,
-    closeAndFocusButton,
-    handleButtonKeyDown,
-    handleListboxKeyDown,
-    listboxId,
-    open,
-    rootRef,
-    setOpen,
-  } = useListboxDropdown({ optionSelector: optionFocusSelector });
 
   const buttonLabel = props.multi
     ? props.values.length === 0
-      ? '선택'
+      ? '?좏깮'
       : props.values.length === 1
         ? props.values[0]
-        : `${props.values[0]} 외 ${props.values.length - 1}`
+        : `${props.values[0]} ??${props.values.length - 1}`
     : props.value;
 
   return (
-    <div
-      ref={rootRef}
-      className={`relative inline-block ${props.className ?? ''}`.trim()}
+    <ListboxDropdown
+      className={props.className}
+      optionSelector={optionFocusSelector}
     >
-      <button
-        ref={buttonRef}
-        type="button"
-        aria-haspopup="listbox"
-        aria-expanded={open}
-        aria-controls={open ? listboxId : undefined}
-        onClick={() => setOpen((v) => !v)}
-        onKeyDown={handleButtonKeyDown}
-        className="inline-flex min-w-[12rem] items-center justify-between gap-8 rounded-12 border border-gray-300 bg-white px-12 py-8 text-body2 text-gray-900 transition-colors hover:bg-gray-100"
-      >
-        <span>{buttonLabel}</span>
-        <ArrowDownIcon
-          aria-hidden
-          className={`icon-12 text-gray-700 transition-transform ${
-            open ? 'rotate-180' : ''
-          }`}
-        />
-      </button>
+      {({ closeAndFocusButton, listboxProps, open, triggerProps }) => (
+        <>
+          <button
+            {...triggerProps}
+            className="inline-flex min-w-[12rem] items-center justify-between gap-8 rounded-12 border border-gray-300 bg-white px-12 py-8 text-body2 text-gray-900 transition-colors hover:bg-gray-100"
+          >
+            <span>{buttonLabel}</span>
+            <ArrowDownIcon
+              aria-hidden
+              className={`icon-12 text-gray-700 transition-transform ${
+                open ? 'rotate-180' : ''
+              }`}
+            />
+          </button>
 
-      {open && (
-        <div
-          id={listboxId}
-          role="listbox"
-          aria-multiselectable={props.multi ? true : undefined}
-          onKeyDown={handleListboxKeyDown}
-          className="absolute left-0 z-10 mt-4 w-max min-w-full overflow-hidden rounded-12 border border-gray-300 bg-white shadow-[0_0.4rem_1.2rem_rgba(0,0,0,0.08)]"
-        >
-          {props.multi && props.headerLabel && (
-            <div className="border-b border-gray-200 px-12 py-8 text-body4 text-gray-600">
-              {props.headerLabel}
+          {open && (
+            <div
+              {...listboxProps}
+              aria-multiselectable={props.multi ? true : undefined}
+              className="absolute left-0 z-10 mt-4 w-max min-w-full overflow-hidden rounded-12 border border-gray-300 bg-white shadow-[0_0.4rem_1.2rem_rgba(0,0,0,0.08)]"
+            >
+              {props.multi && props.headerLabel && (
+                <div className="border-b border-gray-200 px-12 py-8 text-body4 text-gray-600">
+                  {props.headerLabel}
+                </div>
+              )}
+
+              {props.options.map((opt) => {
+                if (props.multi) {
+                  const checked = props.values.includes(opt);
+                  const disabled =
+                    !checked &&
+                    props.maxSelect !== undefined &&
+                    props.values.length >= props.maxSelect;
+                  const handleToggle = () => {
+                    if (disabled) return;
+
+                    const next = checked
+                      ? props.values.filter((v) => v !== opt)
+                      : [...props.values, opt];
+                    props.onChange(next);
+                  };
+
+                  return (
+                    <label
+                      key={opt}
+                      role="option"
+                      aria-selected={checked}
+                      aria-disabled={disabled}
+                      tabIndex={disabled ? -1 : 0}
+                      onClick={(event) => {
+                        event.preventDefault();
+                        handleToggle();
+                      }}
+                      onKeyDown={(event) => {
+                        if (event.key !== 'Enter' && event.key !== ' ') return;
+
+                        event.preventDefault();
+                        handleToggle();
+                      }}
+                      className={`flex cursor-pointer items-center gap-8 px-12 py-8 text-body2 transition-colors hover:bg-gray-100 ${
+                        disabled
+                          ? 'cursor-not-allowed text-gray-500'
+                          : 'text-gray-900'
+                      }`}
+                    >
+                      <input
+                        type="checkbox"
+                        aria-hidden
+                        tabIndex={-1}
+                        checked={checked}
+                        disabled={disabled}
+                        readOnly
+                        className="h-16 w-16 accent-orange-500"
+                      />
+                      <span>{opt}</span>
+                    </label>
+                  );
+                }
+
+                const selected = props.value === opt;
+                return (
+                  <button
+                    key={opt}
+                    type="button"
+                    role="option"
+                    aria-selected={selected}
+                    onClick={() => {
+                      props.onChange(opt);
+                      closeAndFocusButton();
+                    }}
+                    className={`block w-full px-12 py-8 text-left text-body2 transition-colors hover:bg-gray-100 ${
+                      selected ? 'text-orange-500' : 'text-gray-900'
+                    }`}
+                  >
+                    {opt}
+                  </button>
+                );
+              })}
             </div>
           )}
-
-          {props.options.map((opt) => {
-            if (props.multi) {
-              const checked = props.values.includes(opt);
-              const disabled =
-                !checked &&
-                props.maxSelect !== undefined &&
-                props.values.length >= props.maxSelect;
-              const handleToggle = () => {
-                if (disabled) return;
-
-                const next = checked
-                  ? props.values.filter((v) => v !== opt)
-                  : [...props.values, opt];
-                props.onChange(next);
-              };
-
-              return (
-                <label
-                  key={opt}
-                  role="option"
-                  aria-selected={checked}
-                  aria-disabled={disabled}
-                  tabIndex={disabled ? -1 : 0}
-                  onClick={(event) => {
-                    event.preventDefault();
-                    handleToggle();
-                  }}
-                  onKeyDown={(event) => {
-                    if (event.key !== 'Enter' && event.key !== ' ') return;
-
-                    event.preventDefault();
-                    handleToggle();
-                  }}
-                  className={`flex cursor-pointer items-center gap-8 px-12 py-8 text-body2 transition-colors hover:bg-gray-100 ${
-                    disabled
-                      ? 'cursor-not-allowed text-gray-500'
-                      : 'text-gray-900'
-                  }`}
-                >
-                  <input
-                    type="checkbox"
-                    aria-hidden
-                    tabIndex={-1}
-                    checked={checked}
-                    disabled={disabled}
-                    readOnly
-                    className="h-16 w-16 accent-orange-500"
-                  />
-                  <span>{opt}</span>
-                </label>
-              );
-            }
-
-            const selected = props.value === opt;
-            return (
-              <button
-                key={opt}
-                type="button"
-                role="option"
-                aria-selected={selected}
-                onClick={() => {
-                  props.onChange(opt);
-                  closeAndFocusButton();
-                }}
-                className={`block w-full px-12 py-8 text-left text-body2 transition-colors hover:bg-gray-100 ${
-                  selected ? 'text-orange-500' : 'text-gray-900'
-                }`}
-              >
-                {opt}
-              </button>
-            );
-          })}
-        </div>
+        </>
       )}
-    </div>
+    </ListboxDropdown>
   );
 }

--- a/apps/fe/src/app/(main)/analysis/[id]/_hooks/useAnalysisChat.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_hooks/useAnalysisChat.ts
@@ -1,24 +1,12 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useCallback, useEffect, useReducer, useRef, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { useSearchParams } from 'next/navigation';
 import {
-  analysisQueryKeys,
-  createQuestion,
-  getCriteria,
-  getCriteriaStatus,
-  getResult,
-  getResultStatus,
-  getSummary,
-  getSummaryStatus,
-  updateCriteria,
-  type AnalysisJobStatus,
   type GetQuestionCriteriaResponse,
   type GetQuestionResultResponse,
   type GetSummaryResponse,
-  type QuestionCriteriaParams,
-  type QuestionResultParams,
   type UpdateQuestionCriteriaRequest,
 } from '@/apis/analysis';
 import {
@@ -37,6 +25,13 @@ import {
 import type { PromptInputValue } from '../../_components/PromptInput';
 import type { ColumnCandidate } from '../_components/AnalysisResult';
 import type { DataTableColumn } from '../_components/DataTablePreview';
+import {
+  analysisChatFlowReducer,
+  initialAnalysisChatFlowState,
+} from './useAnalysisChatFlow';
+import { useCriteriaPhase } from './useCriteriaPhase';
+import { useResultPhase } from './useResultPhase';
+import { useSummaryPhase } from './useSummaryPhase';
 
 export type CriteriaInitialMode = 'normal' | 'edit';
 
@@ -90,26 +85,6 @@ const SUMMARY_WARNING_MESSAGE_MAP: Record<string, string> = {
     '날짜 기준을 하나로 정할 수 없어요. 어떤 날짜를 기준으로 볼지 선택해 주세요.',
 };
 
-type QuestionAnalysisVariables = {
-  targetConversationId: number;
-  targetAnalysisFlowId: number;
-  question: string;
-};
-
-type UpdateCriteriaVariables = {
-  targetConversationId: number;
-  targetAnalysisFlowId: number;
-  messageId: number;
-  request: UpdateQuestionCriteriaRequest;
-};
-
-type ResultAnalysisVariables = {
-  targetConversationId: number;
-  targetAnalysisFlowId: number;
-  messageId: number;
-  analysisCriteriaId: number;
-};
-
 function parsePositiveNumber(value: string | null | undefined) {
   if (!value) return null;
 
@@ -125,57 +100,6 @@ function compactStrings(values: Array<string | null | undefined>) {
 
 export function uniqueStrings(values: Array<string | null | undefined>) {
   return Array.from(new Set(compactStrings(values)));
-}
-
-function shouldPollJobStatus(status?: AnalysisJobStatus) {
-  return (
-    !status ||
-    status === 'QUEUED' ||
-    status === 'RUNNING' ||
-    status === 'RETRYING'
-  );
-}
-
-function isFailedJobStatus(status?: AnalysisJobStatus) {
-  return status === 'FAILED' || status === 'CANCELED' || status === 'CANCELLED';
-}
-
-function wait(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-async function waitForCriteriaSuccess(params: QuestionCriteriaParams) {
-  const startedAt = Date.now();
-
-  while (Date.now() - startedAt < QUESTION_ANALYSIS_TIMEOUT_MS) {
-    const { status } = await getCriteriaStatus(params);
-
-    if (status === 'SUCCESS') return;
-    if (isFailedJobStatus(status)) {
-      throw new Error(GET_CRITERIA_ERROR_MESSAGE);
-    }
-
-    await wait(STATUS_POLL_INTERVAL_MS);
-  }
-
-  throw new Error(GET_CRITERIA_ERROR_MESSAGE);
-}
-
-async function waitForResultSuccess(params: QuestionResultParams) {
-  const startedAt = Date.now();
-
-  while (Date.now() - startedAt < RESULT_ANALYSIS_TIMEOUT_MS) {
-    const { status } = await getResultStatus(params);
-
-    if (status === 'SUCCESS') return;
-    if (isFailedJobStatus(status)) {
-      throw new Error(GET_RESULT_ERROR_MESSAGE);
-    }
-
-    await wait(STATUS_POLL_INTERVAL_MS);
-  }
-
-  throw new Error(GET_RESULT_ERROR_MESSAGE);
 }
 
 function createPreviewTable(preview?: FilePreview | null) {
@@ -266,15 +190,18 @@ export function useAnalysisChat(routeConversationId: string) {
     },
   ]);
   const { toast, showToast } = useToast();
-  const [hasStartedInitialQuestion, setHasStartedInitialQuestion] =
-    useState(false);
-  const [hasResolvedStartPayload, setHasResolvedStartPayload] = useState(false);
-  const [canAutoStartInitialQuestion, setCanAutoStartInitialQuestion] =
-    useState(false);
-  const openNextCriteriaInEditRef = useRef(false);
+  const [flow, dispatchFlow] = useReducer(
+    analysisChatFlowReducer,
+    initialAnalysisChatFlowState,
+  );
   const readStartPayloadConversationIdRef = useRef<number | null>(null);
-  const questionSubmissionLockedRef = useRef(false);
-  const criteriaSubmissionLockedRef = useRef(false);
+  const {
+    canAutoStartInitialQuestion,
+    criteriaSubmissionLocked,
+    hasResolvedStartPayload,
+    hasStartedInitialQuestion,
+    questionSubmissionLocked,
+  } = flow;
 
   const initialPrompt = startPayload.prompt || DEFAULT_PROMPT;
   const fileName = startPayload.fileName ?? null;
@@ -288,105 +215,32 @@ export function useAnalysisChat(routeConversationId: string) {
     enabled: dataSourceId !== null,
   });
 
-  const summaryStatusQuery = useQuery({
-    queryKey: analysisQueryKeys.summaryStatus(
-      conversationId ?? 0,
-      analysisFlowId ?? 0,
-    ),
-    queryFn: () => {
-      if (conversationId === null || analysisFlowId === null) {
-        throw new Error(INVALID_ROUTE_MESSAGE);
-      }
-
-      return getSummaryStatus({ conversationId, analysisFlowId });
+  const { summary, summaryErrorMessage, summaryPending, summaryQuery } =
+    useSummaryPhase({
+      analysisFlowId,
+      conversationId,
+      failedSummaryMessage:
+        'CSV 데이터 요약에 실패했어요. 파일을 확인하고 다시 시도해 주세요.',
+      getSummaryErrorMessage: GET_SUMMARY_ERROR_MESSAGE,
+      invalidRouteMessage: INVALID_ROUTE_MESSAGE,
+      routeReady,
+      statusPollIntervalMs: STATUS_POLL_INTERVAL_MS,
+    });
+  const { questionAnalysisMutation, updateCriteriaMutation } = useCriteriaPhase(
+    {
+      getCriteriaErrorMessage: GET_CRITERIA_ERROR_MESSAGE,
+      questionAnalysisTimeoutMs: QUESTION_ANALYSIS_TIMEOUT_MS,
+      statusPollIntervalMs: STATUS_POLL_INTERVAL_MS,
     },
-    enabled: routeReady,
-    refetchInterval: (query) => {
-      const status = query.state.data?.status;
-
-      if (query.state.error || !status) return false;
-
-      return shouldPollJobStatus(status) ? STATUS_POLL_INTERVAL_MS : false;
-    },
-  });
-  const summaryStatus = summaryStatusQuery.data?.status;
-
-  const summaryQuery = useQuery({
-    queryKey: analysisQueryKeys.summary(
-      conversationId ?? 0,
-      analysisFlowId ?? 0,
-    ),
-    queryFn: () => {
-      if (conversationId === null || analysisFlowId === null) {
-        throw new Error(INVALID_ROUTE_MESSAGE);
-      }
-
-      return getSummary({ conversationId, analysisFlowId });
-    },
-    enabled: routeReady && summaryStatus === 'SUCCESS',
-  });
-
+  );
   const {
     mutate: mutateQuestionAnalysis,
     isPending: isQuestionAnalysisPending,
-  } = useMutation({
-    mutationFn: async ({
-      targetConversationId,
-      targetAnalysisFlowId,
-      question,
-    }: QuestionAnalysisVariables) => {
-      const createdQuestion = await createQuestion(
-        {
-          conversationId: targetConversationId,
-          analysisFlowId: targetAnalysisFlowId,
-        },
-        { question },
-      );
-      const criteriaParams = {
-        conversationId: targetConversationId,
-        analysisFlowId: targetAnalysisFlowId,
-        messageId: createdQuestion.messageId,
-      };
-
-      await waitForCriteriaSuccess(criteriaParams);
-      return getCriteria(criteriaParams);
-    },
-  });
-
-  const updateCriteriaMutation = useMutation({
-    mutationFn: ({
-      targetConversationId,
-      targetAnalysisFlowId,
-      messageId,
-      request,
-    }: UpdateCriteriaVariables) =>
-      updateCriteria(
-        {
-          conversationId: targetConversationId,
-          analysisFlowId: targetAnalysisFlowId,
-          messageId,
-        },
-        request,
-      ),
-  });
-
-  const resultAnalysisMutation = useMutation({
-    mutationFn: async ({
-      targetConversationId,
-      targetAnalysisFlowId,
-      messageId,
-      analysisCriteriaId,
-    }: ResultAnalysisVariables) => {
-      const resultParams = {
-        conversationId: targetConversationId,
-        analysisFlowId: targetAnalysisFlowId,
-        messageId,
-        analysisCriteriaId,
-      };
-
-      await waitForResultSuccess(resultParams);
-      return getResult(resultParams);
-    },
+  } = questionAnalysisMutation;
+  const resultAnalysisMutation = useResultPhase({
+    getResultErrorMessage: GET_RESULT_ERROR_MESSAGE,
+    resultAnalysisTimeoutMs: RESULT_ANALYSIS_TIMEOUT_MS,
+    statusPollIntervalMs: STATUS_POLL_INTERVAL_MS,
   });
 
   const appendNotice = useCallback(
@@ -406,8 +260,12 @@ export function useAnalysisChat(routeConversationId: string) {
   );
 
   const startQuestion = useCallback(
-    (question: string, appendUserMessage = true) => {
-      if (questionSubmissionLockedRef.current) return;
+    (
+      question: string,
+      appendUserMessage = true,
+      initialMode: CriteriaInitialMode = 'normal',
+    ) => {
+      if (questionSubmissionLocked) return;
 
       if (conversationId === null || analysisFlowId === null) {
         showToast(INVALID_ROUTE_MESSAGE);
@@ -418,7 +276,7 @@ export function useAnalysisChat(routeConversationId: string) {
       const normalizedQuestion = question.trim();
       if (!normalizedQuestion) return;
 
-      questionSubmissionLockedRef.current = true;
+      dispatchFlow({ type: 'question-submission-started' });
 
       if (appendUserMessage) {
         setMessages((prev) => [
@@ -436,13 +294,11 @@ export function useAnalysisChat(routeConversationId: string) {
           targetConversationId: conversationId,
           targetAnalysisFlowId: analysisFlowId,
           question: normalizedQuestion,
+          initialMode,
         },
         {
-          onSuccess: (criteria) => {
-            questionSubmissionLockedRef.current = false;
-            const initialMode: CriteriaInitialMode =
-              openNextCriteriaInEditRef.current ? 'edit' : 'normal';
-            openNextCriteriaInEditRef.current = false;
+          onSuccess: (criteria, variables) => {
+            dispatchFlow({ type: 'question-submission-finished' });
             setMessages((prev) => [
               ...prev,
               {
@@ -450,13 +306,12 @@ export function useAnalysisChat(routeConversationId: string) {
                 role: 'bot',
                 kind: 'criteria',
                 criteria,
-                initialMode,
+                initialMode: variables.initialMode,
               },
             ]);
           },
           onError: (error) => {
-            questionSubmissionLockedRef.current = false;
-            openNextCriteriaInEditRef.current = false;
+            dispatchFlow({ type: 'question-submission-finished' });
             const message = getApiErrorMessage(
               error,
               CREATE_QUESTION_ERROR_MESSAGE,
@@ -471,7 +326,9 @@ export function useAnalysisChat(routeConversationId: string) {
       analysisFlowId,
       appendNotice,
       conversationId,
+      dispatchFlow,
       mutateQuestionAnalysis,
+      questionSubmissionLocked,
       setMessages,
       showToast,
     ],
@@ -489,10 +346,8 @@ export function useAnalysisChat(routeConversationId: string) {
       }
 
       markAnalysisStartPayloadConsumed(conversationId);
-      setCanAutoStartInitialQuestion(false);
-      setHasStartedInitialQuestion(true);
-      openNextCriteriaInEditRef.current = initialMode === 'edit';
-      startQuestion(initialPrompt, false);
+      dispatchFlow({ type: 'initial-question-started' });
+      startQuestion(initialPrompt, false, initialMode);
     },
     [
       canAutoStartInitialQuestion,
@@ -500,8 +355,7 @@ export function useAnalysisChat(routeConversationId: string) {
       hasResolvedStartPayload,
       hasStartedInitialQuestion,
       initialPrompt,
-      setCanAutoStartInitialQuestion,
-      setHasStartedInitialQuestion,
+      dispatchFlow,
       startQuestion,
     ],
   );
@@ -516,33 +370,24 @@ export function useAnalysisChat(routeConversationId: string) {
       if (conversationId !== null) {
         markAnalysisStartPayloadConsumed(conversationId);
       }
-      setCanAutoStartInitialQuestion(false);
-      setHasStartedInitialQuestion(true);
-      openNextCriteriaInEditRef.current = false;
+      dispatchFlow({ type: 'initial-question-started' });
       startQuestion(value.prompt);
     },
-    [
-      conversationId,
-      setCanAutoStartInitialQuestion,
-      setHasStartedInitialQuestion,
-      showToast,
-      startQuestion,
-      summaryQuery.data,
-    ],
+    [conversationId, dispatchFlow, showToast, startQuestion, summaryQuery.data],
   );
 
   function handleConfirmCriteria(
     messageId: number,
     request: UpdateQuestionCriteriaRequest,
   ) {
-    if (criteriaSubmissionLockedRef.current) return;
+    if (criteriaSubmissionLocked) return;
 
     if (conversationId === null || analysisFlowId === null) {
       showToast(INVALID_ROUTE_MESSAGE);
       return;
     }
 
-    criteriaSubmissionLockedRef.current = true;
+    dispatchFlow({ type: 'criteria-submission-started' });
 
     updateCriteriaMutation.mutate(
       {
@@ -563,7 +408,7 @@ export function useAnalysisChat(routeConversationId: string) {
             },
             {
               onSuccess: (result) => {
-                criteriaSubmissionLockedRef.current = false;
+                dispatchFlow({ type: 'criteria-submission-finished' });
                 setMessages((prev) => [
                   ...prev,
                   {
@@ -575,7 +420,7 @@ export function useAnalysisChat(routeConversationId: string) {
                 ]);
               },
               onError: (error) => {
-                criteriaSubmissionLockedRef.current = false;
+                dispatchFlow({ type: 'criteria-submission-finished' });
                 const message = getApiErrorMessage(
                   error,
                   GET_RESULT_ERROR_MESSAGE,
@@ -587,7 +432,7 @@ export function useAnalysisChat(routeConversationId: string) {
           );
         },
         onError: (error) => {
-          criteriaSubmissionLockedRef.current = false;
+          dispatchFlow({ type: 'criteria-submission-finished' });
           const message = getApiErrorMessage(
             error,
             UPDATE_CRITERIA_ERROR_MESSAGE,
@@ -607,13 +452,15 @@ export function useAnalysisChat(routeConversationId: string) {
       return;
     }
 
-    setHasResolvedStartPayload(false);
-    setCanAutoStartInitialQuestion(false);
+    dispatchFlow({ type: 'start-payload-loading' });
 
     const timer = window.setTimeout(() => {
       if (conversationId === null) {
         setStartPayload({ prompt: DEFAULT_PROMPT, fileName: null });
-        setHasResolvedStartPayload(true);
+        dispatchFlow({
+          type: 'start-payload-resolved',
+          canAutoStartInitialQuestion: false,
+        });
         return;
       }
 
@@ -628,8 +475,10 @@ export function useAnalysisChat(routeConversationId: string) {
         prompt: storedPayload?.prompt || DEFAULT_PROMPT,
         fileName: storedPayload?.fileName ?? null,
       });
-      setCanAutoStartInitialQuestion(canAutoStart);
-      setHasResolvedStartPayload(true);
+      dispatchFlow({
+        type: 'start-payload-resolved',
+        canAutoStartInitialQuestion: canAutoStart,
+      });
     }, 0);
 
     return () => window.clearTimeout(timer);
@@ -679,23 +528,7 @@ export function useAnalysisChat(routeConversationId: string) {
     summaryQuery.data,
   ]);
 
-  const summary = summaryQuery.data;
   const summaryColumnOptions = getSummaryColumnOptions(summary);
-  const summaryPending =
-    routeReady &&
-    !summaryStatusQuery.isError &&
-    !summaryQuery.isError &&
-    !summary &&
-    !isFailedJobStatus(summaryStatus);
-  const summaryErrorMessage = !routeReady
-    ? INVALID_ROUTE_MESSAGE
-    : summaryStatusQuery.isError
-      ? getApiErrorMessage(summaryStatusQuery.error, GET_SUMMARY_ERROR_MESSAGE)
-      : summaryQuery.isError
-        ? getApiErrorMessage(summaryQuery.error, GET_SUMMARY_ERROR_MESSAGE)
-        : isFailedJobStatus(summaryStatus)
-          ? 'CSV 데이터 요약에 실패했어요. 파일을 확인하고 다시 시도해 주세요.'
-          : null;
   const shouldShowAnalyzing =
     summaryPending ||
     isQuestionAnalysisPending ||
@@ -721,7 +554,9 @@ export function useAnalysisChat(routeConversationId: string) {
     isQuestionAnalysisPending ||
     updateCriteriaMutation.isPending;
   const criteriaSubmitting =
-    updateCriteriaMutation.isPending || resultAnalysisMutation.isPending;
+    criteriaSubmissionLocked ||
+    updateCriteriaMutation.isPending ||
+    resultAnalysisMutation.isPending;
   const [initialMessage, ...restMessages] = messages;
 
   return {

--- a/apps/fe/src/app/(main)/analysis/[id]/_hooks/useAnalysisChatFlow.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_hooks/useAnalysisChatFlow.ts
@@ -1,0 +1,76 @@
+export type AnalysisChatFlowState = {
+  canAutoStartInitialQuestion: boolean;
+  criteriaSubmissionLocked: boolean;
+  hasResolvedStartPayload: boolean;
+  hasStartedInitialQuestion: boolean;
+  questionSubmissionLocked: boolean;
+};
+
+export type AnalysisChatFlowAction =
+  | { type: 'start-payload-loading' }
+  | { type: 'start-payload-resolved'; canAutoStartInitialQuestion: boolean }
+  | { type: 'initial-question-started' }
+  | { type: 'auto-start-disabled' }
+  | { type: 'question-submission-started' }
+  | { type: 'question-submission-finished' }
+  | { type: 'criteria-submission-started' }
+  | { type: 'criteria-submission-finished' };
+
+export const initialAnalysisChatFlowState: AnalysisChatFlowState = {
+  canAutoStartInitialQuestion: false,
+  criteriaSubmissionLocked: false,
+  hasResolvedStartPayload: false,
+  hasStartedInitialQuestion: false,
+  questionSubmissionLocked: false,
+};
+
+export function analysisChatFlowReducer(
+  state: AnalysisChatFlowState,
+  action: AnalysisChatFlowAction,
+): AnalysisChatFlowState {
+  switch (action.type) {
+    case 'start-payload-loading':
+      return {
+        ...state,
+        canAutoStartInitialQuestion: false,
+        hasResolvedStartPayload: false,
+      };
+    case 'start-payload-resolved':
+      return {
+        ...state,
+        canAutoStartInitialQuestion: action.canAutoStartInitialQuestion,
+        hasResolvedStartPayload: true,
+      };
+    case 'initial-question-started':
+      return {
+        ...state,
+        canAutoStartInitialQuestion: false,
+        hasStartedInitialQuestion: true,
+      };
+    case 'auto-start-disabled':
+      return {
+        ...state,
+        canAutoStartInitialQuestion: false,
+      };
+    case 'question-submission-started':
+      return {
+        ...state,
+        questionSubmissionLocked: true,
+      };
+    case 'question-submission-finished':
+      return {
+        ...state,
+        questionSubmissionLocked: false,
+      };
+    case 'criteria-submission-started':
+      return {
+        ...state,
+        criteriaSubmissionLocked: true,
+      };
+    case 'criteria-submission-finished':
+      return {
+        ...state,
+        criteriaSubmissionLocked: false,
+      };
+  }
+}

--- a/apps/fe/src/app/(main)/analysis/[id]/_hooks/useCriteriaPhase.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_hooks/useCriteriaPhase.ts
@@ -1,0 +1,94 @@
+'use client';
+
+import { useMutation } from '@tanstack/react-query';
+import {
+  createQuestion,
+  getCriteria,
+  getCriteriaStatus,
+  updateCriteria,
+  type QuestionCriteriaParams,
+  type UpdateQuestionCriteriaRequest,
+} from '@/apis/analysis';
+import type { CriteriaInitialMode } from './useAnalysisChat';
+import { useJobPoller } from './useJobPoller';
+
+export type QuestionAnalysisVariables = {
+  initialMode: CriteriaInitialMode;
+  targetConversationId: number;
+  targetAnalysisFlowId: number;
+  question: string;
+};
+
+export type UpdateCriteriaVariables = {
+  targetConversationId: number;
+  targetAnalysisFlowId: number;
+  messageId: number;
+  request: UpdateQuestionCriteriaRequest;
+};
+
+type UseCriteriaPhaseOptions = {
+  getCriteriaErrorMessage: string;
+  questionAnalysisTimeoutMs: number;
+  statusPollIntervalMs: number;
+};
+
+export function useCriteriaPhase({
+  getCriteriaErrorMessage,
+  questionAnalysisTimeoutMs,
+  statusPollIntervalMs,
+}: UseCriteriaPhaseOptions) {
+  const waitForCriteriaSuccess = useJobPoller<QuestionCriteriaParams>(
+    getCriteriaStatus,
+    {
+      errorMessage: getCriteriaErrorMessage,
+      intervalMs: statusPollIntervalMs,
+      timeoutMs: questionAnalysisTimeoutMs,
+    },
+  );
+
+  const questionAnalysisMutation = useMutation({
+    mutationFn: async ({
+      targetConversationId,
+      targetAnalysisFlowId,
+      question,
+    }: QuestionAnalysisVariables) => {
+      const createdQuestion = await createQuestion(
+        {
+          conversationId: targetConversationId,
+          analysisFlowId: targetAnalysisFlowId,
+        },
+        { question },
+      );
+      const criteriaParams = {
+        conversationId: targetConversationId,
+        analysisFlowId: targetAnalysisFlowId,
+        messageId: createdQuestion.messageId,
+      };
+
+      await waitForCriteriaSuccess(criteriaParams);
+      return getCriteria(criteriaParams);
+    },
+  });
+
+  const updateCriteriaMutation = useMutation({
+    mutationFn: ({
+      targetConversationId,
+      targetAnalysisFlowId,
+      messageId,
+      request,
+    }: UpdateCriteriaVariables) =>
+      updateCriteria(
+        {
+          conversationId: targetConversationId,
+          analysisFlowId: targetAnalysisFlowId,
+          messageId,
+        },
+        request,
+      ),
+  });
+
+  return {
+    questionAnalysisMutation,
+    updateCriteriaMutation,
+  };
+}

--- a/apps/fe/src/app/(main)/analysis/[id]/_hooks/useJobPoller.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_hooks/useJobPoller.ts
@@ -1,0 +1,59 @@
+'use client';
+
+import { useCallback } from 'react';
+import type {
+  AnalysisJobStatus,
+  AnalysisStatusResponse,
+} from '@/apis/analysis';
+
+type FetchStatus<TParams> = (
+  params: TParams,
+) => Promise<AnalysisStatusResponse>;
+
+type UseJobPollerOptions = {
+  errorMessage: string;
+  intervalMs: number;
+  timeoutMs: number;
+};
+
+function wait(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function shouldPollJobStatus(status?: AnalysisJobStatus) {
+  return (
+    !status ||
+    status === 'QUEUED' ||
+    status === 'RUNNING' ||
+    status === 'RETRYING'
+  );
+}
+
+export function isFailedJobStatus(status?: AnalysisJobStatus) {
+  return status === 'FAILED' || status === 'CANCELED' || status === 'CANCELLED';
+}
+
+export function useJobPoller<TParams>(
+  fetchStatus: FetchStatus<TParams>,
+  { errorMessage, intervalMs, timeoutMs }: UseJobPollerOptions,
+) {
+  return useCallback(
+    async (params: TParams) => {
+      const startedAt = Date.now();
+
+      while (Date.now() - startedAt < timeoutMs) {
+        const { status } = await fetchStatus(params);
+
+        if (status === 'SUCCESS') return;
+        if (isFailedJobStatus(status)) {
+          throw new Error(errorMessage);
+        }
+
+        await wait(intervalMs);
+      }
+
+      throw new Error(errorMessage);
+    },
+    [errorMessage, fetchStatus, intervalMs, timeoutMs],
+  );
+}

--- a/apps/fe/src/app/(main)/analysis/[id]/_hooks/useResultPhase.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_hooks/useResultPhase.ts
@@ -1,0 +1,56 @@
+'use client';
+
+import { useMutation } from '@tanstack/react-query';
+import {
+  getResult,
+  getResultStatus,
+  type QuestionResultParams,
+} from '@/apis/analysis';
+import { useJobPoller } from './useJobPoller';
+
+export type ResultAnalysisVariables = {
+  targetConversationId: number;
+  targetAnalysisFlowId: number;
+  messageId: number;
+  analysisCriteriaId: number;
+};
+
+type UseResultPhaseOptions = {
+  getResultErrorMessage: string;
+  resultAnalysisTimeoutMs: number;
+  statusPollIntervalMs: number;
+};
+
+export function useResultPhase({
+  getResultErrorMessage,
+  resultAnalysisTimeoutMs,
+  statusPollIntervalMs,
+}: UseResultPhaseOptions) {
+  const waitForResultSuccess = useJobPoller<QuestionResultParams>(
+    getResultStatus,
+    {
+      errorMessage: getResultErrorMessage,
+      intervalMs: statusPollIntervalMs,
+      timeoutMs: resultAnalysisTimeoutMs,
+    },
+  );
+
+  return useMutation({
+    mutationFn: async ({
+      targetConversationId,
+      targetAnalysisFlowId,
+      messageId,
+      analysisCriteriaId,
+    }: ResultAnalysisVariables) => {
+      const resultParams = {
+        conversationId: targetConversationId,
+        analysisFlowId: targetAnalysisFlowId,
+        messageId,
+        analysisCriteriaId,
+      };
+
+      await waitForResultSuccess(resultParams);
+      return getResult(resultParams);
+    },
+  });
+}

--- a/apps/fe/src/app/(main)/analysis/[id]/_hooks/useSummaryPhase.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_hooks/useSummaryPhase.ts
@@ -1,0 +1,94 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import {
+  analysisQueryKeys,
+  getSummary,
+  getSummaryStatus,
+} from '@/apis/analysis';
+import { getApiErrorMessage } from '@/apis/errors';
+import { isFailedJobStatus, shouldPollJobStatus } from './useJobPoller';
+
+type UseSummaryPhaseParams = {
+  analysisFlowId: number | null;
+  conversationId: number | null;
+  failedSummaryMessage: string;
+  getSummaryErrorMessage: string;
+  invalidRouteMessage: string;
+  routeReady: boolean;
+  statusPollIntervalMs: number;
+};
+
+export function useSummaryPhase({
+  analysisFlowId,
+  conversationId,
+  failedSummaryMessage,
+  getSummaryErrorMessage,
+  invalidRouteMessage,
+  routeReady,
+  statusPollIntervalMs,
+}: UseSummaryPhaseParams) {
+  const summaryStatusQuery = useQuery({
+    queryKey: analysisQueryKeys.summaryStatus(
+      conversationId ?? 0,
+      analysisFlowId ?? 0,
+    ),
+    queryFn: () => {
+      if (conversationId === null || analysisFlowId === null) {
+        throw new Error(invalidRouteMessage);
+      }
+
+      return getSummaryStatus({ conversationId, analysisFlowId });
+    },
+    enabled: routeReady,
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+
+      if (query.state.error || !status) return false;
+
+      return shouldPollJobStatus(status) ? statusPollIntervalMs : false;
+    },
+  });
+  const summaryStatus = summaryStatusQuery.data?.status;
+
+  const summaryQuery = useQuery({
+    queryKey: analysisQueryKeys.summary(
+      conversationId ?? 0,
+      analysisFlowId ?? 0,
+    ),
+    queryFn: () => {
+      if (conversationId === null || analysisFlowId === null) {
+        throw new Error(invalidRouteMessage);
+      }
+
+      return getSummary({ conversationId, analysisFlowId });
+    },
+    enabled: routeReady && summaryStatus === 'SUCCESS',
+  });
+
+  const summary = summaryQuery.data;
+  const summaryPending =
+    routeReady &&
+    !summaryStatusQuery.isError &&
+    !summaryQuery.isError &&
+    !summary &&
+    !isFailedJobStatus(summaryStatus);
+  const summaryErrorMessage = !routeReady
+    ? invalidRouteMessage
+    : summaryStatusQuery.isError
+      ? getApiErrorMessage(summaryStatusQuery.error, getSummaryErrorMessage)
+      : summaryQuery.isError
+        ? getApiErrorMessage(summaryQuery.error, getSummaryErrorMessage)
+        : isFailedJobStatus(summaryStatus)
+          ? failedSummaryMessage
+          : null;
+
+  return {
+    summary,
+    summaryErrorMessage,
+    summaryPending,
+    summaryQuery,
+    summaryStatus,
+    summaryStatusQuery,
+  };
+}

--- a/apps/fe/src/app/(main)/analysis/[id]/page.tsx
+++ b/apps/fe/src/app/(main)/analysis/[id]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { use, useState } from 'react';
-import { ChatBubble, ToastAlert } from '@/components';
+import { ChatBubble, ToastPortal } from '@/components';
 import PromptInput from '../_components/PromptInput';
 import AnalysisResult from './_components/AnalysisResult';
 import AnalyzingIndicator from './_components/AnalyzingIndicator';
@@ -173,11 +173,7 @@ export default function AnalysisChatPage({
             />
           </div>
 
-          {chat.toast && (
-            <div className="pointer-events-none fixed bottom-[4.4rem] left-1/2 z-[60] -translate-x-1/2">
-              <ToastAlert role="alert">{chat.toast.message}</ToastAlert>
-            </div>
-          )}
+          <ToastPortal toast={chat.toast} />
         </div>
       }
     />

--- a/apps/fe/src/app/(main)/analysis/page.tsx
+++ b/apps/fe/src/app/(main)/analysis/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ToastAlert } from '@/components';
+import { ToastPortal } from '@/components';
 import { useMyInfo } from '@/hooks/useMyInfo';
 import { useStartAnalysis } from '@/hooks/useStartAnalysis';
 import { useToast } from '@/hooks/useToast';
@@ -88,11 +88,7 @@ export default function AnalysisPage() {
 
       <SampleDataSection />
 
-      {toast && (
-        <div className="pointer-events-none fixed bottom-[4.4rem] left-1/2 z-[60] -translate-x-1/2">
-          <ToastAlert role="alert">{toast.message}</ToastAlert>
-        </div>
-      )}
+      <ToastPortal toast={toast} />
     </main>
   );
 }

--- a/apps/fe/src/app/(main)/data/[id]/page.tsx
+++ b/apps/fe/src/app/(main)/data/[id]/page.tsx
@@ -8,7 +8,7 @@ import {
   deleteDataSource,
   getDataSource,
 } from '@/apis/datasource';
-import { ConfirmModal, ToastAlert } from '@/components';
+import { ConfirmModal, ToastPortal } from '@/components';
 import { useToast } from '@/hooks/useToast';
 import { formatDateTime } from '@/lib/dateTime';
 import { formatFileSize } from '@/lib/fileValidation';
@@ -141,11 +141,7 @@ export default function DataDetailPage({
         }
       />
 
-      {toast && (
-        <div className="pointer-events-none fixed bottom-[4.4rem] left-1/2 z-[60] -translate-x-1/2">
-          <ToastAlert role="alert">{toast.message}</ToastAlert>
-        </div>
-      )}
+      <ToastPortal toast={toast} />
     </main>
   );
 }

--- a/apps/fe/src/app/(main)/data/_components/DataSourceRow.tsx
+++ b/apps/fe/src/app/(main)/data/_components/DataSourceRow.tsx
@@ -1,0 +1,69 @@
+import { type DataSourceSummary } from '@/apis/datasource';
+import ChatIcon from '@/assets/icons/chat.svg';
+import { Checkbox } from '@/components';
+import { formatDateTime } from '@/lib/dateTime';
+import { formatFileSize } from '@/lib/fileValidation';
+
+type DataSourceRowProps = {
+  checked: boolean;
+  chatDisabled: boolean;
+  chatPending: boolean;
+  dataSource: DataSourceSummary;
+  onChat: (dataSource: DataSourceSummary) => void;
+  onOpenDetail: (id: number) => void;
+  onToggle: (id: number) => void;
+};
+
+export default function DataSourceRow({
+  checked,
+  chatDisabled,
+  chatPending,
+  dataSource,
+  onChat,
+  onOpenDetail,
+  onToggle,
+}: DataSourceRowProps) {
+  return (
+    <tr className="border-t border-gray-200 transition-colors hover:bg-gray-100">
+      <td className="py-16 pl-24" onClick={(event) => event.stopPropagation()}>
+        <Checkbox
+          size="md"
+          checked={checked}
+          onCheckedChange={() => onToggle(dataSource.dataSourceId)}
+          aria-label={`${dataSource.fileName} 선택`}
+        />
+      </td>
+      <td className="py-16 text-gray-900">
+        <button
+          type="button"
+          onClick={() => onOpenDetail(dataSource.dataSourceId)}
+          aria-label={`${dataSource.fileName} 데이터 소스 상세 보기`}
+          className="text-left transition-colors hover:text-orange-600 hover:underline focus-visible:rounded-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500"
+        >
+          {dataSource.fileName}
+        </button>
+      </td>
+      <td className="py-16 text-gray-800">
+        {formatFileSize(dataSource.fileSize)}
+      </td>
+      <td className="py-16 text-gray-800">
+        {formatDateTime(dataSource.uploadedAt)}
+      </td>
+      <td
+        className="py-16 pr-24 text-right"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <button
+          type="button"
+          onClick={() => onChat(dataSource)}
+          disabled={chatDisabled}
+          aria-label={`${dataSource.fileName} 분석 채팅 시작`}
+          className="inline-flex items-center gap-4 rounded-full border border-gray-300 bg-white px-12 py-6 text-body4 text-gray-700 transition-colors hover:bg-gray-100 disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400"
+        >
+          <ChatIcon aria-hidden className="icon-12 text-orange-500" />
+          <span>{chatPending ? '시작 중' : '채팅'}</span>
+        </button>
+      </td>
+    </tr>
+  );
+}

--- a/apps/fe/src/app/(main)/data/_components/SortDropdown.tsx
+++ b/apps/fe/src/app/(main)/data/_components/SortDropdown.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import DownIcon from '@/assets/icons/down.svg';
-import { useListboxDropdown } from '@/hooks/useListboxDropdown';
+import { ListboxDropdown } from '@/components';
 
 export type SortOption<T extends string = string> = {
   value: T;
@@ -19,78 +19,63 @@ export default function SortDropdown<T extends string>({
   value,
   onChange,
 }: SortDropdownProps<T>) {
-  const {
-    buttonRef,
-    closeAndFocusButton,
-    handleButtonKeyDown,
-    handleListboxKeyDown,
-    listboxId,
-    open,
-    rootRef,
-    setOpen,
-  } = useListboxDropdown();
-
   const selectedLabel = options.find((o) => o.value === value)?.label ?? '';
 
   return (
-    <div ref={rootRef} className="relative inline-block">
-      <button
-        ref={buttonRef}
-        type="button"
-        aria-haspopup="listbox"
-        aria-expanded={open}
-        aria-controls={open ? listboxId : undefined}
-        onClick={() => setOpen((v) => !v)}
-        onKeyDown={handleButtonKeyDown}
-        className="inline-flex min-w-[12rem] items-center justify-between gap-8 rounded-12 border border-gray-300 bg-white px-12 py-8 text-body4 text-gray-700 transition-colors hover:bg-gray-100"
-      >
-        <span>{selectedLabel}</span>
-        <DownIcon
-          aria-hidden
-          className={`icon-16 text-gray-900 transition-transform ${
-            open ? 'rotate-180' : ''
-          }`}
-        />
-      </button>
+    <ListboxDropdown>
+      {({ closeAndFocusButton, listboxProps, open, triggerProps }) => (
+        <>
+          <button
+            {...triggerProps}
+            className="inline-flex min-w-[12rem] items-center justify-between gap-8 rounded-12 border border-gray-300 bg-white px-12 py-8 text-body4 text-gray-700 transition-colors hover:bg-gray-100"
+          >
+            <span>{selectedLabel}</span>
+            <DownIcon
+              aria-hidden
+              className={`icon-16 text-gray-900 transition-transform ${
+                open ? 'rotate-180' : ''
+              }`}
+            />
+          </button>
 
-      {open && (
-        <div
-          id={listboxId}
-          role="listbox"
-          onKeyDown={handleListboxKeyDown}
-          className="absolute left-0 z-10 mt-4 min-w-[14rem] overflow-hidden rounded-12 border border-gray-300 bg-white py-8 shadow-[0_0.4rem_1.2rem_rgba(0,0,0,0.08)]"
-        >
-          {options.map((opt) => {
-            const selected = opt.value === value;
-            return (
-              <button
-                key={opt.value}
-                type="button"
-                role="option"
-                aria-selected={selected}
-                onClick={() => {
-                  onChange(opt.value);
-                  closeAndFocusButton();
-                }}
-                className={`flex w-full items-center gap-12 px-16 py-12 text-left text-body4 transition-colors hover:bg-gray-100 ${
-                  selected ? 'text-orange-500' : 'text-gray-500'
-                }`}
-              >
-                <span
-                  className={`flex h-16 w-16 shrink-0 items-center justify-center rounded-full border-2 ${
-                    selected ? 'border-orange-500' : 'border-gray-400'
-                  }`}
-                >
-                  {selected && (
-                    <span className="h-8 w-8 rounded-full bg-orange-500" />
-                  )}
-                </span>
-                <span>{opt.label}</span>
-              </button>
-            );
-          })}
-        </div>
+          {open && (
+            <div
+              {...listboxProps}
+              className="absolute left-0 z-10 mt-4 min-w-[14rem] overflow-hidden rounded-12 border border-gray-300 bg-white py-8 shadow-[0_0.4rem_1.2rem_rgba(0,0,0,0.08)]"
+            >
+              {options.map((opt) => {
+                const selected = opt.value === value;
+                return (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    role="option"
+                    aria-selected={selected}
+                    onClick={() => {
+                      onChange(opt.value);
+                      closeAndFocusButton();
+                    }}
+                    className={`flex w-full items-center gap-12 px-16 py-12 text-left text-body4 transition-colors hover:bg-gray-100 ${
+                      selected ? 'text-orange-500' : 'text-gray-500'
+                    }`}
+                  >
+                    <span
+                      className={`flex h-16 w-16 shrink-0 items-center justify-center rounded-full border-2 ${
+                        selected ? 'border-orange-500' : 'border-gray-400'
+                      }`}
+                    >
+                      {selected && (
+                        <span className="h-8 w-8 rounded-full bg-orange-500" />
+                      )}
+                    </span>
+                    <span>{opt.label}</span>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </>
       )}
-    </div>
+    </ListboxDropdown>
   );
 }

--- a/apps/fe/src/app/(main)/data/_hooks/useDataSourceList.ts
+++ b/apps/fe/src/app/(main)/data/_hooks/useDataSourceList.ts
@@ -1,0 +1,45 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import {
+  dataSourceKeys,
+  getDataSources,
+  type DataSourceSort,
+} from '@/apis/datasource';
+import { getApiErrorMessage } from '@/apis/errors';
+
+const DATA_SOURCE_PAGE_SIZE = 20;
+
+type UseDataSourceListParams = {
+  enabled: boolean;
+  fallbackErrorMessage: string;
+  page: number;
+  sort: DataSourceSort;
+};
+
+export function useDataSourceList({
+  enabled,
+  fallbackErrorMessage,
+  page,
+  sort,
+}: UseDataSourceListParams) {
+  const listParams = useMemo(
+    () => ({ sort, page, size: DATA_SOURCE_PAGE_SIZE }),
+    [page, sort],
+  );
+
+  const query = useQuery({
+    queryKey: dataSourceKeys.list(listParams),
+    queryFn: () => getDataSources(listParams),
+    enabled,
+  });
+
+  return {
+    ...query,
+    dataSources: query.data?.dataSources ?? [],
+    errorMessage: query.isError
+      ? getApiErrorMessage(query.error, fallbackErrorMessage)
+      : null,
+  };
+}

--- a/apps/fe/src/app/(main)/data/_hooks/useDeleteDataSources.ts
+++ b/apps/fe/src/app/(main)/data/_hooks/useDeleteDataSources.ts
@@ -1,0 +1,45 @@
+'use client';
+
+import { useCallback } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { dataSourceKeys, deleteDataSources } from '@/apis/datasource';
+import { getApiErrorMessage } from '@/apis/errors';
+
+type UseDeleteDataSourcesOptions = {
+  fallbackErrorMessage: string;
+  onError: (message: string) => void;
+  onSuccess: () => void;
+};
+
+export function useDeleteDataSources({
+  fallbackErrorMessage,
+  onError,
+  onSuccess,
+}: UseDeleteDataSourcesOptions) {
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: deleteDataSources,
+  });
+
+  const remove = useCallback(
+    async (dataSourceIds: number[]) => {
+      if (dataSourceIds.length === 0) return;
+
+      try {
+        await mutation.mutateAsync(dataSourceIds);
+        await queryClient.invalidateQueries({
+          queryKey: dataSourceKeys.lists(),
+        });
+        onSuccess();
+      } catch (error) {
+        onError(getApiErrorMessage(error, fallbackErrorMessage));
+      }
+    },
+    [fallbackErrorMessage, mutation, onError, onSuccess, queryClient],
+  );
+
+  return {
+    isPending: mutation.isPending,
+    remove,
+  };
+}

--- a/apps/fe/src/app/(main)/data/_hooks/useUploadDataSource.ts
+++ b/apps/fe/src/app/(main)/data/_hooks/useUploadDataSource.ts
@@ -1,0 +1,56 @@
+'use client';
+
+import { useCallback } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { dataSourceKeys, uploadDataSource } from '@/apis/datasource';
+import { getApiErrorMessage } from '@/apis/errors';
+
+type UseUploadDataSourceOptions = {
+  fallbackErrorMessage: string;
+  hasAccessToken: boolean;
+  loginRequiredMessage: string;
+  onSuccess: () => void;
+};
+
+export function useUploadDataSource({
+  fallbackErrorMessage,
+  hasAccessToken,
+  loginRequiredMessage,
+  onSuccess,
+}: UseUploadDataSourceOptions) {
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: uploadDataSource,
+  });
+
+  const upload = useCallback(
+    async (file: File) => {
+      if (!hasAccessToken) {
+        throw new Error(loginRequiredMessage);
+      }
+
+      try {
+        await mutation.mutateAsync(file);
+        await queryClient.invalidateQueries({
+          queryKey: dataSourceKeys.lists(),
+        });
+        onSuccess();
+      } catch (error) {
+        throw new Error(getApiErrorMessage(error, fallbackErrorMessage));
+      }
+    },
+    [
+      fallbackErrorMessage,
+      hasAccessToken,
+      loginRequiredMessage,
+      mutation,
+      onSuccess,
+      queryClient,
+    ],
+  );
+
+  return {
+    isPending: mutation.isPending,
+    upload,
+  };
+}

--- a/apps/fe/src/app/(main)/data/page.tsx
+++ b/apps/fe/src/app/(main)/data/page.tsx
@@ -1,34 +1,25 @@
 'use client';
 
-import { useMemo, useState } from 'react';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import {
-  dataSourceKeys,
-  deleteDataSources,
-  getDataSources,
-  uploadDataSource,
-  type DataSourceSummary,
-  type DataSourceSort,
-} from '@/apis/datasource';
-import { getApiErrorMessage } from '@/apis/errors';
-import ChatIcon from '@/assets/icons/chat.svg';
-import SuccessIcon from '@/assets/icons/success.svg';
+import { type DataSourceSummary, type DataSourceSort } from '@/apis/datasource';
 import {
   Checkbox,
   ConfirmModal,
   FileUploadModal,
-  ToastAlert,
+  ToastPortal,
 } from '@/components';
 import { useStartAnalysis } from '@/hooks/useStartAnalysis';
 import { useToast } from '@/hooks/useToast';
-import { formatDateTime } from '@/lib/dateTime';
-import { formatFileSize, validateCsvFile } from '@/lib/fileValidation';
+import { validateCsvFile } from '@/lib/fileValidation';
 import { useAuthSession } from '@/providers/AuthProvider';
+import DataSourceRow from './_components/DataSourceRow';
 import SortDropdown from './_components/SortDropdown';
+import { useDataSourceList } from './_hooks/useDataSourceList';
+import { useDeleteDataSources } from './_hooks/useDeleteDataSources';
+import { useUploadDataSource } from './_hooks/useUploadDataSource';
 
 const DELETE_ILLUST_SRC = '/illusts/delete.svg';
-const DATA_SOURCE_PAGE_SIZE = 20;
 const LOGIN_REQUIRED_MESSAGE = '로그인이 필요해요. 다시 로그인해 주세요.';
 const LIST_ERROR_MESSAGE = '데이터 소스 목록을 불러오지 못했어요.';
 const UPLOAD_ERROR_MESSAGE =
@@ -51,7 +42,6 @@ const DATA_FILE_MESSAGES = {
 
 export default function DataPage() {
   const router = useRouter();
-  const queryClient = useQueryClient();
   const { hasAccessToken } = useAuthSession();
   const { toast, showToast } = useToast();
   const [sortKey, setSortKey] = useState<DataSourceSort>('LATEST');
@@ -65,26 +55,36 @@ export default function DataPage() {
     onError: (message) => showToast(message, 'error'),
   });
 
-  const listParams = useMemo(
-    () => ({ sort: sortKey, page, size: DATA_SOURCE_PAGE_SIZE }),
-    [page, sortKey],
-  );
-
-  const dataSourcesQuery = useQuery({
-    queryKey: dataSourceKeys.list(listParams),
-    queryFn: () => getDataSources(listParams),
+  const dataSourcesQuery = useDataSourceList({
     enabled: hasAccessToken,
+    fallbackErrorMessage: LIST_ERROR_MESSAGE,
+    page,
+    sort: sortKey,
+  });
+  const uploadDataSourceMutation = useUploadDataSource({
+    fallbackErrorMessage: UPLOAD_ERROR_MESSAGE,
+    hasAccessToken,
+    loginRequiredMessage: LOGIN_REQUIRED_MESSAGE,
+    onSuccess: () => {
+      setSelectedIds(new Set());
+      setUploadOpen(false);
+      showToast('파일을 업로드했습니다.', 'success');
+    },
+  });
+  const deleteDataSourcesMutation = useDeleteDataSources({
+    fallbackErrorMessage: DELETE_ERROR_MESSAGE,
+    onError: (message) => {
+      setDeleteOpen(false);
+      showToast(message, 'error');
+    },
+    onSuccess: () => {
+      setSelectedIds(new Set());
+      setDeleteOpen(false);
+      showToast('파일을 삭제했습니다.', 'success');
+    },
   });
 
-  const uploadMutation = useMutation({
-    mutationFn: uploadDataSource,
-  });
-
-  const deleteMutation = useMutation({
-    mutationFn: deleteDataSources,
-  });
-
-  const dataSources = dataSourcesQuery.data?.dataSources ?? [];
+  const dataSources = dataSourcesQuery.dataSources;
   const chatPendingDataSourceId = startAnalysis.pendingDataSourceId;
   const allSelected =
     dataSources.length > 0 &&
@@ -96,7 +96,7 @@ export default function DataPage() {
     : dataSourcesQuery.isLoading
       ? '데이터 소스 목록을 불러오는 중이에요.'
       : dataSourcesQuery.isError
-        ? getApiErrorMessage(dataSourcesQuery.error, LIST_ERROR_MESSAGE)
+        ? dataSourcesQuery.errorMessage
         : dataSources.length === 0
           ? '업로드된 데이터 소스가 없습니다.'
           : null;
@@ -135,44 +135,13 @@ export default function DataPage() {
     setUploadOpen(true);
   };
 
-  const handleUploaded = async (uploaded: File) => {
-    if (!hasAccessToken) {
-      throw new Error(LOGIN_REQUIRED_MESSAGE);
-    }
-
-    try {
-      await uploadMutation.mutateAsync(uploaded);
-      await queryClient.invalidateQueries({
-        queryKey: dataSourceKeys.lists(),
-      });
-      setSelectedIds(new Set());
-      setUploadOpen(false);
-      showToast('파일을 업로드했습니다.', 'success');
-    } catch (error) {
-      throw new Error(getApiErrorMessage(error, UPLOAD_ERROR_MESSAGE));
-    }
-  };
-
   const handleDeleteClick = () => {
     if (selectedIds.size === 0) return;
     setDeleteOpen(true);
   };
 
   const handleDeleteConfirm = async () => {
-    if (selectedIds.size === 0) return;
-
-    try {
-      await deleteMutation.mutateAsync(Array.from(selectedIds));
-      await queryClient.invalidateQueries({
-        queryKey: dataSourceKeys.lists(),
-      });
-      setSelectedIds(new Set());
-      setDeleteOpen(false);
-      showToast('파일을 삭제했습니다.', 'success');
-    } catch (error) {
-      setDeleteOpen(false);
-      showToast(getApiErrorMessage(error, DELETE_ERROR_MESSAGE), 'error');
-    }
+    await deleteDataSourcesMutation.remove(Array.from(selectedIds));
   };
 
   const handleChat = (dataSource: DataSourceSummary) => {
@@ -209,7 +178,7 @@ export default function DataPage() {
             <button
               type="button"
               onClick={handleDeleteClick}
-              disabled={deleteMutation.isPending}
+              disabled={deleteDataSourcesMutation.isPending}
               className="text-body4 text-gray-700 underline underline-offset-2 hover:text-gray-900 disabled:cursor-not-allowed disabled:text-gray-400"
             >
               삭제하기
@@ -218,7 +187,7 @@ export default function DataPage() {
           <button
             type="button"
             onClick={handleUploadClick}
-            disabled={uploadMutation.isPending}
+            disabled={uploadDataSourceMutation.isPending}
             className="rounded-full bg-orange-500 px-16 py-8 text-body4 font-medium text-white transition-colors hover:bg-orange-600 disabled:cursor-not-allowed disabled:bg-gray-400"
           >
             CSV 파일 업로드
@@ -262,63 +231,20 @@ export default function DataPage() {
                 </td>
               </tr>
             ) : (
-              dataSources.map((row) => {
-                const checked = selectedIds.has(row.dataSourceId);
-                const isChatPending =
-                  chatPendingDataSourceId === row.dataSourceId;
-                return (
-                  <tr
-                    key={row.dataSourceId}
-                    className="border-t border-gray-200 transition-colors hover:bg-gray-100"
-                  >
-                    <td
-                      className="py-16 pl-24"
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      <Checkbox
-                        size="md"
-                        checked={checked}
-                        onCheckedChange={() => toggleOne(row.dataSourceId)}
-                        aria-label={`${row.fileName} 선택`}
-                      />
-                    </td>
-                    <td className="py-16 text-gray-900">
-                      <button
-                        type="button"
-                        onClick={() => goToDetail(row.dataSourceId)}
-                        aria-label={`${row.fileName} 데이터 소스 상세 보기`}
-                        className="text-left transition-colors hover:text-orange-600 hover:underline focus-visible:rounded-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500"
-                      >
-                        {row.fileName}
-                      </button>
-                    </td>
-                    <td className="py-16 text-gray-800">
-                      {formatFileSize(row.fileSize)}
-                    </td>
-                    <td className="py-16 text-gray-800">
-                      {formatDateTime(row.uploadedAt)}
-                    </td>
-                    <td
-                      className="py-16 pr-24 text-right"
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      <button
-                        type="button"
-                        onClick={() => handleChat(row)}
-                        disabled={startAnalysis.isPending}
-                        aria-label={`${row.fileName} 분석 채팅 시작`}
-                        className="inline-flex items-center gap-4 rounded-full border border-gray-300 bg-white px-12 py-6 text-body4 text-gray-700 transition-colors hover:bg-gray-100 disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400"
-                      >
-                        <ChatIcon
-                          aria-hidden
-                          className="icon-12 text-orange-500"
-                        />
-                        <span>{isChatPending ? '시작 중' : '채팅'}</span>
-                      </button>
-                    </td>
-                  </tr>
-                );
-              })
+              dataSources.map((dataSource) => (
+                <DataSourceRow
+                  key={dataSource.dataSourceId}
+                  checked={selectedIds.has(dataSource.dataSourceId)}
+                  chatDisabled={startAnalysis.isPending}
+                  chatPending={
+                    chatPendingDataSourceId === dataSource.dataSourceId
+                  }
+                  dataSource={dataSource}
+                  onChat={handleChat}
+                  onOpenDetail={goToDetail}
+                  onToggle={toggleOne}
+                />
+              ))
             )}
           </tbody>
         </table>
@@ -329,7 +255,7 @@ export default function DataPage() {
         onClose={() => setUploadOpen(false)}
         validateFile={(file) => validateCsvFile(file, DATA_FILE_MESSAGES)}
         onError={(message) => showToast(message, 'error')}
-        onUpload={handleUploaded}
+        onUpload={uploadDataSourceMutation.upload}
       />
 
       <ConfirmModal
@@ -340,7 +266,7 @@ export default function DataPage() {
         description="삭제 후엔 복구할 수 없어요."
         confirmLabel="삭제하기"
         cancelLabel="취소하기"
-        confirmDisabled={deleteMutation.isPending}
+        confirmDisabled={deleteDataSourcesMutation.isPending}
         icon={
           <>
             {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -354,20 +280,7 @@ export default function DataPage() {
         }
       />
 
-      {toast && (
-        <div className="pointer-events-none fixed bottom-[4.4rem] left-1/2 z-[60] -translate-x-1/2">
-          <ToastAlert
-            role={toast.tone === 'error' ? 'alert' : 'status'}
-            icon={
-              toast.tone === 'success' ? (
-                <SuccessIcon aria-hidden className="icon-24" />
-              ) : undefined
-            }
-          >
-            {toast.message}
-          </ToastAlert>
-        </div>
-      )}
+      <ToastPortal toast={toast} />
     </main>
   );
 }

--- a/apps/fe/src/components/Dropdown/Dropdown.tsx
+++ b/apps/fe/src/components/Dropdown/Dropdown.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { type ReactNode } from 'react';
-import { useListboxDropdown } from '@/hooks/useListboxDropdown';
 import DropdownDetails from '../DropdownDetails/DropdownDetails';
+import ListboxDropdown from '../ListboxDropdown/ListboxDropdown';
 
 export type DropdownOption = {
   label: string;
@@ -23,70 +23,59 @@ export default function Dropdown({
   options,
   value,
   onChange,
-  placeholder = '선택',
+  placeholder = '?좏깮',
   icon,
   className = '',
   helperText,
 }: DropdownProps) {
-  const {
-    buttonRef,
-    closeAndFocusButton,
-    handleButtonKeyDown,
-    listboxId,
-    open,
-    rootRef,
-    setOpen,
-  } = useListboxDropdown();
-
   const selected = options.find((o) => o.value === value);
 
   return (
-    <div ref={rootRef} className={`relative inline-block ${className}`.trim()}>
-      <button
-        ref={buttonRef}
-        type="button"
-        aria-haspopup="listbox"
-        aria-expanded={open}
-        aria-controls={open ? listboxId : undefined}
-        onClick={() => setOpen((prev) => !prev)}
-        onKeyDown={handleButtonKeyDown}
-        className="inline-flex h-[3.4rem] items-center justify-center gap-12 rounded-8 border border-gray-800 bg-white pl-16 pr-12 text-body2 text-gray-800 transition-colors hover:border-gray-900"
-      >
-        {icon && <span className="shrink-0 [&>svg]:icon-16">{icon}</span>}
-        <span>{selected?.label ?? placeholder}</span>
-        <svg
-          width="12"
-          height="8"
-          viewBox="0 0 12 8"
-          fill="none"
-          aria-hidden
-          className={`shrink-0 transition-transform ${open ? 'rotate-180' : ''}`}
-        >
-          <path
-            d="M1 1.5l5 5 5-5"
-            stroke="currentColor"
-            strokeWidth="1.5"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-        </svg>
-      </button>
+    <ListboxDropdown className={className}>
+      {({ closeAndFocusButton, listboxProps, open, triggerProps }) => (
+        <>
+          <button
+            {...triggerProps}
+            className="inline-flex h-[3.4rem] items-center justify-center gap-12 rounded-8 border border-gray-800 bg-white pl-16 pr-12 text-body2 text-gray-800 transition-colors hover:border-gray-900"
+          >
+            {icon && <span className="shrink-0 [&>svg]:icon-16">{icon}</span>}
+            <span>{selected?.label ?? placeholder}</span>
+            <svg
+              width="12"
+              height="8"
+              viewBox="0 0 12 8"
+              fill="none"
+              aria-hidden
+              className={`shrink-0 transition-transform ${
+                open ? 'rotate-180' : ''
+              }`}
+            >
+              <path
+                d="M1 1.5l5 5 5-5"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </button>
 
-      {open && (
-        <DropdownDetails
-          id={listboxId}
-          type="radio"
-          options={options}
-          selectedValues={value ? [value] : []}
-          helperText={helperText}
-          onSelect={(nextValue) => {
-            onChange?.(nextValue);
-            closeAndFocusButton();
-          }}
-          onEscape={closeAndFocusButton}
-          className="absolute left-0 top-full z-10 mt-4"
-        />
+          {open && (
+            <DropdownDetails
+              {...listboxProps}
+              type="radio"
+              options={options}
+              selectedValues={value ? [value] : []}
+              helperText={helperText}
+              onSelect={(nextValue) => {
+                onChange?.(nextValue);
+                closeAndFocusButton();
+              }}
+              className="absolute left-0 top-full z-10 mt-4"
+            />
+          )}
+        </>
       )}
-    </div>
+    </ListboxDropdown>
   );
 }

--- a/apps/fe/src/components/ListboxDropdown/ListboxDropdown.tsx
+++ b/apps/fe/src/components/ListboxDropdown/ListboxDropdown.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import {
+  type ButtonHTMLAttributes,
+  type HTMLAttributes,
+  type KeyboardEventHandler,
+  type ReactNode,
+  type Ref,
+} from 'react';
+import { useListboxDropdown } from '@/hooks/useListboxDropdown';
+
+export type ListboxDropdownTriggerProps = Omit<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  'children'
+> & {
+  ref: Ref<HTMLButtonElement>;
+};
+
+export type ListboxDropdownListboxProps = Omit<
+  HTMLAttributes<HTMLElement>,
+  'children'
+> & {
+  id: string;
+  role: 'listbox';
+  onKeyDown: KeyboardEventHandler<HTMLElement>;
+};
+
+export type ListboxDropdownRenderProps = {
+  closeAndFocusButton: () => void;
+  listboxId: string;
+  listboxProps: ListboxDropdownListboxProps;
+  open: boolean;
+  triggerProps: ListboxDropdownTriggerProps;
+};
+
+export type ListboxDropdownProps = {
+  children: (props: ListboxDropdownRenderProps) => ReactNode;
+  optionSelector?: string;
+} & Omit<HTMLAttributes<HTMLDivElement>, 'children'>;
+
+export default function ListboxDropdown({
+  children,
+  className = '',
+  optionSelector,
+  ...rest
+}: ListboxDropdownProps) {
+  const {
+    buttonRef,
+    closeAndFocusButton,
+    handleButtonKeyDown,
+    handleListboxKeyDown,
+    listboxId,
+    open,
+    rootRef,
+    setOpen,
+  } = useListboxDropdown(
+    optionSelector === undefined ? undefined : { optionSelector },
+  );
+
+  return (
+    <div
+      ref={rootRef}
+      className={`relative inline-block ${className}`.trim()}
+      {...rest}
+    >
+      {children({
+        closeAndFocusButton,
+        listboxId,
+        listboxProps: {
+          id: listboxId,
+          role: 'listbox',
+          onKeyDown: handleListboxKeyDown,
+        },
+        open,
+        triggerProps: {
+          ref: buttonRef,
+          type: 'button',
+          'aria-haspopup': 'listbox',
+          'aria-expanded': open,
+          'aria-controls': open ? listboxId : undefined,
+          onClick: () => setOpen((prev) => !prev),
+          onKeyDown: handleButtonKeyDown,
+        },
+      })}
+    </div>
+  );
+}

--- a/apps/fe/src/components/ToastAlert/ToastPortal.tsx
+++ b/apps/fe/src/components/ToastAlert/ToastPortal.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { createPortal } from 'react-dom';
+import SuccessIcon from '@/assets/icons/success.svg';
+import type { ToastState } from '@/hooks/useToast';
+import ToastAlert from './ToastAlert';
+
+export type ToastPortalProps = {
+  toast: ToastState | null;
+};
+
+export default function ToastPortal({ toast }: ToastPortalProps) {
+  if (!toast) return null;
+  if (typeof document === 'undefined') return null;
+
+  return createPortal(
+    <div className="pointer-events-none fixed bottom-[4.4rem] left-1/2 z-[60] -translate-x-1/2">
+      <ToastAlert
+        role={toast.tone === 'error' ? 'alert' : 'status'}
+        icon={
+          toast.tone === 'success' ? (
+            <SuccessIcon aria-hidden className="icon-24" />
+          ) : undefined
+        }
+      >
+        {toast.message}
+      </ToastAlert>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/fe/src/components/index.ts
+++ b/apps/fe/src/components/index.ts
@@ -69,6 +69,14 @@ export type { ProgressBarProps } from './ProgressBar/ProgressBar';
 
 export { default as ToastAlert } from './ToastAlert/ToastAlert';
 export type { ToastAlertProps } from './ToastAlert/ToastAlert';
+export { default as ToastPortal } from './ToastAlert/ToastPortal';
+export type { ToastPortalProps } from './ToastAlert/ToastPortal';
+
+export { default as ListboxDropdown } from './ListboxDropdown/ListboxDropdown';
+export type {
+  ListboxDropdownProps,
+  ListboxDropdownRenderProps,
+} from './ListboxDropdown/ListboxDropdown';
 
 export { default as MenuTab } from './MenuTab/MenuTab';
 export type { MenuTabProps } from './MenuTab/MenuTab';


### PR DESCRIPTION
﻿## 요약
- Toast 렌더링을 ToastPortal로 통합했습니다.
- listbox 드롭다운의 root/ARIA/open-close 구조를 ListboxDropdown으로 공통화했습니다.
- 데이터 소스 목록 페이지의 조회, 업로드, 삭제 로직과 행 렌더링을 훅/컴포넌트로 분리했습니다.
- useAnalysisChat의 summary/criteria/result 단계와 polling, 제출 잠금 상태를 분리했습니다.

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - yarn lint
  - yarn test
  - NEXT_PUBLIC_API_URL=http://localhost:8080 yarn build

## 스크린샷/로그 (선택)
- UI 리디자인 없이 구조 리팩토링만 진행했습니다.

## 롤백/리스크
- 리스크 사인: 분석 채팅의 비동기 단계 전이, 데이터 소스 업로드/삭제 후 캐시 갱신, 드롭다운 키보드 탐색 동작
- 롤백 방법: 이 PR의 merge commit 또는 커밋을 revert합니다.

## 관련 이슈
Closes #193
