### PR TITLE
fix: 데이터 소스 목 데이터 표시 보장

### DIFF
--- a/apps/fe/src/apis/datasource.ts
+++ b/apps/fe/src/apis/datasource.ts
@@ -1,6 +1,7 @@
 import instance from '@/lib/axios';
 import {
   getMockDataSource,
+  getMockDataSourceListResponse,
   isMockDataSourceId,
   withMockDataSource,
 } from './mockDataSource';
@@ -64,12 +65,16 @@ export const dataSourceKeys = {
 };
 
 export async function getDataSources(params: GetDataSourceListParams) {
-  const { data } = await instance.get<ApiResponse<GetDataSourceListResponse>>(
-    '/api/datasources',
-    { params },
-  );
+  try {
+    const { data } = await instance.get<ApiResponse<GetDataSourceListResponse>>(
+      '/api/datasources',
+      { params },
+    );
 
-  return withMockDataSource(unwrapApiResponse(data), params);
+    return withMockDataSource(unwrapApiResponse(data), params);
+  } catch {
+    return getMockDataSourceListResponse(params);
+  }
 }
 
 export async function uploadDataSource(file: File) {

--- a/apps/fe/src/apis/mockDataSource.ts
+++ b/apps/fe/src/apis/mockDataSource.ts
@@ -88,6 +88,18 @@ export function withMockDataSource(
   };
 }
 
+export function getMockDataSourceListResponse(
+  params: GetDataSourceListParams,
+): GetDataSourceListResponse {
+  return {
+    sort: params.sort,
+    page: params.page,
+    size: params.size,
+    totalPages: 1,
+    dataSources: params.page === 0 ? [MOCK_MARKETING_CVR_SUMMARY] : [],
+  };
+}
+
 export async function getMockDataSource(): Promise<GetFileResponse> {
   return {
     fileName: MOCK_MARKETING_CVR_FILE_NAME,

--- a/apps/fe/src/app/(main)/data/_hooks/useDataSourceList.ts
+++ b/apps/fe/src/app/(main)/data/_hooks/useDataSourceList.ts
@@ -8,6 +8,7 @@ import {
   type DataSourceSort,
 } from '@/apis/datasource';
 import { getApiErrorMessage } from '@/apis/errors';
+import { getMockDataSourceListResponse } from '@/apis/mockDataSource';
 
 const DATA_SOURCE_PAGE_SIZE = 20;
 
@@ -34,12 +35,19 @@ export function useDataSourceList({
     queryFn: () => getDataSources(listParams),
     enabled,
   });
+  const dataSources =
+    query.data?.dataSources ??
+    getMockDataSourceListResponse(listParams).dataSources;
+  const hasDataSources = dataSources.length > 0;
 
   return {
     ...query,
-    dataSources: query.data?.dataSources ?? [],
-    errorMessage: query.isError
-      ? getApiErrorMessage(query.error, fallbackErrorMessage)
-      : null,
+    dataSources,
+    isError: query.isError && !hasDataSources,
+    isLoading: query.isLoading && !hasDataSources,
+    errorMessage:
+      query.isError && !hasDataSources
+        ? getApiErrorMessage(query.error, fallbackErrorMessage)
+        : null,
   };
 }


### PR DESCRIPTION
## 요약
- 로그인 후 `/data`에서 마케팅 CVR 목 데이터가 데이터 소스 목록에 표시되도록 보장했습니다.
- 서버 데이터소스 목록이 비어 있거나 조회가 실패해도 첫 페이지에는 `marketing-cvr-mock-data.csv`가 보이도록 fallback을 추가했습니다.
- 기존 mock id 상세 조회(`/data/900001`)와 삭제 제외 처리는 유지했습니다.

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `yarn lint`
  - `NEXT_PUBLIC_API_URL=https://api-stg.asklogue.co yarn build`
  - Playwright로 로그인 성공 + 서버 데이터소스 목록 empty 상태를 재현하고 `/data`에 `marketing-cvr-mock-data.csv`가 표시되는지 확인

## 스크린샷/로그 (선택)
- Playwright 확인 결과: `hasMockFile: true`

## 롤백/리스크
- 리스크: 서버 목록 조회 실패 시에도 mock 데이터가 표시되므로 실제 서버 오류 메시지는 첫 페이지에서 숨겨질 수 있습니다. 이 PR의 의도는 데모/목 데이터가 항상 보이게 하는 것입니다.
- 롤백 방법: `apps/fe/src/apis/datasource.ts`, `apps/fe/src/apis/mockDataSource.ts`, `apps/fe/src/app/(main)/data/_hooks/useDataSourceList.ts` 변경을 되돌립니다.

## 관련 이슈
Closes #209