### PR TITLE
fix: 인증 상태 재로그인 반복 수정

### DIFF
--- a/apps/fe/src/app/(main)/analysis/[id]/_hooks/useAnalysisChat.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_hooks/useAnalysisChat.ts
@@ -223,17 +223,19 @@ export function useAnalysisChat({
     enabled: hasAccessToken && dataSourceId !== null,
   });
 
-  const { summary, summaryErrorMessage, summaryPending, summaryQuery } =
-    useSummaryPhase({
-      analysisFlowId,
-      conversationId,
-      failedSummaryMessage:
-        'CSV 데이터 요약에 실패했어요. 파일을 확인하고 다시 시도해 주세요.',
-      getSummaryErrorMessage: GET_SUMMARY_ERROR_MESSAGE,
-      invalidRouteMessage: INVALID_ROUTE_MESSAGE,
-      routeReady: hasAccessToken && routeReady,
-      statusPollIntervalMs: STATUS_POLL_INTERVAL_MS,
-    });
+  const { summary, summaryErrorMessage, summaryPending } = useSummaryPhase({
+    analysisFlowId,
+    conversationId,
+    failedSummaryMessage:
+      'CSV 데이터 요약에 실패했어요. 파일을 확인하고 다시 시도해 주세요.',
+    getSummaryErrorMessage: GET_SUMMARY_ERROR_MESSAGE,
+    invalidRouteMessage: INVALID_ROUTE_MESSAGE,
+    routeReady: hasAccessToken && routeReady,
+    statusPollIntervalMs: STATUS_POLL_INTERVAL_MS,
+  });
+  const dataSourcePreview = hasAccessToken
+    ? dataSourceQuery.data?.preview
+    : undefined;
   const { questionAnalysisMutation, updateCriteriaMutation } = useCriteriaPhase(
     {
       getCriteriaErrorMessage: GET_CRITERIA_ERROR_MESSAGE,
@@ -345,6 +347,7 @@ export function useAnalysisChat({
   const startInitialQuestion = useCallback(
     (initialMode: CriteriaInitialMode = 'normal') => {
       if (
+        !hasAccessToken ||
         hasStartedInitialQuestion ||
         !hasResolvedStartPayload ||
         !canAutoStartInitialQuestion ||
@@ -360,6 +363,7 @@ export function useAnalysisChat({
     [
       canAutoStartInitialQuestion,
       conversationId,
+      hasAccessToken,
       hasResolvedStartPayload,
       hasStartedInitialQuestion,
       initialPrompt,
@@ -370,7 +374,7 @@ export function useAnalysisChat({
 
   const handleSubmit = useCallback(
     (value: PromptInputValue) => {
-      if (!summaryQuery.data) {
+      if (!summary) {
         showToast(SUMMARY_NOT_READY_MESSAGE);
         return;
       }
@@ -381,7 +385,7 @@ export function useAnalysisChat({
       dispatchFlow({ type: 'initial-question-started' });
       startQuestion(value.prompt);
     },
-    [conversationId, dispatchFlow, showToast, startQuestion, summaryQuery.data],
+    [conversationId, dispatchFlow, showToast, startQuestion, summary],
   );
 
   function handleConfirmCriteria(
@@ -514,14 +518,15 @@ export function useAnalysisChat({
 
   useEffect(() => {
     if (
-      !summaryQuery.data ||
+      !hasAccessToken ||
+      !summary ||
       hasStartedInitialQuestion ||
       !hasResolvedStartPayload ||
       !canAutoStartInitialQuestion
     ) {
       return;
     }
-    if (createSummaryWarnings(summaryQuery.data).length > 0) return;
+    if (createSummaryWarnings(summary).length > 0) return;
 
     const timer = window.setTimeout(() => {
       startInitialQuestion();
@@ -530,10 +535,11 @@ export function useAnalysisChat({
     return () => window.clearTimeout(timer);
   }, [
     canAutoStartInitialQuestion,
+    hasAccessToken,
     hasResolvedStartPayload,
     hasStartedInitialQuestion,
     startInitialQuestion,
-    summaryQuery.data,
+    summary,
   ]);
 
   const summaryColumnOptions = getSummaryColumnOptions(summary);
@@ -574,8 +580,8 @@ export function useAnalysisChat({
     handleSubmit,
     initialMessage,
     inputDisabled,
-    isDataSourceLoading: dataSourceQuery.isLoading,
-    previewTable: createPreviewTable(dataSourceQuery.data?.preview),
+    isDataSourceLoading: hasAccessToken && dataSourceQuery.isLoading,
+    previewTable: createPreviewTable(dataSourcePreview),
     restMessages,
     shouldShowAnalyzing,
     startInitialQuestion,

--- a/apps/fe/src/app/(main)/analysis/[id]/_hooks/useAnalysisChat.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_hooks/useAnalysisChat.ts
@@ -166,7 +166,15 @@ function createMessageId(prefix: string) {
   return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 }
 
-export function useAnalysisChat(routeConversationId: string) {
+type UseAnalysisChatParams = {
+  hasAccessToken: boolean;
+  routeConversationId: string;
+};
+
+export function useAnalysisChat({
+  hasAccessToken,
+  routeConversationId,
+}: UseAnalysisChatParams) {
   const searchParams = useSearchParams();
   const conversationId = parsePositiveNumber(routeConversationId);
   const analysisFlowId = parsePositiveNumber(
@@ -212,7 +220,7 @@ export function useAnalysisChat(routeConversationId: string) {
       if (dataSourceId === null) throw new Error(INVALID_ROUTE_MESSAGE);
       return getDataSource(dataSourceId);
     },
-    enabled: dataSourceId !== null,
+    enabled: hasAccessToken && dataSourceId !== null,
   });
 
   const { summary, summaryErrorMessage, summaryPending, summaryQuery } =
@@ -223,7 +231,7 @@ export function useAnalysisChat(routeConversationId: string) {
         'CSV 데이터 요약에 실패했어요. 파일을 확인하고 다시 시도해 주세요.',
       getSummaryErrorMessage: GET_SUMMARY_ERROR_MESSAGE,
       invalidRouteMessage: INVALID_ROUTE_MESSAGE,
-      routeReady,
+      routeReady: hasAccessToken && routeReady,
       statusPollIntervalMs: STATUS_POLL_INTERVAL_MS,
     });
   const { questionAnalysisMutation, updateCriteriaMutation } = useCriteriaPhase(

--- a/apps/fe/src/app/(main)/analysis/[id]/_hooks/useSummaryPhase.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_hooks/useSummaryPhase.ts
@@ -49,7 +49,9 @@ export function useSummaryPhase({
       return shouldPollJobStatus(status) ? statusPollIntervalMs : false;
     },
   });
-  const summaryStatus = summaryStatusQuery.data?.status;
+  const summaryStatus = routeReady
+    ? summaryStatusQuery.data?.status
+    : undefined;
 
   const summaryQuery = useQuery({
     queryKey: analysisQueryKeys.summary(
@@ -66,7 +68,7 @@ export function useSummaryPhase({
     enabled: routeReady && summaryStatus === 'SUCCESS',
   });
 
-  const summary = summaryQuery.data;
+  const summary = routeReady ? summaryQuery.data : undefined;
   const summaryPending =
     routeReady &&
     !summaryStatusQuery.isError &&

--- a/apps/fe/src/app/(main)/analysis/[id]/page.tsx
+++ b/apps/fe/src/app/(main)/analysis/[id]/page.tsx
@@ -26,10 +26,11 @@ export default function AnalysisChatPage({
   params: Promise<PageParams>;
 }) {
   const { id } = use(params);
-  const { hasAccessToken } = useAuthSession();
+  const { status } = useAuthSession();
+  const isAuthenticated = status === 'authenticated';
   const [isChatCollapsed, setIsChatCollapsed] = useState(false);
   const chat = useAnalysisChat({
-    hasAccessToken,
+    hasAccessToken: isAuthenticated,
     routeConversationId: id,
   });
 

--- a/apps/fe/src/app/(main)/analysis/[id]/page.tsx
+++ b/apps/fe/src/app/(main)/analysis/[id]/page.tsx
@@ -2,6 +2,7 @@
 
 import { use, useState } from 'react';
 import { ChatBubble, ToastPortal } from '@/components';
+import { useAuthSession } from '@/providers/AuthProvider';
 import PromptInput from '../_components/PromptInput';
 import AnalysisResult from './_components/AnalysisResult';
 import AnalyzingIndicator from './_components/AnalyzingIndicator';
@@ -25,8 +26,12 @@ export default function AnalysisChatPage({
   params: Promise<PageParams>;
 }) {
   const { id } = use(params);
+  const { hasAccessToken } = useAuthSession();
   const [isChatCollapsed, setIsChatCollapsed] = useState(false);
-  const chat = useAnalysisChat(id);
+  const chat = useAnalysisChat({
+    hasAccessToken,
+    routeConversationId: id,
+  });
 
   const renderSummaryMessage = () => {
     if (!chat.summary) return null;

--- a/apps/fe/src/app/(main)/analysis/page.tsx
+++ b/apps/fe/src/app/(main)/analysis/page.tsx
@@ -23,23 +23,24 @@ const ANALYSIS_FILE_MESSAGES = {
 };
 
 export default function AnalysisPage() {
-  const { hasAccessToken } = useAuthSession();
+  const { status } = useAuthSession();
+  const isAuthenticated = status === 'authenticated';
   const { toast, showToast } = useToast();
   const {
     data: myInfo,
     isError: isUserInfoError,
     isLoading: isUserInfoLoading,
-  } = useMyInfo(hasAccessToken);
+  } = useMyInfo(isAuthenticated);
   const startAnalysis = useStartAnalysis({
     loginRequiredMessage: LOGIN_REQUIRED_MESSAGE,
     fallbackErrorMessage: START_ANALYSIS_ERROR_MESSAGE,
     onError: showToast,
   });
 
-  const shouldShowUserInfoLoading = hasAccessToken && isUserInfoLoading;
-  const shouldShowUserInfoError = hasAccessToken && isUserInfoError;
+  const shouldShowUserInfoLoading = isAuthenticated && isUserInfoLoading;
+  const shouldShowUserInfoError = isAuthenticated && isUserInfoError;
   const shouldUseFetchedUserName =
-    hasAccessToken && !isUserInfoLoading && !isUserInfoError;
+    isAuthenticated && !isUserInfoLoading && !isUserInfoError;
   const userName = shouldUseFetchedUserName
     ? (myInfo?.name ?? FALLBACK_USER_NAME)
     : FALLBACK_USER_NAME;

--- a/apps/fe/src/app/(main)/data/[id]/page.tsx
+++ b/apps/fe/src/app/(main)/data/[id]/page.tsx
@@ -44,7 +44,8 @@ export default function DataDetailPage({
   const { id } = use(params);
   const router = useRouter();
   const queryClient = useQueryClient();
-  const { hasAccessToken } = useAuthSession();
+  const { hasAccessToken, status } = useAuthSession();
+  const isAuthenticated = status === 'authenticated';
   const [deleteOpen, setDeleteOpen] = useState(false);
   const { toast, showToast } = useToast();
 
@@ -59,7 +60,7 @@ export default function DataDetailPage({
   } = useQuery({
     queryKey: dataSourceKeys.detail(dataSourceId),
     queryFn: () => getDataSource(dataSourceId),
-    enabled: hasAccessToken && isValidDataSourceId,
+    enabled: isAuthenticated && isValidDataSourceId,
   });
 
   const deleteMutation = useMutation({
@@ -91,6 +92,10 @@ export default function DataDetailPage({
 
   if (!isValidDataSourceId) {
     return <DataDetailStatus message="올바르지 않은 데이터 소스입니다." />;
+  }
+
+  if (status === 'initializing') {
+    return <DataDetailStatus message="데이터 소스를 불러오는 중입니다." />;
   }
 
   if (!hasAccessToken) {

--- a/apps/fe/src/app/(main)/data/page.tsx
+++ b/apps/fe/src/app/(main)/data/page.tsx
@@ -42,7 +42,8 @@ const DATA_FILE_MESSAGES = {
 
 export default function DataPage() {
   const router = useRouter();
-  const { hasAccessToken } = useAuthSession();
+  const { hasAccessToken, status } = useAuthSession();
+  const isAuthenticated = status === 'authenticated';
   const { toast, showToast } = useToast();
   const [sortKey, setSortKey] = useState<DataSourceSort>('LATEST');
   const [page, setPage] = useState(0);
@@ -56,7 +57,7 @@ export default function DataPage() {
   });
 
   const dataSourcesQuery = useDataSourceList({
-    enabled: hasAccessToken,
+    enabled: isAuthenticated,
     fallbackErrorMessage: LIST_ERROR_MESSAGE,
     page,
     sort: sortKey,
@@ -91,15 +92,16 @@ export default function DataPage() {
     dataSources.every((dataSource) => selectedIds.has(dataSource.dataSourceId));
   const partiallySelected = !allSelected && selectedIds.size > 0;
   const hasSelection = selectedIds.size > 0;
-  const tableMessage = !hasAccessToken
-    ? LOGIN_REQUIRED_MESSAGE
-    : dataSourcesQuery.isLoading
-      ? '데이터 소스 목록을 불러오는 중이에요.'
-      : dataSourcesQuery.isError
-        ? dataSourcesQuery.errorMessage
-        : dataSources.length === 0
-          ? '업로드된 데이터 소스가 없습니다.'
-          : null;
+  const tableMessage =
+    !hasAccessToken && status !== 'initializing'
+      ? LOGIN_REQUIRED_MESSAGE
+      : status === 'initializing' || dataSourcesQuery.isLoading
+        ? '데이터 소스 목록을 불러오는 중이에요.'
+        : dataSourcesQuery.isError
+          ? dataSourcesQuery.errorMessage
+          : dataSources.length === 0
+            ? '업로드된 데이터 소스가 없습니다.'
+            : null;
 
   const toggleAll = () => {
     if (allSelected) {

--- a/apps/fe/src/app/(main)/layout.tsx
+++ b/apps/fe/src/app/(main)/layout.tsx
@@ -15,7 +15,10 @@ import {
   getRefreshToken,
   skipNextAuthEntryRedirect,
 } from '@/lib/auth';
-import { startOAuthLogin } from '@/lib/authRedirect';
+import {
+  OAUTH_LOGIN_POPUP_BLOCKED_MESSAGE,
+  startOAuthLogin,
+} from '@/lib/authRedirect';
 import { useMyInfo } from '@/hooks/useMyInfo';
 import { useAuthSession } from '@/providers/AuthProvider';
 
@@ -193,7 +196,9 @@ export default function MainLayout({
   ) : undefined;
 
   const handleProfileClick = () => {
-    startOAuthLogin();
+    if (startOAuthLogin() !== 'opened') {
+      window.alert(OAUTH_LOGIN_POPUP_BLOCKED_MESSAGE);
+    }
   };
 
   return (

--- a/apps/fe/src/app/(main)/layout.tsx
+++ b/apps/fe/src/app/(main)/layout.tsx
@@ -15,6 +15,7 @@ import {
   getRefreshToken,
   skipNextAuthEntryRedirect,
 } from '@/lib/auth';
+import { startOAuthLogin } from '@/lib/authRedirect';
 import { useMyInfo } from '@/hooks/useMyInfo';
 import { useAuthSession } from '@/providers/AuthProvider';
 
@@ -149,12 +150,13 @@ export default function MainLayout({
   const router = useRouter();
   const pathname = usePathname();
   const queryClient = useQueryClient();
-  const { hasAccessToken } = useAuthSession();
+  const { status } = useAuthSession();
+  const isAuthenticated = status === 'authenticated';
   const {
     data: myInfo,
     isError: isUserInfoError,
     isLoading: isUserInfoLoading,
-  } = useMyInfo(hasAccessToken);
+  } = useMyInfo(isAuthenticated);
 
   const showDataSearch = pathname.startsWith('/data');
   const handleLogout = () => {
@@ -173,7 +175,7 @@ export default function MainLayout({
     router.push('/');
   };
 
-  const profileSlot = hasAccessToken ? (
+  const profileSlot = isAuthenticated ? (
     <div className="flex items-center gap-12">
       <UserProfileSlot
         user={myInfo}
@@ -191,7 +193,7 @@ export default function MainLayout({
   ) : undefined;
 
   const handleProfileClick = () => {
-    window.location.assign('/login');
+    startOAuthLogin();
   };
 
   return (
@@ -209,7 +211,7 @@ export default function MainLayout({
         }
         onLogoClick={handleLogoClick}
         onNavClick={(href) => router.push(href)}
-        onProfileClick={hasAccessToken ? undefined : handleProfileClick}
+        onProfileClick={isAuthenticated ? undefined : handleProfileClick}
       />
       {children}
     </div>

--- a/apps/fe/src/app/page.tsx
+++ b/apps/fe/src/app/page.tsx
@@ -7,6 +7,7 @@ import IntroCarousel from './_components/IntroCarousel';
 import IntroCtaSection from './_components/IntroCtaSection';
 import IntroHeader from './_components/IntroHeader';
 import IntroHeroSection from './_components/IntroHeroSection';
+import { startOAuthLogin } from '@/lib/authRedirect';
 
 const SOLUTION_CARDS = [
   {
@@ -67,7 +68,7 @@ export default function IntroPage() {
   const [scrolled, setScrolled] = useState(false);
 
   const goToLogin = () => {
-    window.location.assign('/login');
+    startOAuthLogin();
   };
 
   const goToAnalysis = () => {

--- a/apps/fe/src/app/page.tsx
+++ b/apps/fe/src/app/page.tsx
@@ -7,7 +7,10 @@ import IntroCarousel from './_components/IntroCarousel';
 import IntroCtaSection from './_components/IntroCtaSection';
 import IntroHeader from './_components/IntroHeader';
 import IntroHeroSection from './_components/IntroHeroSection';
-import { startOAuthLogin } from '@/lib/authRedirect';
+import {
+  OAUTH_LOGIN_POPUP_BLOCKED_MESSAGE,
+  startOAuthLogin,
+} from '@/lib/authRedirect';
 
 const SOLUTION_CARDS = [
   {
@@ -68,7 +71,9 @@ export default function IntroPage() {
   const [scrolled, setScrolled] = useState(false);
 
   const goToLogin = () => {
-    startOAuthLogin();
+    if (startOAuthLogin() !== 'opened') {
+      window.alert(OAUTH_LOGIN_POPUP_BLOCKED_MESSAGE);
+    }
   };
 
   const goToAnalysis = () => {

--- a/apps/fe/src/hooks/useStartAnalysis.ts
+++ b/apps/fe/src/hooks/useStartAnalysis.ts
@@ -8,6 +8,9 @@ import { getApiErrorMessage } from '@/apis/errors';
 import { writeAnalysisStartPayload } from '@/lib/analysisStartPayload';
 import { useAuthSession } from '@/providers/AuthProvider';
 
+const AUTH_INITIALIZING_MESSAGE =
+  '인증 상태를 확인하고 있어요. 잠시 후 다시 시도해 주세요.';
+
 export type StartAnalysisInput =
   | {
       type: 'file';
@@ -34,10 +37,14 @@ export function useStartAnalysis({
 }: UseStartAnalysisOptions) {
   const router = useRouter();
   const queryClient = useQueryClient();
-  const { hasAccessToken } = useAuthSession();
+  const { hasAccessToken, status } = useAuthSession();
 
   const mutation = useMutation({
     mutationFn: async (input: StartAnalysisInput) => {
+      if (status === 'initializing') {
+        throw new Error(AUTH_INITIALIZING_MESSAGE);
+      }
+
       if (!hasAccessToken) {
         throw new Error(loginRequiredMessage);
       }

--- a/apps/fe/src/lib/authRedirect.test.ts
+++ b/apps/fe/src/lib/authRedirect.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { getOAuthCallbackRedirectUrl } from './authRedirect';
+import {
+  OAUTH_POPUP_CALLBACK_MESSAGE_TYPE,
+  getOAuthCallbackRedirectUrl,
+  getOAuthPopupCallbackRelay,
+  getOAuthPopupWindowName,
+  isAllowedOAuthPopupOrigin,
+  readOAuthPopupCallbackMessage,
+} from './authRedirect';
 
 describe('getOAuthCallbackRedirectUrl', () => {
   it('moves tokenized login callbacks to the auth callback entry', () => {
@@ -36,5 +43,79 @@ describe('getOAuthCallbackRedirectUrl', () => {
         new URL('https://www.asklogue.co/login?accessToken=%20'),
       ),
     ).toBeNull();
+  });
+});
+
+describe('OAuth popup relay helpers', () => {
+  it('creates a relay payload for a popup token callback', () => {
+    const windowName = getOAuthPopupWindowName(
+      'https://logue-git-fix-fe-207-maetelson-s-projects.vercel.app',
+    );
+
+    expect(windowName).not.toBeNull();
+
+    const relay = getOAuthPopupCallbackRelay(
+      new URL(
+        'https://logue-git-dev-maetelson-s-projects.vercel.app/?accessToken=access-token&refreshToken=refresh-token',
+      ),
+      windowName ?? '',
+    );
+
+    expect(relay).toEqual({
+      targetOrigin:
+        'https://logue-git-fix-fe-207-maetelson-s-projects.vercel.app',
+      message: {
+        type: OAUTH_POPUP_CALLBACK_MESSAGE_TYPE,
+        tokens: {
+          accessToken: 'access-token',
+          refreshToken: 'refresh-token',
+        },
+        redirectPath: '/analysis',
+      },
+    });
+  });
+
+  it('routes onboarding popup callbacks back to onboarding', () => {
+    const windowName = getOAuthPopupWindowName('https://www.asklogue.co');
+    const relay = getOAuthPopupCallbackRelay(
+      new URL(
+        'https://www.asklogue.co/onboarding?accessToken=access-token&refreshToken=refresh-token',
+      ),
+      windowName ?? '',
+    );
+
+    expect(relay?.message.redirectPath).toBe('/onboarding');
+  });
+
+  it('rejects untrusted popup origins and malformed messages', () => {
+    expect(isAllowedOAuthPopupOrigin('https://evil.example.com')).toBe(false);
+    expect(getOAuthPopupWindowName('https://evil.example.com')).toBeNull();
+    expect(
+      readOAuthPopupCallbackMessage({
+        type: OAUTH_POPUP_CALLBACK_MESSAGE_TYPE,
+        tokens: { accessToken: 'access-token' },
+        redirectPath: 'https://evil.example.com',
+      }),
+    ).toBeNull();
+  });
+
+  it('normalizes trusted popup messages', () => {
+    expect(
+      readOAuthPopupCallbackMessage({
+        type: OAUTH_POPUP_CALLBACK_MESSAGE_TYPE,
+        tokens: {
+          accessToken: ' access-token ',
+          refreshToken: ' refresh-token ',
+        },
+        redirectPath: '/analysis',
+      }),
+    ).toEqual({
+      type: OAUTH_POPUP_CALLBACK_MESSAGE_TYPE,
+      tokens: {
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+      },
+      redirectPath: '/analysis',
+    });
   });
 });

--- a/apps/fe/src/lib/authRedirect.test.ts
+++ b/apps/fe/src/lib/authRedirect.test.ts
@@ -1,12 +1,65 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
+  OAUTH_LOGIN_POPUP_BLOCKED_MESSAGE,
   OAUTH_POPUP_CALLBACK_MESSAGE_TYPE,
+  consumeOAuthPopupState,
   getOAuthCallbackRedirectUrl,
   getOAuthPopupCallbackRelay,
   getOAuthPopupWindowName,
   isAllowedOAuthPopupOrigin,
   readOAuthPopupCallbackMessage,
+  startOAuthLogin,
 } from './authRedirect';
+
+function createStorage() {
+  const store = new Map<string, string>();
+
+  return {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (key: string) => store.get(key) ?? null,
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+  } satisfies Storage;
+}
+
+function installWindow(openResult: Window | null) {
+  const sessionStorage = createStorage();
+  const assign = vi.fn();
+  const open = vi.fn(() => openResult);
+
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: {
+      crypto: {
+        getRandomValues: (bytes: Uint8Array) => {
+          bytes.fill(1);
+          return bytes;
+        },
+      },
+      location: {
+        assign,
+        origin: 'https://logue-git-fix-fe-207-maetelson-s-projects.vercel.app',
+      },
+      open,
+      sessionStorage,
+    },
+  });
+
+  return { assign, open, sessionStorage };
+}
+
+afterEach(() => {
+  Reflect.deleteProperty(globalThis, 'window');
+  vi.restoreAllMocks();
+});
 
 describe('getOAuthCallbackRedirectUrl', () => {
   it('moves tokenized login callbacks to the auth callback entry', () => {
@@ -50,6 +103,7 @@ describe('OAuth popup relay helpers', () => {
   it('creates a relay payload for a popup token callback', () => {
     const windowName = getOAuthPopupWindowName(
       'https://logue-git-fix-fe-207-maetelson-s-projects.vercel.app',
+      'state-1',
     );
 
     expect(windowName).not.toBeNull();
@@ -71,12 +125,16 @@ describe('OAuth popup relay helpers', () => {
           refreshToken: 'refresh-token',
         },
         redirectPath: '/analysis',
+        state: 'state-1',
       },
     });
   });
 
   it('routes onboarding popup callbacks back to onboarding', () => {
-    const windowName = getOAuthPopupWindowName('https://www.asklogue.co');
+    const windowName = getOAuthPopupWindowName(
+      'https://www.asklogue.co',
+      'state-1',
+    );
     const relay = getOAuthPopupCallbackRelay(
       new URL(
         'https://www.asklogue.co/onboarding?accessToken=access-token&refreshToken=refresh-token',
@@ -89,12 +147,15 @@ describe('OAuth popup relay helpers', () => {
 
   it('rejects untrusted popup origins and malformed messages', () => {
     expect(isAllowedOAuthPopupOrigin('https://evil.example.com')).toBe(false);
-    expect(getOAuthPopupWindowName('https://evil.example.com')).toBeNull();
+    expect(
+      getOAuthPopupWindowName('https://evil.example.com', 'state-1'),
+    ).toBeNull();
     expect(
       readOAuthPopupCallbackMessage({
         type: OAUTH_POPUP_CALLBACK_MESSAGE_TYPE,
         tokens: { accessToken: 'access-token' },
         redirectPath: 'https://evil.example.com',
+        state: 'state-1',
       }),
     ).toBeNull();
   });
@@ -108,6 +169,7 @@ describe('OAuth popup relay helpers', () => {
           refreshToken: ' refresh-token ',
         },
         redirectPath: '/analysis',
+        state: 'state-1',
       }),
     ).toEqual({
       type: OAUTH_POPUP_CALLBACK_MESSAGE_TYPE,
@@ -116,6 +178,46 @@ describe('OAuth popup relay helpers', () => {
         refreshToken: 'refresh-token',
       },
       redirectPath: '/analysis',
+      state: 'state-1',
     });
+  });
+
+  it('rejects callback messages when the popup state does not match', () => {
+    expect(
+      readOAuthPopupCallbackMessage(
+        {
+          type: OAUTH_POPUP_CALLBACK_MESSAGE_TYPE,
+          tokens: { accessToken: 'access-token' },
+          redirectPath: '/analysis',
+          state: 'actual-state',
+        },
+        'expected-state',
+      ),
+    ).toBeNull();
+  });
+
+  it('does not fall back to same-tab login when the popup is blocked', () => {
+    const { assign, open } = installWindow(null);
+
+    expect(startOAuthLogin()).toBe('blocked');
+    expect(open).toHaveBeenCalledOnce();
+    expect(assign).not.toHaveBeenCalled();
+  });
+
+  it('stores a pending popup state and consumes it only once', () => {
+    const popup = { focus: vi.fn() } as unknown as Window;
+    installWindow(popup);
+
+    expect(startOAuthLogin()).toBe('opened');
+    expect(consumeOAuthPopupState('01010101010101010101010101010101')).toBe(
+      true,
+    );
+    expect(consumeOAuthPopupState('01010101010101010101010101010101')).toBe(
+      false,
+    );
+  });
+
+  it('exposes the popup blocked message used by login buttons', () => {
+    expect(OAUTH_LOGIN_POPUP_BLOCKED_MESSAGE).toContain('팝업');
   });
 });

--- a/apps/fe/src/lib/authRedirect.ts
+++ b/apps/fe/src/lib/authRedirect.ts
@@ -1,23 +1,198 @@
 import { getApiBaseUrl } from './apiBaseUrl';
+import { readAuthTokensFromSearchParams, type AuthTokens } from './auth';
 
 const AUTH_CALLBACK_PATH = '/';
+const AUTH_REDIRECT_PATH = '/analysis';
+const ONBOARDING_PATH = '/onboarding';
+const LOGIN_PATH = '/login';
+const OAUTH_POPUP_WINDOW_NAME_PREFIX = 'logue-oauth:';
+const OAUTH_POPUP_FEATURES =
+  'popup=yes,width=480,height=720,menubar=no,toolbar=no,location=yes,status=no';
+const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1']);
+const ALLOWED_HTTPS_HOSTS = new Set([
+  'asklogue.co',
+  'www.asklogue.co',
+  'logue-git-dev-maetelson-s-projects.vercel.app',
+]);
+const ALLOWED_VERCEL_HOST_SUFFIX = '-maetelson-s-projects.vercel.app';
+
+export const OAUTH_POPUP_CALLBACK_MESSAGE_TYPE = 'logue:oauth-popup-callback';
+
+type OAuthRedirectPath = typeof AUTH_REDIRECT_PATH | typeof ONBOARDING_PATH;
+
+export type OAuthPopupCallbackMessage = {
+  type: typeof OAUTH_POPUP_CALLBACK_MESSAGE_TYPE;
+  tokens: AuthTokens;
+  redirectPath: OAuthRedirectPath;
+};
+
+export type OAuthPopupCallbackRelay = {
+  message: OAuthPopupCallbackMessage;
+  targetOrigin: string;
+};
 
 export function getOAuthLoginUrl() {
   return new URL('/oauth2/authorization/google', getApiBaseUrl()).toString();
 }
 
 export function getOAuthCallbackRedirectUrl(requestUrl: URL) {
-  const accessToken = requestUrl.searchParams.get('accessToken')?.trim();
+  const tokens = readAuthTokensFromSearchParams(requestUrl.searchParams);
 
-  if (!accessToken) return null;
-
-  const refreshToken = requestUrl.searchParams.get('refreshToken')?.trim();
+  if (!tokens) return null;
   const redirectUrl = new URL(AUTH_CALLBACK_PATH, requestUrl.origin);
-  redirectUrl.searchParams.set('accessToken', accessToken);
+  redirectUrl.searchParams.set('accessToken', tokens.accessToken);
 
-  if (refreshToken) {
-    redirectUrl.searchParams.set('refreshToken', refreshToken);
+  if (tokens.refreshToken) {
+    redirectUrl.searchParams.set('refreshToken', tokens.refreshToken);
   }
 
   return redirectUrl;
+}
+
+function getUrlOrigin(origin: string) {
+  try {
+    return new URL(origin).origin;
+  } catch {
+    return null;
+  }
+}
+
+export function isAllowedOAuthPopupOrigin(origin: string) {
+  const normalizedOrigin = getUrlOrigin(origin);
+  if (!normalizedOrigin) return false;
+
+  const { hostname, protocol } = new URL(normalizedOrigin);
+
+  if (protocol === 'http:') return LOCAL_HOSTS.has(hostname);
+  if (protocol !== 'https:') return false;
+
+  return (
+    ALLOWED_HTTPS_HOSTS.has(hostname) ||
+    hostname.endsWith(ALLOWED_VERCEL_HOST_SUFFIX)
+  );
+}
+
+export function getOAuthPopupWindowName(origin: string) {
+  const normalizedOrigin = getUrlOrigin(origin);
+
+  if (!normalizedOrigin || !isAllowedOAuthPopupOrigin(normalizedOrigin)) {
+    return null;
+  }
+
+  return `${OAUTH_POPUP_WINDOW_NAME_PREFIX}${encodeURIComponent(
+    normalizedOrigin,
+  )}`;
+}
+
+function getOAuthPopupTargetOrigin(windowName: string) {
+  if (!windowName.startsWith(OAUTH_POPUP_WINDOW_NAME_PREFIX)) return null;
+
+  const encodedOrigin = windowName.slice(OAUTH_POPUP_WINDOW_NAME_PREFIX.length);
+
+  try {
+    const origin = decodeURIComponent(encodedOrigin);
+    const normalizedOrigin = getUrlOrigin(origin);
+
+    if (!normalizedOrigin || !isAllowedOAuthPopupOrigin(normalizedOrigin)) {
+      return null;
+    }
+
+    return normalizedOrigin;
+  } catch {
+    return null;
+  }
+}
+
+function getPostOAuthRedirectPath(pathname: string): OAuthRedirectPath {
+  return pathname === ONBOARDING_PATH ? ONBOARDING_PATH : AUTH_REDIRECT_PATH;
+}
+
+export function getOAuthPopupCallbackRelay(
+  requestUrl: URL,
+  windowName: string,
+): OAuthPopupCallbackRelay | null {
+  const targetOrigin = getOAuthPopupTargetOrigin(windowName);
+  const tokens = readAuthTokensFromSearchParams(requestUrl.searchParams);
+
+  if (!targetOrigin || !tokens) return null;
+
+  return {
+    targetOrigin,
+    message: {
+      type: OAUTH_POPUP_CALLBACK_MESSAGE_TYPE,
+      tokens,
+      redirectPath: getPostOAuthRedirectPath(requestUrl.pathname),
+    },
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function readMessageTokens(value: unknown) {
+  if (!isRecord(value)) return null;
+
+  const params = new URLSearchParams();
+
+  if (typeof value.accessToken === 'string') {
+    params.set('accessToken', value.accessToken);
+  }
+
+  if (typeof value.refreshToken === 'string') {
+    params.set('refreshToken', value.refreshToken);
+  }
+
+  return readAuthTokensFromSearchParams(params);
+}
+
+function readRedirectPath(value: unknown): OAuthRedirectPath | null {
+  if (value === AUTH_REDIRECT_PATH || value === ONBOARDING_PATH) return value;
+
+  return null;
+}
+
+export function readOAuthPopupCallbackMessage(
+  data: unknown,
+): OAuthPopupCallbackMessage | null {
+  if (!isRecord(data) || data.type !== OAUTH_POPUP_CALLBACK_MESSAGE_TYPE) {
+    return null;
+  }
+
+  const tokens = readMessageTokens(data.tokens);
+  const redirectPath = readRedirectPath(data.redirectPath);
+
+  if (!tokens || !redirectPath) return null;
+
+  return {
+    type: OAUTH_POPUP_CALLBACK_MESSAGE_TYPE,
+    tokens,
+    redirectPath,
+  };
+}
+
+export function startOAuthLogin() {
+  if (typeof window === 'undefined') return false;
+
+  const windowName = getOAuthPopupWindowName(window.location.origin);
+
+  if (!windowName) {
+    window.location.assign(LOGIN_PATH);
+    return false;
+  }
+
+  const popup = window.open(
+    `${LOGIN_PATH}?mode=popup`,
+    windowName,
+    OAUTH_POPUP_FEATURES,
+  );
+
+  if (!popup) {
+    window.location.assign(LOGIN_PATH);
+    return false;
+  }
+
+  popup.focus();
+
+  return true;
 }

--- a/apps/fe/src/lib/authRedirect.ts
+++ b/apps/fe/src/lib/authRedirect.ts
@@ -6,6 +6,8 @@ const AUTH_REDIRECT_PATH = '/analysis';
 const ONBOARDING_PATH = '/onboarding';
 const LOGIN_PATH = '/login';
 const OAUTH_POPUP_WINDOW_NAME_PREFIX = 'logue-oauth:';
+const OAUTH_POPUP_STATE_STORAGE_KEY = 'logue:oauth-popup-state';
+const OAUTH_POPUP_STATE_BYTES = 16;
 const OAUTH_POPUP_FEATURES =
   'popup=yes,width=480,height=720,menubar=no,toolbar=no,location=yes,status=no';
 const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1']);
@@ -17,13 +19,17 @@ const ALLOWED_HTTPS_HOSTS = new Set([
 const ALLOWED_VERCEL_HOST_SUFFIX = '-maetelson-s-projects.vercel.app';
 
 export const OAUTH_POPUP_CALLBACK_MESSAGE_TYPE = 'logue:oauth-popup-callback';
+export const OAUTH_LOGIN_POPUP_BLOCKED_MESSAGE =
+  '로그인 팝업이 차단됐어요. 브라우저 팝업을 허용한 뒤 다시 시도해 주세요.';
 
 type OAuthRedirectPath = typeof AUTH_REDIRECT_PATH | typeof ONBOARDING_PATH;
+export type OAuthLoginStartResult = 'opened' | 'blocked' | 'unsupported';
 
 export type OAuthPopupCallbackMessage = {
   type: typeof OAUTH_POPUP_CALLBACK_MESSAGE_TYPE;
   tokens: AuthTokens;
   redirectPath: OAuthRedirectPath;
+  state: string;
 };
 
 export type OAuthPopupCallbackRelay = {
@@ -57,6 +63,86 @@ function getUrlOrigin(origin: string) {
   }
 }
 
+function getOptionalSessionStorage() {
+  if (typeof window === 'undefined') return null;
+
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+function normalizePopupState(state: string | null | undefined) {
+  const normalized = state?.trim();
+
+  if (
+    !normalized ||
+    normalized.length > 128 ||
+    !/^[A-Za-z0-9_-]+$/.test(normalized)
+  ) {
+    return null;
+  }
+
+  return normalized;
+}
+
+function createOAuthPopupState() {
+  const bytes = new Uint8Array(OAUTH_POPUP_STATE_BYTES);
+
+  if (window.crypto?.getRandomValues) {
+    window.crypto.getRandomValues(bytes);
+    return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join(
+      '',
+    );
+  }
+
+  return `${Date.now().toString(36)}_${Math.random().toString(36).slice(2)}`;
+}
+
+function storeOAuthPopupState(state: string) {
+  const storage = getOptionalSessionStorage();
+  if (!storage) return false;
+
+  try {
+    storage.setItem(OAUTH_POPUP_STATE_STORAGE_KEY, state);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function clearOAuthPopupState(state?: string) {
+  const storage = getOptionalSessionStorage();
+  if (!storage) return;
+
+  try {
+    if (!state || storage.getItem(OAUTH_POPUP_STATE_STORAGE_KEY) === state) {
+      storage.removeItem(OAUTH_POPUP_STATE_STORAGE_KEY);
+    }
+  } catch {
+    // Ignore browsers that block sessionStorage.
+  }
+}
+
+export function consumeOAuthPopupState(state: string) {
+  const normalizedState = normalizePopupState(state);
+  const storage = getOptionalSessionStorage();
+
+  if (!normalizedState || !storage) return false;
+
+  try {
+    if (storage.getItem(OAUTH_POPUP_STATE_STORAGE_KEY) !== normalizedState) {
+      return false;
+    }
+
+    storage.removeItem(OAUTH_POPUP_STATE_STORAGE_KEY);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function isAllowedOAuthPopupOrigin(origin: string) {
   const normalizedOrigin = getUrlOrigin(origin);
   if (!normalizedOrigin) return false;
@@ -72,22 +158,35 @@ export function isAllowedOAuthPopupOrigin(origin: string) {
   );
 }
 
-export function getOAuthPopupWindowName(origin: string) {
+export function getOAuthPopupWindowName(origin: string, state: string) {
   const normalizedOrigin = getUrlOrigin(origin);
+  const normalizedState = normalizePopupState(state);
 
-  if (!normalizedOrigin || !isAllowedOAuthPopupOrigin(normalizedOrigin)) {
+  if (
+    !normalizedOrigin ||
+    !normalizedState ||
+    !isAllowedOAuthPopupOrigin(normalizedOrigin)
+  ) {
     return null;
   }
 
   return `${OAUTH_POPUP_WINDOW_NAME_PREFIX}${encodeURIComponent(
     normalizedOrigin,
-  )}`;
+  )}:${normalizedState}`;
 }
 
 function getOAuthPopupTargetOrigin(windowName: string) {
   if (!windowName.startsWith(OAUTH_POPUP_WINDOW_NAME_PREFIX)) return null;
 
-  const encodedOrigin = windowName.slice(OAUTH_POPUP_WINDOW_NAME_PREFIX.length);
+  const payload = windowName.slice(OAUTH_POPUP_WINDOW_NAME_PREFIX.length);
+  const separatorIndex = payload.lastIndexOf(':');
+
+  if (separatorIndex === -1) return null;
+
+  const encodedOrigin = payload.slice(0, separatorIndex);
+  const state = normalizePopupState(payload.slice(separatorIndex + 1));
+
+  if (!state) return null;
 
   try {
     const origin = decodeURIComponent(encodedOrigin);
@@ -97,7 +196,10 @@ function getOAuthPopupTargetOrigin(windowName: string) {
       return null;
     }
 
-    return normalizedOrigin;
+    return {
+      origin: normalizedOrigin,
+      state,
+    };
   } catch {
     return null;
   }
@@ -111,17 +213,18 @@ export function getOAuthPopupCallbackRelay(
   requestUrl: URL,
   windowName: string,
 ): OAuthPopupCallbackRelay | null {
-  const targetOrigin = getOAuthPopupTargetOrigin(windowName);
+  const target = getOAuthPopupTargetOrigin(windowName);
   const tokens = readAuthTokensFromSearchParams(requestUrl.searchParams);
 
-  if (!targetOrigin || !tokens) return null;
+  if (!target || !tokens) return null;
 
   return {
-    targetOrigin,
+    targetOrigin: target.origin,
     message: {
       type: OAUTH_POPUP_CALLBACK_MESSAGE_TYPE,
       tokens,
       redirectPath: getPostOAuthRedirectPath(requestUrl.pathname),
+      state: target.state,
     },
   };
 }
@@ -154,6 +257,7 @@ function readRedirectPath(value: unknown): OAuthRedirectPath | null {
 
 export function readOAuthPopupCallbackMessage(
   data: unknown,
+  expectedState?: string,
 ): OAuthPopupCallbackMessage | null {
   if (!isRecord(data) || data.type !== OAUTH_POPUP_CALLBACK_MESSAGE_TYPE) {
     return null;
@@ -161,24 +265,33 @@ export function readOAuthPopupCallbackMessage(
 
   const tokens = readMessageTokens(data.tokens);
   const redirectPath = readRedirectPath(data.redirectPath);
+  const state = normalizePopupState(
+    typeof data.state === 'string' ? data.state : null,
+  );
 
-  if (!tokens || !redirectPath) return null;
+  if (!tokens || !redirectPath || !state) return null;
+  if (expectedState && expectedState !== state) return null;
 
   return {
     type: OAUTH_POPUP_CALLBACK_MESSAGE_TYPE,
     tokens,
     redirectPath,
+    state,
   };
 }
 
-export function startOAuthLogin() {
-  if (typeof window === 'undefined') return false;
+export function startOAuthLogin(): OAuthLoginStartResult {
+  if (typeof window === 'undefined') return 'unsupported';
 
-  const windowName = getOAuthPopupWindowName(window.location.origin);
+  const state = createOAuthPopupState();
+  const windowName = getOAuthPopupWindowName(window.location.origin, state);
 
   if (!windowName) {
-    window.location.assign(LOGIN_PATH);
-    return false;
+    return 'unsupported';
+  }
+
+  if (!storeOAuthPopupState(state)) {
+    return 'unsupported';
   }
 
   const popup = window.open(
@@ -188,11 +301,11 @@ export function startOAuthLogin() {
   );
 
   if (!popup) {
-    window.location.assign(LOGIN_PATH);
-    return false;
+    clearOAuthPopupState(state);
+    return 'blocked';
   }
 
   popup.focus();
 
-  return true;
+  return 'opened';
 }

--- a/apps/fe/src/lib/authSession.test.ts
+++ b/apps/fe/src/lib/authSession.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getLoginRedirectPath,
+  shouldRedirectPrivatePath,
+  type AuthStatus,
+} from './authSession';
+
+describe('auth session route guards', () => {
+  it('redirects private routes only after auth is known to be anonymous', () => {
+    const statuses = [
+      'initializing',
+      'authenticated',
+      'anonymous',
+    ] satisfies AuthStatus[];
+
+    expect(
+      statuses.map((status) => shouldRedirectPrivatePath(status, '/analysis')),
+    ).toEqual([false, false, true]);
+    expect(shouldRedirectPrivatePath('anonymous', '/')).toBe(false);
+  });
+
+  it('preserves the current private path in the login redirect', () => {
+    expect(
+      getLoginRedirectPath(
+        new URL('https://www.asklogue.co/data/12?q=csv#preview'),
+      ),
+    ).toBe('/login?next=%2Fdata%2F12%3Fq%3Dcsv%23preview');
+  });
+});

--- a/apps/fe/src/lib/authSession.ts
+++ b/apps/fe/src/lib/authSession.ts
@@ -1,0 +1,42 @@
+export type AuthStatus = 'initializing' | 'authenticated' | 'anonymous';
+
+const LOGIN_PATH = '/login';
+const PRIVATE_PATH_PREFIXES = ['/analysis', '/data', '/history'];
+export const AUTH_REDIRECT_PATH = '/analysis';
+const ONBOARDING_PATH = '/onboarding';
+const AUTH_ENTRY_PATHS = new Set(['/', '/login']);
+
+function isPrivatePath(pathname: string) {
+  return PRIVATE_PATH_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+}
+
+export function shouldRedirectAuthenticatedUser(pathname: string) {
+  return AUTH_ENTRY_PATHS.has(pathname);
+}
+
+export function getLoginRedirectPath(currentUrl: URL) {
+  const loginUrl = new URL(LOGIN_PATH, currentUrl.origin);
+  const nextPath = `${currentUrl.pathname}${currentUrl.search}${currentUrl.hash}`;
+
+  if (nextPath && nextPath !== LOGIN_PATH) {
+    loginUrl.searchParams.set('next', nextPath);
+  }
+
+  return `${loginUrl.pathname}${loginUrl.search}${loginUrl.hash}`;
+}
+
+export function shouldRedirectPrivatePath(
+  status: AuthStatus,
+  pathname: string,
+) {
+  return status === 'anonymous' && isPrivatePath(pathname);
+}
+
+export function getPostAuthRedirectPath(pathname: string) {
+  if (pathname === ONBOARDING_PATH) return ONBOARDING_PATH;
+  if (shouldRedirectAuthenticatedUser(pathname)) return AUTH_REDIRECT_PATH;
+
+  return pathname;
+}

--- a/apps/fe/src/lib/axios.test.ts
+++ b/apps/fe/src/lib/axios.test.ts
@@ -71,8 +71,8 @@ afterEach(() => {
 });
 
 describe('axios auth interceptor', () => {
-  it('clears tokens when the current user no longer exists', async () => {
-    installWindowStorage();
+  it('keeps tokens when the current user profile lookup returns 404', async () => {
+    const { localStorage } = installWindowStorage();
     setAuthTokens({
       accessToken: 'access-token',
       refreshToken: 'refresh-token',
@@ -93,8 +93,13 @@ describe('axios auth interceptor', () => {
       response: { status: 404 },
     });
 
-    expect(getAccessToken()).toBeNull();
-    expect(getRefreshToken()).toBeNull();
+    expect(localStorage.getItem(ACCESS_TOKEN_STORAGE_KEY)).toBe('access-token');
+    expect(localStorage.getItem(LEGACY_ACCESS_TOKEN_STORAGE_KEY)).toBe(
+      'access-token',
+    );
+    expect(localStorage.getItem(REFRESH_TOKEN_STORAGE_KEY)).toBe(
+      'refresh-token',
+    );
   });
 
   it('keeps tokens for non-auth 404 responses', async () => {
@@ -126,5 +131,28 @@ describe('axios auth interceptor', () => {
     expect(localStorage.getItem(REFRESH_TOKEN_STORAGE_KEY)).toBe(
       'refresh-token',
     );
+  });
+
+  it('clears tokens when an authenticated request returns 401 without refresh token', async () => {
+    installWindowStorage();
+    setAuthTokens({ accessToken: 'access-token' });
+
+    const adapter: AxiosAdapter = async (config) => {
+      return Promise.reject({
+        config,
+        isAxiosError: true,
+        response: createRejectedResponse(config, 401),
+        toJSON: () => ({}),
+      });
+    };
+
+    instance.defaults.adapter = adapter;
+
+    await expect(instance.get('/api/datasources')).rejects.toMatchObject({
+      response: { status: 401 },
+    });
+
+    expect(getAccessToken()).toBeNull();
+    expect(getRefreshToken()).toBeNull();
   });
 });

--- a/apps/fe/src/lib/axios.ts
+++ b/apps/fe/src/lib/axios.ts
@@ -43,31 +43,12 @@ function getReissuedAuthTokens(refreshToken: string) {
   return reissueTokensRequest;
 }
 
-function getRequestPath(config: InternalAxiosRequestConfig) {
-  if (!config.url) return null;
-
-  try {
-    return new URL(config.url, config.baseURL ?? API_BASE_URL).pathname;
-  } catch {
-    return null;
-  }
-}
-
-function isUserInfoRequest(config: InternalAxiosRequestConfig) {
-  return getRequestPath(config) === '/api/user/me';
-}
-
 instance.interceptors.response.use(
   (response) => response,
   async (error: AxiosError) => {
     const originalRequest = error.config as AuthRetryRequestConfig | undefined;
 
     if (!originalRequest) {
-      return Promise.reject(error);
-    }
-
-    if (error.response?.status === 404 && isUserInfoRequest(originalRequest)) {
-      clearAuthTokens();
       return Promise.reject(error);
     }
 

--- a/apps/fe/src/providers/AuthProvider.tsx
+++ b/apps/fe/src/providers/AuthProvider.tsx
@@ -20,14 +20,22 @@ import {
   readAuthTokensFromSearchParams,
   setAuthTokens,
 } from '@/lib/auth';
-
-const LOGIN_PATH = '/login';
-const PRIVATE_PATH_PREFIXES = ['/analysis', '/data', '/history'];
-const AUTH_REDIRECT_PATH = '/analysis';
-const ONBOARDING_PATH = '/onboarding';
-const AUTH_ENTRY_PATHS = new Set(['/', '/login']);
+import {
+  getOAuthPopupCallbackRelay,
+  isAllowedOAuthPopupOrigin,
+  readOAuthPopupCallbackMessage,
+} from '@/lib/authRedirect';
+import {
+  AUTH_REDIRECT_PATH,
+  getLoginRedirectPath,
+  getPostAuthRedirectPath,
+  shouldRedirectAuthenticatedUser,
+  shouldRedirectPrivatePath,
+  type AuthStatus,
+} from '@/lib/authSession';
 
 type AuthContextValue = {
+  status: AuthStatus;
   hasAccessToken: boolean;
 };
 
@@ -48,47 +56,32 @@ function removeTokenParamsFromCurrentUrl(url: URL) {
   );
 }
 
-function isPrivatePath(pathname: string) {
-  return PRIVATE_PATH_PREFIXES.some(
-    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
-  );
-}
-
-function shouldRedirectAuthenticatedUser(pathname: string) {
-  return AUTH_ENTRY_PATHS.has(pathname);
-}
-
 function replaceLocation(pathname: string) {
   window.location.replace(pathname);
-}
-
-function getPostAuthRedirectPath(pathname: string) {
-  if (pathname === ONBOARDING_PATH) return ONBOARDING_PATH;
-  if (shouldRedirectAuthenticatedUser(pathname)) return AUTH_REDIRECT_PATH;
-
-  return pathname;
 }
 
 export default function AuthProvider({ children }: { children: ReactNode }) {
   const pathname = usePathname();
   const queryClient = useQueryClient();
-  const [hasAccessToken, setHasAccessToken] = useState(false);
+  const [status, setStatus] = useState<AuthStatus>('initializing');
 
   useEffect(() => {
     const syncAccessToken = () => {
-      const nextHasAccessToken = Boolean(getAccessToken());
+      const nextStatus: AuthStatus = getAccessToken()
+        ? 'authenticated'
+        : 'anonymous';
 
-      setHasAccessToken(nextHasAccessToken);
+      setStatus(nextStatus);
 
-      if (!nextHasAccessToken) {
+      if (nextStatus === 'anonymous') {
         queryClient.clear();
 
-        if (isPrivatePath(pathname)) {
-          replaceLocation(LOGIN_PATH);
+        if (shouldRedirectPrivatePath(nextStatus, pathname)) {
+          replaceLocation(getLoginRedirectPath(new URL(window.location.href)));
         }
       }
 
-      return nextHasAccessToken;
+      return nextStatus;
     };
 
     const currentUrl = new URL(window.location.href);
@@ -97,20 +90,29 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
     );
 
     if (redirectedTokens) {
+      const popupRelay = getOAuthPopupCallbackRelay(currentUrl, window.name);
+
+      if (popupRelay && window.opener) {
+        removeTokenParamsFromCurrentUrl(currentUrl);
+        window.opener.postMessage(popupRelay.message, popupRelay.targetOrigin);
+        window.close();
+        return;
+      }
+
       setAuthTokens(redirectedTokens);
       removeTokenParamsFromCurrentUrl(currentUrl);
+      queryClient.clear();
       replaceLocation(getPostAuthRedirectPath(pathname));
       return;
     }
 
-    const nextHasAccessToken = syncAccessToken();
+    const nextStatus = syncAccessToken();
     const shouldBypassAuthEntryRedirect =
       shouldRedirectAuthenticatedUser(pathname) &&
       consumeAuthEntryRedirectBypass();
 
     if (
-      !redirectedTokens &&
-      nextHasAccessToken &&
+      nextStatus === 'authenticated' &&
       shouldRedirectAuthenticatedUser(pathname) &&
       !shouldBypassAuthEntryRedirect
     ) {
@@ -128,20 +130,36 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
       }
     };
 
+    const handleMessage = (event: MessageEvent) => {
+      if (!isAllowedOAuthPopupOrigin(event.origin)) return;
+
+      const message = readOAuthPopupCallbackMessage(event.data);
+      if (!message) return;
+
+      setAuthTokens(message.tokens);
+      queryClient.clear();
+      setStatus('authenticated');
+      replaceLocation(message.redirectPath);
+    };
+
     window.addEventListener(AUTH_TOKENS_CHANGED_EVENT, syncAccessToken);
+    window.addEventListener('message', handleMessage);
     window.addEventListener('storage', handleStorage);
 
     return () => {
       window.removeEventListener(AUTH_TOKENS_CHANGED_EVENT, syncAccessToken);
+      window.removeEventListener('message', handleMessage);
       window.removeEventListener('storage', handleStorage);
     };
   }, [pathname, queryClient]);
 
+  const hasAccessToken = status === 'authenticated';
   const value = useMemo(
     () => ({
+      status,
       hasAccessToken,
     }),
-    [hasAccessToken],
+    [hasAccessToken, status],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/apps/fe/src/providers/AuthProvider.tsx
+++ b/apps/fe/src/providers/AuthProvider.tsx
@@ -21,6 +21,7 @@ import {
   setAuthTokens,
 } from '@/lib/auth';
 import {
+  consumeOAuthPopupState,
   getOAuthPopupCallbackRelay,
   isAllowedOAuthPopupOrigin,
   readOAuthPopupCallbackMessage,
@@ -135,6 +136,7 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
 
       const message = readOAuthPopupCallbackMessage(event.data);
       if (!message) return;
+      if (!consumeOAuthPopupState(message.state)) return;
 
       setAuthTokens(message.tokens);
       queryClient.clear();


### PR DESCRIPTION
﻿## 요약
- `/api/user/me` 프로필 조회 404가 전체 인증 토큰 삭제로 이어지지 않도록 수정했습니다.
- 분석 상세 라우트의 미리보기/요약 조회도 로그인 상태가 확인된 뒤에만 실행되도록 보강했습니다.
- `/data`, `/data/[id]`, `/analysis`, `/analysis/[id]`, `/history`의 인증 API 진입 조건을 함께 점검했습니다.

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩터링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `yarn test`
  - `yarn lint`
  - `$env:NEXT_PUBLIC_API_URL='https://api-stg.asklogue.co'; yarn build` 시도: 로컬 dev 서버가 `.next/codex-dev-3001.err.log`를 점유해 `EBUSY`로 중단

## 스크린샷/로그 (선택)
- 빌드 중단 로그: `EBUSY: resource busy or locked, unlink 'C:\Users\user\Desktop\Logue\apps\fe\.next\codex-dev-3001.err.log'`

## 롤백/리스크
- 리스크: `/api/user/me`가 404를 반환해도 토큰을 즉시 삭제하지 않으므로, 프로필 영역은 실패 상태로 남고 다른 인증 API는 기존 토큰으로 계속 시도합니다. 실제 인증 실패(401/refresh 실패)는 기존처럼 토큰을 삭제합니다.
- 롤백 방법: `src/lib/axios.ts`, `src/lib/axios.test.ts`, `src/app/(main)/analysis/[id]/page.tsx`, `src/app/(main)/analysis/[id]/_hooks/useAnalysisChat.ts` 변경을 되돌립니다.

## 관련 이슈
Closes #207


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 인증 토큰 관리 로직이 개선되었습니다. 사용자 정보 조회 실패 시 토큰을 자동 삭제하지 않으며, 인증 오류 응답에서만 토큰을 제거합니다.
  * 분석 채팅 기능이 인증 상태를 더 정확하게 확인하도록 개선되어 보안이 강화되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/26-ewha-capstone-logue/logue/pull/208?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->