### PR TITLE
feat: 분석 응답 정규화 어댑터 추가

### DIFF
--- a/apps/fe/src/app/(main)/analysis/[id]/_adapters/normalizeAnalysisError.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_adapters/normalizeAnalysisError.ts
@@ -1,0 +1,177 @@
+import axios from 'axios';
+import type { AnalysisJobStatus } from '@/apis/analysis';
+import type {
+  AnalysisUiStatus,
+  UserFacingAnalysisError,
+} from '../_models/analysisErrorTypes';
+
+const ERROR_BY_CODE: Record<string, UserFacingAnalysisError> = {
+  LLM_OUTPUT_INVALID: {
+    code: 'LLM_OUTPUT_INVALID',
+    title: '분석 응답을 해석하지 못했어요',
+    message:
+      'AI 분석 응답 형식이 올바르지 않아 결과를 표시할 수 없습니다. 다시 시도해 주세요.',
+    retryable: false,
+  },
+  LLM_REFERENCE_VIOLATION: {
+    code: 'LLM_REFERENCE_VIOLATION',
+    title: '분석 기준이 데이터와 맞지 않아요',
+    message:
+      'AI가 데이터에 없는 기준을 참조했습니다. 질문을 조금 바꿔 다시 시도해 주세요.',
+    retryable: false,
+  },
+  LLM_CALL_FAILED: {
+    code: 'LLM_CALL_FAILED',
+    title: 'AI 분석 호출에 실패했어요',
+    message:
+      '일시적인 AI 분석 호출 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.',
+    retryable: true,
+  },
+  FAILED: {
+    code: 'FAILED',
+    title: '분석에 실패했어요',
+    message:
+      '분석 작업이 실패했습니다. 파일과 질문을 확인한 뒤 다시 시도해 주세요.',
+    retryable: true,
+  },
+  CANCELED: {
+    code: 'CANCELED',
+    title: '분석이 취소되었어요',
+    message: '분석 작업이 취소되었습니다.',
+    retryable: false,
+  },
+  UNKNOWN_STATUS: {
+    code: 'UNKNOWN_STATUS',
+    title: '분석 상태를 확인하지 못했어요',
+    message: '예상하지 못한 분석 상태가 전달되었습니다. 다시 시도해 주세요.',
+    retryable: true,
+  },
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function pickString(value: unknown, key: string) {
+  if (!isRecord(value)) return null;
+  const picked = value[key];
+  return typeof picked === 'string' && picked.trim() ? picked.trim() : null;
+}
+
+function pickErrorPayload(value: unknown): unknown {
+  if (!isRecord(value)) return value;
+  const detail = value.detail;
+  if (isRecord(detail)) return detail;
+  return value;
+}
+
+function isApiResponseErrorLike(
+  value: unknown,
+): value is { response: unknown } {
+  return (
+    isRecord(value) && value.name === 'ApiResponseError' && 'response' in value
+  );
+}
+
+function resolveErrorCode(value: unknown) {
+  const payload = pickErrorPayload(value);
+  return (
+    pickString(payload, 'code') ??
+    pickString(payload, 'error_code') ??
+    pickString(payload, 'errorCode')
+  );
+}
+
+function resolveErrorMessage(value: unknown) {
+  const payload = pickErrorPayload(value);
+  return pickString(payload, 'message') ?? pickString(value, 'message');
+}
+
+export function normalizeAnalysisError(
+  error: unknown,
+  fallbackMessage = '분석 요청을 처리하지 못했습니다. 잠시 후 다시 시도해 주세요.',
+): UserFacingAnalysisError {
+  const payload = axios.isAxiosError(error)
+    ? error.response?.data
+    : isApiResponseErrorLike(error)
+      ? error.response
+      : error;
+  const code = resolveErrorCode(payload) ?? 'UNKNOWN_ANALYSIS_ERROR';
+  const known = ERROR_BY_CODE[code];
+
+  if (known) {
+    return {
+      ...known,
+      message: resolveErrorMessage(payload) ?? known.message,
+    };
+  }
+
+  const message =
+    resolveErrorMessage(payload) ??
+    (error instanceof Error && error.message.trim()
+      ? error.message
+      : fallbackMessage);
+
+  return {
+    code,
+    title: '분석 요청을 처리하지 못했어요',
+    message,
+    retryable: true,
+  };
+}
+
+export function normalizeAnalysisStatus(
+  status: AnalysisJobStatus | null | undefined,
+): AnalysisUiStatus {
+  if (!status) return 'idle';
+
+  switch (status) {
+    case 'QUEUED':
+    case 'RUNNING':
+    case 'RETRYING':
+      return 'polling';
+    case 'SUCCESS':
+      return 'success';
+    case 'FAILED':
+      return 'failed';
+    case 'CANCELED':
+    case 'CANCELLED':
+      return 'canceled';
+    default:
+      return 'failed';
+  }
+}
+
+export function shouldPollAnalysisStatus(
+  status: AnalysisJobStatus | null | undefined,
+) {
+  return normalizeAnalysisStatus(status) === 'polling' || !status;
+}
+
+export function isFailedAnalysisStatus(
+  status: AnalysisJobStatus | null | undefined,
+) {
+  const normalized = normalizeAnalysisStatus(status);
+  return normalized === 'failed' || normalized === 'canceled';
+}
+
+export function normalizeAnalysisStatusError(
+  status: AnalysisJobStatus | null | undefined,
+  fallbackMessage: string,
+): UserFacingAnalysisError | null {
+  const normalized = normalizeAnalysisStatus(status);
+  if (normalized !== 'failed' && normalized !== 'canceled') return null;
+
+  if (status === 'CANCELED' || status === 'CANCELLED') {
+    return ERROR_BY_CODE.CANCELED;
+  }
+
+  if (status === 'FAILED') {
+    return {
+      ...ERROR_BY_CODE.FAILED,
+      message: fallbackMessage || ERROR_BY_CODE.FAILED.message,
+    };
+  }
+
+  return ERROR_BY_CODE.UNKNOWN_STATUS;
+}

--- a/apps/fe/src/app/(main)/analysis/[id]/_adapters/normalizeChartData.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_adapters/normalizeChartData.ts
@@ -1,0 +1,171 @@
+import type {
+  BarChartViewModel,
+  ChartRowViewModel,
+  ChartSeriesViewModel,
+  ChartTabViewModel,
+  ChartViewModel,
+  EmptyChartViewModel,
+} from '../_models/analysisViewModels';
+
+const EMPTY_CHART_MESSAGES: Record<EmptyChartViewModel['reason'], string> = {
+  missing: '표시할 차트 데이터가 없습니다.',
+  empty: '표시할 차트 데이터가 비어 있습니다.',
+  invalid: '차트 데이터 형식이 올바르지 않습니다.',
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function createEmptyChart(
+  reason: EmptyChartViewModel['reason'],
+): ChartViewModel {
+  return {
+    type: 'empty',
+    reason,
+    message: EMPTY_CHART_MESSAGES[reason],
+  };
+}
+
+function asStringArray(value: unknown) {
+  return Array.isArray(value)
+    ? value
+        .map((item) => (typeof item === 'string' ? item.trim() : ''))
+        .filter(Boolean)
+    : [];
+}
+
+function asNumberArray(value: unknown) {
+  return Array.isArray(value)
+    ? value.filter(
+        (item): item is number =>
+          typeof item === 'number' && Number.isFinite(item),
+      )
+    : [];
+}
+
+function uniqueStrings(values: string[]) {
+  return Array.from(
+    new Set(values.map((value) => value.trim()).filter(Boolean)),
+  );
+}
+
+function getChartEmptyReason(value: unknown): EmptyChartViewModel['reason'] {
+  if (value == null) return 'missing';
+  if (Array.isArray(value) && value.length === 0) return 'empty';
+  if (isRecord(value)) {
+    const tabResults = value.tabResults;
+    const rows = value.rows;
+    if (Array.isArray(tabResults) && tabResults.length === 0) return 'empty';
+    if (rows == null && 'rows' in value) return 'empty';
+    if (Array.isArray(rows) && rows.length === 0) return 'empty';
+  }
+  return 'invalid';
+}
+
+function normalizeTabResult(
+  value: unknown,
+  index: number,
+): ChartTabViewModel | null {
+  if (!isRecord(value)) return null;
+
+  const chart = isRecord(value.chart) ? value.chart : null;
+  if (!chart) return null;
+
+  const labels = asStringArray(chart.labels);
+  const series = Array.isArray(chart.series) ? chart.series : [];
+  if (labels.length === 0 || series.length === 0) return null;
+
+  const yKeys: ChartSeriesViewModel[] = [];
+  const seriesValues: number[][] = [];
+
+  series.forEach((item, seriesIndex) => {
+    if (!isRecord(item)) return;
+
+    const values = asNumberArray(item.values);
+    if (values.length === 0) return;
+
+    const key = `series-${seriesIndex}`;
+    const name =
+      typeof item.name === 'string' && item.name.trim()
+        ? item.name.trim()
+        : `값 ${seriesIndex + 1}`;
+
+    yKeys.push({ key, name });
+    seriesValues.push(values);
+  });
+
+  if (yKeys.length === 0) return null;
+
+  const data = labels.map<ChartRowViewModel>((label, labelIndex) => {
+    const row: ChartRowViewModel = {
+      name: label || `항목 ${labelIndex + 1}`,
+    };
+
+    yKeys.forEach((seriesKey, seriesIndex) => {
+      row[seriesKey.key] = seriesValues[seriesIndex]?.[labelIndex] ?? 0;
+    });
+
+    return row;
+  });
+
+  return {
+    name:
+      typeof value.tabName === 'string' && value.tabName.trim()
+        ? value.tabName.trim()
+        : `탭 ${index + 1}`,
+    data,
+    yKeys,
+    unit:
+      typeof chart.unit === 'string' && chart.unit.trim()
+        ? chart.unit.trim()
+        : '',
+  };
+}
+
+function normalizeTabChartData(value: Record<string, unknown>) {
+  const tabResults = Array.isArray(value.tabResults) ? value.tabResults : null;
+  if (!tabResults) return null;
+
+  const normalizedTabs = tabResults
+    .map(normalizeTabResult)
+    .filter((tab): tab is ChartTabViewModel => tab !== null);
+  if (normalizedTabs.length === 0) return null;
+
+  const rawTabs = asStringArray(value.tabs);
+  const tabNames = uniqueStrings([
+    ...rawTabs,
+    ...normalizedTabs.map((tab) => tab.name),
+  ]).filter((tabName) =>
+    normalizedTabs.some((tabResult) => tabResult.name === tabName),
+  );
+  const defaultTab =
+    typeof value.defaultTab === 'string' &&
+    tabNames.includes(value.defaultTab.trim())
+      ? value.defaultTab.trim()
+      : normalizedTabs[0].name;
+  const defaultTabResult =
+    normalizedTabs.find((tab) => tab.name === defaultTab) ?? normalizedTabs[0];
+
+  return {
+    type: 'bar',
+    tabs:
+      tabNames.length > 0 ? tabNames : normalizedTabs.map((tab) => tab.name),
+    defaultTab,
+    data: defaultTabResult.data,
+    xKey: 'name',
+    yKeys: defaultTabResult.yKeys,
+    unit: defaultTabResult.unit,
+    tabResults: normalizedTabs,
+    exportEnabled: value.exportEnabled === true,
+  } satisfies BarChartViewModel;
+}
+
+export function normalizeChartData(value: unknown): ChartViewModel {
+  if (!isRecord(value)) return createEmptyChart(getChartEmptyReason(value));
+
+  const normalized = normalizeTabChartData(value);
+  if (normalized) return normalized;
+
+  return createEmptyChart(getChartEmptyReason(value));
+}

--- a/apps/fe/src/app/(main)/analysis/[id]/_adapters/normalizeCriteria.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_adapters/normalizeCriteria.ts
@@ -1,0 +1,230 @@
+import type {
+  CriteriaInfo,
+  FilterInfo,
+  GetQuestionCriteriaResponse,
+  UpdateQuestionCriteriaRequest,
+} from '@/apis/analysis';
+import type {
+  AnalysisFieldViewModel,
+  AnalysisFilterViewModel,
+  CriteriaEditValues,
+  CriteriaViewModel,
+} from '../_models/analysisViewModels';
+import type { AnalysisWarningViewModel } from '../_models/analysisWarningTypes';
+import {
+  createMissingFieldWarning,
+  normalizeDataWarningItems,
+  normalizeWarningText,
+} from './normalizeWarnings';
+
+const ANALYSIS_TYPE_LABELS: Record<string, string> = {
+  COMPARISON: '비교 분석',
+  RANKING: '순위 분석',
+};
+
+const REQUIRED_FIELD_LABELS = {
+  analysisType: '분석 방식',
+  metricName: '지표',
+  baseDateColumn: '날짜 기준',
+  standardPeriod: '분석 기간',
+  comparePeriod: '비교 기간',
+  groupBy: '비교 기준',
+  sortBy: '정렬 기준',
+  sortDirection: '정렬 순서',
+} as const;
+
+function normalizeString(value: string | null | undefined) {
+  const trimmed = value?.trim();
+  return trimmed || null;
+}
+
+function normalizeStringList(values: string[] | null | undefined) {
+  return Array.isArray(values)
+    ? Array.from(
+        new Set(
+          values
+            .map((value) => normalizeString(value))
+            .filter(Boolean) as string[],
+        ),
+      )
+    : [];
+}
+
+function createField(
+  value: string | null | undefined,
+  mapLabel?: (value: string) => string,
+): AnalysisFieldViewModel {
+  const normalized = normalizeString(value);
+  return {
+    value: normalized,
+    label: normalized ? (mapLabel?.(normalized) ?? normalized) : '-',
+    missing: normalized === null,
+  };
+}
+
+function formatFilterLabel(filter: AnalysisFilterViewModel) {
+  const values = [
+    filter.field,
+    filter.operator,
+    filter.value == null ? null : String(filter.value),
+  ].filter(Boolean);
+
+  return values.length > 0 ? values.join(' ') : '조건 없음';
+}
+
+function normalizeFilters(filters: FilterInfo[] | null | undefined) {
+  if (!filters?.length) return [];
+
+  return filters.map<AnalysisFilterViewModel>((filter) => {
+    const normalized = {
+      field: normalizeString(filter.field),
+      operator: normalizeString(filter.operator),
+      value: filter.value,
+      label: '',
+    };
+
+    return {
+      ...normalized,
+      label: formatFilterLabel(normalized),
+    };
+  });
+}
+
+function getMissingFields(criteria?: CriteriaInfo | null) {
+  if (!criteria) return Object.values(REQUIRED_FIELD_LABELS);
+
+  const missing: string[] = [];
+  const analysisType = normalizeString(criteria.analysisType);
+
+  if (!analysisType) missing.push(REQUIRED_FIELD_LABELS.analysisType);
+  if (!normalizeString(criteria.metricName))
+    missing.push(REQUIRED_FIELD_LABELS.metricName);
+  if (!normalizeString(criteria.baseDateColumn))
+    missing.push(REQUIRED_FIELD_LABELS.baseDateColumn);
+  if (!normalizeString(criteria.standardPeriod))
+    missing.push(REQUIRED_FIELD_LABELS.standardPeriod);
+  if (
+    analysisType === 'COMPARISON' &&
+    !normalizeString(criteria.comparePeriod)
+  ) {
+    missing.push(REQUIRED_FIELD_LABELS.comparePeriod);
+  }
+  if (normalizeStringList(criteria.groupBy).length === 0) {
+    missing.push(REQUIRED_FIELD_LABELS.groupBy);
+  }
+  if (!normalizeString(criteria.sortBy))
+    missing.push(REQUIRED_FIELD_LABELS.sortBy);
+  if (!normalizeString(criteria.sortDirection))
+    missing.push(REQUIRED_FIELD_LABELS.sortDirection);
+
+  return missing;
+}
+
+function createUnknownEnumWarnings(criteria?: CriteriaInfo | null) {
+  const warnings: AnalysisWarningViewModel[] = [];
+  const analysisType = normalizeString(criteria?.analysisType);
+
+  if (analysisType && !ANALYSIS_TYPE_LABELS[analysisType]) {
+    const warning = normalizeWarningText(
+      `UNKNOWN_ANALYSIS_TYPE_${analysisType}`,
+      'criteria',
+      ['analysisType'],
+    );
+    if (warning) warnings.push(warning);
+  }
+
+  return warnings;
+}
+
+export function normalizeCriteria(
+  response: GetQuestionCriteriaResponse,
+): CriteriaViewModel {
+  const criteria = response.criteria;
+  const analysisType = createField(
+    criteria?.analysisType,
+    (value) => ANALYSIS_TYPE_LABELS[value] ?? value,
+  );
+  const metric = createField(criteria?.metricName);
+  const dateField = createField(criteria?.baseDateColumn);
+  const standardPeriod = normalizeString(criteria?.standardPeriod);
+  const comparePeriod = normalizeString(criteria?.comparePeriod);
+  const groupBy = normalizeStringList(criteria?.groupBy);
+  const sortBy = normalizeString(criteria?.sortBy);
+  const sortDirection = normalizeString(criteria?.sortDirection);
+  const missingFields = getMissingFields(criteria);
+  const missingWarning = createMissingFieldWarning(missingFields, 'criteria');
+  const warnings = [
+    ...normalizeDataWarningItems(criteria?.dataWarning, 'criteria'),
+    ...normalizeStringList(criteria?.needConfirm)
+      .map((field) =>
+        normalizeWarningText(`확인이 필요한 필드: ${field}`, 'criteria', [
+          field,
+        ]),
+      )
+      .filter(
+        (warning): warning is AnalysisWarningViewModel => warning !== null,
+      ),
+    ...createUnknownEnumWarnings(criteria),
+    ...(missingWarning ? [missingWarning] : []),
+  ];
+
+  return {
+    messageId: response.messageId,
+    question: response.question,
+    message: normalizeString(response.message),
+    analysisType,
+    metric,
+    dateField,
+    period: {
+      standard: standardPeriod,
+      compare: comparePeriod,
+      label: [standardPeriod, comparePeriod].filter(Boolean).join(' / ') || '-',
+    },
+    groupBy,
+    sort: {
+      by: sortBy,
+      direction: sortDirection,
+      label: [sortBy, sortDirection].filter(Boolean).join(' ') || '-',
+    },
+    limitNum: criteria?.limitNum ?? null,
+    filters: normalizeFilters(criteria?.filters),
+    missingFields,
+    warnings,
+    createdAt: response.createdAt,
+  };
+}
+
+export function createCriteriaEditValues(
+  criteria: CriteriaViewModel,
+): CriteriaEditValues {
+  return {
+    baseDateColumn: criteria.dateField.value ?? '',
+    standardPeriod: criteria.period.standard ?? '',
+    comparePeriod: criteria.period.compare ?? '',
+    groupBy: criteria.groupBy,
+    sortBy: criteria.sort.by ?? '',
+    sortDirection: criteria.sort.direction ?? '',
+    limitNum: criteria.limitNum,
+    filters: criteria.filters,
+  };
+}
+
+export function createUpdateCriteriaRequest(
+  values: CriteriaEditValues,
+): UpdateQuestionCriteriaRequest {
+  return {
+    baseDateColumn: values.baseDateColumn || undefined,
+    standardPeriod: values.standardPeriod || undefined,
+    comparePeriod: values.comparePeriod || undefined,
+    groupBy: values.groupBy,
+    sortBy: values.sortBy || undefined,
+    sortDirection: values.sortDirection || undefined,
+    limitNum: values.limitNum ?? undefined,
+    filters: values.filters.map((filter) => ({
+      field: filter.field,
+      operator: filter.operator,
+      value: filter.value,
+    })),
+    confirmed: true,
+  };
+}

--- a/apps/fe/src/app/(main)/analysis/[id]/_adapters/normalizeCriteria.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_adapters/normalizeCriteria.ts
@@ -38,6 +38,10 @@ function normalizeString(value: string | null | undefined) {
   return trimmed || null;
 }
 
+function normalizeSortDirection(value: string | null | undefined) {
+  return normalizeString(value)?.toUpperCase() ?? null;
+}
+
 function normalizeStringList(values: string[] | null | undefined) {
   return Array.isArray(values)
     ? Array.from(
@@ -150,7 +154,7 @@ export function normalizeCriteria(
   const comparePeriod = normalizeString(criteria?.comparePeriod);
   const groupBy = normalizeStringList(criteria?.groupBy);
   const sortBy = normalizeString(criteria?.sortBy);
-  const sortDirection = normalizeString(criteria?.sortDirection);
+  const sortDirection = normalizeSortDirection(criteria?.sortDirection);
   const missingFields = getMissingFields(criteria);
   const missingWarning = createMissingFieldWarning(missingFields, 'criteria');
   const warnings = [
@@ -212,13 +216,15 @@ export function createCriteriaEditValues(
 export function createUpdateCriteriaRequest(
   values: CriteriaEditValues,
 ): UpdateQuestionCriteriaRequest {
+  const sortDirection = normalizeSortDirection(values.sortDirection);
+
   return {
     baseDateColumn: values.baseDateColumn || undefined,
     standardPeriod: values.standardPeriod || undefined,
     comparePeriod: values.comparePeriod || undefined,
     groupBy: values.groupBy,
     sortBy: values.sortBy || undefined,
-    sortDirection: values.sortDirection || undefined,
+    sortDirection: sortDirection ?? undefined,
     limitNum: values.limitNum ?? undefined,
     filters: values.filters.map((filter) => ({
       field: filter.field,

--- a/apps/fe/src/app/(main)/analysis/[id]/_adapters/normalizeResult.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_adapters/normalizeResult.ts
@@ -1,0 +1,84 @@
+import type { CriteriaInfo, GetQuestionResultResponse } from '@/apis/analysis';
+import type {
+  QuestionResultViewModel,
+  ResultCriteriaItemViewModel,
+} from '../_models/analysisViewModels';
+import { normalizeAnalysisStatusError } from './normalizeAnalysisError';
+import { normalizeChartData } from './normalizeChartData';
+
+function normalizeString(value: string | null | undefined) {
+  const trimmed = value?.trim();
+  return trimmed || null;
+}
+
+function joinList(values: string[] | null | undefined) {
+  return Array.isArray(values)
+    ? values
+        .map((value) => normalizeString(value))
+        .filter(Boolean)
+        .join(', ')
+    : '';
+}
+
+function createCriteriaItems(
+  criteria?: CriteriaInfo | null,
+): ResultCriteriaItemViewModel[] {
+  if (!criteria) return [];
+
+  return [
+    ['지표', criteria.metricName],
+    ['비교 기준', joinList(criteria.groupBy)],
+    ['날짜 기준', criteria.baseDateColumn],
+    ['분석 기간', criteria.standardPeriod],
+    ['비교 기간', criteria.comparePeriod],
+  ]
+    .map(([label, value]) => [label, normalizeString(value)] as const)
+    .filter((item): item is readonly [string, string] => item[1] !== null)
+    .map(([label, value]) => ({ label, value }));
+}
+
+export function normalizeResult(
+  result: GetQuestionResultResponse | null | undefined,
+): QuestionResultViewModel {
+  if (!result) {
+    const error = normalizeAnalysisStatusError(
+      'FAILED',
+      '분석 결과를 불러오지 못했습니다. 다시 시도해 주세요.',
+    );
+
+    return {
+      status: 'failed',
+      resultId: null,
+      title: error?.title ?? '분석 결과를 불러오지 못했어요',
+      insight: error?.message ?? '분석 결과가 비어 있습니다.',
+      tableRows: [],
+      chart: normalizeChartData(null),
+      criteriaItems: [],
+      warnings: [],
+      canRetry: error?.retryable ?? true,
+      emptyMessage: '분석 결과가 비어 있습니다.',
+      error,
+    };
+  }
+
+  const chart = normalizeChartData(result.chartData);
+  const tableRows = chart.type === 'bar' ? chart.data : [];
+  const emptyMessage = chart.type === 'empty' ? chart.message : null;
+
+  return {
+    status: 'success',
+    resultId: result.resultId,
+    title: normalizeString(result.summaryMessage) ?? '검증이 완료되었어요.',
+    insight:
+      normalizeString(result.description) ??
+      emptyMessage ??
+      '분석 결과 설명을 찾지 못했습니다.',
+    tableRows,
+    chart,
+    criteriaItems: createCriteriaItems(result.criteria),
+    warnings: [],
+    canRetry: false,
+    emptyMessage,
+    error: null,
+  };
+}

--- a/apps/fe/src/app/(main)/analysis/[id]/_adapters/normalizeSummary.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_adapters/normalizeSummary.ts
@@ -1,0 +1,87 @@
+import type { GetSummaryResponse } from '@/apis/analysis';
+import type {
+  SummaryKeyPointViewModel,
+  SummaryViewModel,
+} from '../_models/analysisViewModels';
+import { normalizeWarningLines } from './normalizeWarnings';
+
+const SUMMARY_GROUPS = [
+  { name: '데이터 기준', key: 'dataCriteria' },
+  { name: '지표', key: 'measure' },
+  { name: '차원', key: 'dimension' },
+  { name: '상태 조건', key: 'statusCondition' },
+  { name: '플래그', key: 'flag' },
+  { name: '식별 기준', key: 'idCriteria' },
+] as const;
+
+function compactStrings(values: unknown) {
+  return Array.isArray(values)
+    ? values
+        .map((value) => (typeof value === 'string' ? value.trim() : ''))
+        .filter(Boolean)
+    : [];
+}
+
+function uniqueStrings(values: string[]) {
+  return Array.from(new Set(values));
+}
+
+function asNonNegativeNumber(value: unknown) {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? value
+    : 0;
+}
+
+export function createSummaryKeyPoints(
+  summary: GetSummaryResponse | null | undefined,
+): SummaryKeyPointViewModel[] {
+  if (!summary) return [];
+
+  return SUMMARY_GROUPS.flatMap((group) =>
+    compactStrings(summary[group.key]).map((value) => ({
+      name: group.name,
+      example: value,
+    })),
+  );
+}
+
+export function normalizeSummary(
+  summary: GetSummaryResponse | null | undefined,
+): SummaryViewModel {
+  const keyPoints = createSummaryKeyPoints(summary);
+  const dataCriteria = compactStrings(summary?.dataCriteria);
+  const measure = compactStrings(summary?.measure);
+  const dimension = compactStrings(summary?.dimension);
+  const statusCondition = compactStrings(summary?.statusCondition);
+  const flag = compactStrings(summary?.flag);
+  const idCriteria = compactStrings(summary?.idCriteria);
+  const rowCount = asNonNegativeNumber(summary?.rowCount);
+  const columnCount = asNonNegativeNumber(summary?.columnCount);
+  const columnOptions = uniqueStrings([
+    ...dataCriteria,
+    ...measure,
+    ...dimension,
+    ...statusCondition,
+    ...flag,
+    ...idCriteria,
+  ]);
+  const emptyMessage =
+    rowCount === 0 && columnCount === 0
+      ? '요약할 데이터 정보를 찾지 못했습니다.'
+      : keyPoints.length === 0
+        ? '표시할 데이터 요약 항목이 없습니다.'
+        : null;
+
+  return {
+    title: '데이터를 확인했어요',
+    summaryText: `총 ${rowCount.toLocaleString()}행, ${columnCount.toLocaleString()}열의 데이터가 업로드되었어요.`,
+    keyPoints,
+    warnings: normalizeWarningLines(summary?.sourceDataWarning, 'summary'),
+    emptyMessage,
+    rowCount,
+    columnCount,
+    columnOptions,
+    dateFieldOptions: dataCriteria,
+    measureOptions: measure,
+  };
+}

--- a/apps/fe/src/app/(main)/analysis/[id]/_adapters/normalizeWarnings.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_adapters/normalizeWarnings.ts
@@ -1,0 +1,115 @@
+import type { DataWarningItem } from '@/apis/analysis';
+import type {
+  AnalysisWarningSource,
+  AnalysisWarningViewModel,
+} from '../_models/analysisWarningTypes';
+
+const WARNING_MESSAGE_BY_CODE: Record<string, string> = {
+  DATE_FIELD_CONFLICT:
+    '날짜 기준을 하나로 정하기 어려워요. 어떤 날짜를 기준으로 볼지 선택해 주세요.',
+  QUESTION_DATA_MISMATCH:
+    '질문과 데이터 구조가 맞지 않을 수 있어요. 다른 기준으로 바꿔 계속할 수 있어요.',
+  CRITICAL_NULL_DETECTED:
+    '분석에 필요한 값 일부가 비어 있어 결과가 부정확할 수 있어요.',
+};
+
+const LEGACY_WARNING_CODE_MAP: Record<string, string> = {
+  date_field_conflict: 'DATE_FIELD_CONFLICT',
+};
+
+function compactStrings(values: Array<string | null | undefined>) {
+  return values
+    .map((value) => value?.trim())
+    .filter((value): value is string => Boolean(value));
+}
+
+function uniqueStrings(values: Array<string | null | undefined>) {
+  return Array.from(new Set(compactStrings(values)));
+}
+
+function looksLikeCode(value: string) {
+  return /^[A-Z][A-Z0-9_]*$/.test(value);
+}
+
+function normalizeWarningCode(value: string) {
+  const trimmed = value.trim();
+  return LEGACY_WARNING_CODE_MAP[trimmed] ?? trimmed;
+}
+
+export function normalizeWarningText(
+  value: string | null | undefined,
+  source: AnalysisWarningSource,
+  relatedFields: string[] = [],
+): AnalysisWarningViewModel | null {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+
+  const code = normalizeWarningCode(trimmed);
+  const knownMessage = WARNING_MESSAGE_BY_CODE[code];
+
+  if (knownMessage) {
+    return {
+      code,
+      message: knownMessage,
+      relatedFields: uniqueStrings(relatedFields),
+      source,
+      isKnown: true,
+    };
+  }
+
+  if (looksLikeCode(code)) {
+    return {
+      code,
+      message: `알 수 없는 경고 코드(${code})가 전달되었습니다.`,
+      relatedFields: uniqueStrings(relatedFields),
+      source,
+      isKnown: false,
+    };
+  }
+
+  return {
+    code: 'UNSPECIFIED_WARNING',
+    message: trimmed,
+    relatedFields: uniqueStrings(relatedFields),
+    source,
+    isKnown: false,
+  };
+}
+
+export function normalizeWarningLines(
+  value: string | null | undefined,
+  source: AnalysisWarningSource,
+) {
+  return compactStrings(value?.split('\n') ?? [])
+    .map((line) => normalizeWarningText(line, source))
+    .filter((warning): warning is AnalysisWarningViewModel => warning !== null);
+}
+
+export function normalizeDataWarningItems(
+  items: DataWarningItem[] | null | undefined,
+  source: AnalysisWarningSource,
+) {
+  if (!items?.length) return [];
+
+  return items
+    .slice()
+    .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+    .map((warning) => normalizeWarningText(warning.content, source))
+    .filter((warning): warning is AnalysisWarningViewModel => warning !== null);
+}
+
+export function createMissingFieldWarning(
+  fields: string[],
+  source: AnalysisWarningSource,
+): AnalysisWarningViewModel | null {
+  const relatedFields = uniqueStrings(fields);
+  if (relatedFields.length === 0) return null;
+
+  return {
+    code: 'MISSING_ANALYSIS_FIELDS',
+    message: `확인이 필요한 분석 기준: ${relatedFields.join(', ')}`,
+    relatedFields,
+    source,
+    isKnown: true,
+  };
+}

--- a/apps/fe/src/app/(main)/analysis/[id]/_components/AnalysisResult.tsx
+++ b/apps/fe/src/app/(main)/analysis/[id]/_components/AnalysisResult.tsx
@@ -3,22 +3,10 @@
 import { useState } from 'react';
 import ArrowDownIcon from '@/assets/icons/arrow-down.svg';
 import AlertIcon from '@/assets/icons/alert.svg';
-
-export type ColumnCandidate = {
-  name: string;
-  example: string;
-};
+import type { SummaryViewModel } from '../_models/analysisViewModels';
 
 export type AnalysisResultProps = {
-  rowCount: number;
-  columnCount: number;
-  /** 본문 보조 텍스트 */
-  description?: string;
-  /** 데이터 요약 표 행들 */
-  candidates?: ColumnCandidate[];
-  /** 데이터 경고 메시지들 */
-  warnings?: string[];
-  /** 데이터 경고가 있을 때 노출할 액션 */
+  summary: SummaryViewModel;
   warningActions?: {
     editLabel?: string;
     continueLabel?: string;
@@ -28,38 +16,28 @@ export type AnalysisResultProps = {
   };
 };
 
-const DEFAULT_CANDIDATES: ColumnCandidate[] = Array.from({ length: 9 }, () => ({
-  name: '날짜 기준',
-  example: 'signup_date, created_at',
-}));
-
 export default function AnalysisResult({
-  rowCount,
-  columnCount,
-  description = '분석에 필요한 주요 컬럼 후보를 아래처럼 찾았어요.',
-  candidates = DEFAULT_CANDIDATES,
-  warnings,
+  summary,
   warningActions,
 }: AnalysisResultProps) {
   const [summaryOpen, setSummaryOpen] = useState(true);
-  const hasWarnings = Boolean(warnings?.length);
+  const hasWarnings = summary.warnings.length > 0;
 
   return (
     <div className="flex w-full flex-col gap-16 rounded-20 bg-white p-24 shadow-[0_0.2rem_1.2rem_rgba(0,0,0,0.06)]">
-      {/* 헤더 텍스트 */}
       <div className="flex flex-col gap-8">
-        <p className="text-body2 text-gray-900">데이터를 확인했어요.</p>
+        <p className="text-body2 text-gray-900">{summary.title}</p>
         <p className="text-body2 text-gray-900">
-          총{' '}
-          <span className="text-orange-500">{rowCount.toLocaleString()}행</span>
-          , <span className="text-orange-500">{columnCount}열</span>의 데이터가
-          업로드되었어요.
+          <span className="text-orange-500">
+            {summary.rowCount.toLocaleString()}행
+          </span>
+          , <span className="text-orange-500">{summary.columnCount}열</span>의
+          데이터가 업로드되었어요.
           <br />
-          {description}
+          {summary.emptyMessage ?? summary.summaryText}
         </p>
       </div>
 
-      {/* 데이터 요약 (collapsible) */}
       <div className="flex flex-col gap-8">
         <button
           type="button"
@@ -90,22 +68,35 @@ export default function AnalysisResult({
                 </tr>
               </thead>
               <tbody>
-                {candidates.map((c, i) => (
-                  <tr
-                    key={i}
-                    className="border-b border-gray-200 last:border-b-0"
-                  >
-                    <td className="px-16 py-12 text-gray-900">{c.name}</td>
-                    <td className="px-16 py-12 text-orange-500">{c.example}</td>
+                {summary.keyPoints.length === 0 ? (
+                  <tr>
+                    <td
+                      colSpan={2}
+                      className="px-16 py-12 text-center text-gray-600"
+                    >
+                      {summary.emptyMessage ??
+                        '표시할 데이터 요약 항목이 없습니다.'}
+                    </td>
                   </tr>
-                ))}
+                ) : (
+                  summary.keyPoints.map((item, index) => (
+                    <tr
+                      key={`${item.name}-${item.example}-${index}`}
+                      className="border-b border-gray-200 last:border-b-0"
+                    >
+                      <td className="px-16 py-12 text-gray-900">{item.name}</td>
+                      <td className="px-16 py-12 text-orange-500">
+                        {item.example}
+                      </td>
+                    </tr>
+                  ))
+                )}
               </tbody>
             </table>
           </div>
         )}
       </div>
 
-      {/* 데이터 경고 */}
       {hasWarnings && (
         <div className="flex flex-col gap-8">
           <div className="inline-flex items-center gap-4 text-body4 text-orange-500">
@@ -113,8 +104,10 @@ export default function AnalysisResult({
             <span>데이터 경고</span>
           </div>
           <ul className="ml-20 list-disc text-body2 text-gray-900">
-            {warnings?.map((w, i) => (
-              <li key={i}>{w}</li>
+            {summary.warnings.map((warning) => (
+              <li key={`${warning.code}-${warning.message}`}>
+                {warning.message}
+              </li>
             ))}
           </ul>
           {warningActions && (

--- a/apps/fe/src/app/(main)/analysis/[id]/_components/QuestionAnalysisResult.tsx
+++ b/apps/fe/src/app/(main)/analysis/[id]/_components/QuestionAnalysisResult.tsx
@@ -1,41 +1,27 @@
 'use client';
 
 import { useMemo, useState } from 'react';
-import type {
-  CriteriaInfo,
-  FilterInfo,
-  UpdateQuestionCriteriaRequest,
-} from '@/apis/analysis';
 import AlertIcon from '@/assets/icons/alert.svg';
+import { createCriteriaEditValues } from '../_adapters/normalizeCriteria';
+import type {
+  AnalysisFilterViewModel,
+  CriteriaEditValues,
+  CriteriaViewModel,
+} from '../_models/analysisViewModels';
 import CriterionSelect from './CriterionSelect';
-
-export type EditableValues = {
-  baseDateColumn: string;
-  standardPeriod: string;
-  comparePeriod: string;
-  groupBy: string[];
-  sortBy: string;
-  sortDirection: string;
-  limitNum: number | null;
-  filters: FilterInfo[];
-};
 
 type Mode = 'normal' | 'edit';
 
 export type QuestionAnalysisResultProps = {
-  criteria?: CriteriaInfo | null;
+  criteria: CriteriaViewModel;
   baseDateColumnOptions?: string[];
   groupByOptions?: string[];
   sortByOptions?: string[];
   sortDirectionOptions?: string[];
   initialMode?: Mode;
-  /** 수정하기 클릭 시 노출할 데이터 경고 목록 */
-  warnings?: string[];
   isSubmitting?: boolean;
-  /** 카드 외부 콜백 — 수정하기 클릭 */
   onEdit?: () => void;
-  /** 카드 외부 콜백 — 이 기준으로 계속 클릭 */
-  onContinue?: (values: UpdateQuestionCriteriaRequest) => void;
+  onContinue?: (values: CriteriaEditValues) => void;
 };
 
 type StaticRow = { kind: 'static'; label: string; value: string };
@@ -43,7 +29,7 @@ type SingleRow = {
   kind: 'single';
   label: string;
   key: keyof Pick<
-    EditableValues,
+    CriteriaEditValues,
     | 'baseDateColumn'
     | 'standardPeriod'
     | 'comparePeriod'
@@ -62,34 +48,9 @@ type MultiRow = {
 };
 
 type RowSpec = StaticRow | SingleRow | MultiRow;
-type DefaultCriteria = {
-  analysisType: string;
-  metricName: string;
-  baseDateColumn: string;
-  standardPeriod: string;
-  comparePeriod: string;
-  groupBy: string[];
-  sortBy: string;
-  sortDirection: string;
-  limitNum: number;
-  filters: FilterInfo[];
-};
-
-const DEFAULT_CRITERIA: DefaultCriteria = {
-  analysisType: '비교 분석',
-  metricName: '가입 전환율',
-  baseDateColumn: '가입일',
-  standardPeriod: '이번 주',
-  comparePeriod: '지난 주',
-  groupBy: ['채널', '디바이스'],
-  sortBy: '전환율 변화량',
-  sortDirection: '낮은 순',
-  limitNum: 5,
-  filters: [{ field: 'internal_text', operator: 'exclude', value: true }],
-};
 
 const DEFAULT_PERIOD_OPTIONS = ['이번 주', '지난 주', '이번 달', '지난 달'];
-const DEFAULT_SORT_DIRECTION_OPTIONS = ['ASC', 'DESC', '높은 순', '낮은 순'];
+const DEFAULT_SORT_DIRECTION_OPTIONS = ['ASC', 'DESC', 'asc', 'desc'];
 
 function compactStrings(values: Array<string | null | undefined>) {
   return values
@@ -101,51 +62,13 @@ function uniqueOptions(values: Array<string | null | undefined>) {
   return Array.from(new Set(compactStrings(values)));
 }
 
-function createEditableValues(criteria?: CriteriaInfo | null): EditableValues {
-  return {
-    baseDateColumn: criteria?.baseDateColumn ?? DEFAULT_CRITERIA.baseDateColumn,
-    standardPeriod: criteria?.standardPeriod ?? DEFAULT_CRITERIA.standardPeriod,
-    comparePeriod: criteria?.comparePeriod ?? DEFAULT_CRITERIA.comparePeriod,
-    groupBy:
-      criteria?.groupBy && criteria.groupBy.length > 0
-        ? criteria.groupBy
-        : DEFAULT_CRITERIA.groupBy,
-    sortBy: criteria?.sortBy ?? DEFAULT_CRITERIA.sortBy,
-    sortDirection: criteria?.sortDirection ?? DEFAULT_CRITERIA.sortDirection,
-    limitNum: criteria?.limitNum ?? DEFAULT_CRITERIA.limitNum,
-    filters: criteria?.filters ?? DEFAULT_CRITERIA.filters,
-  };
-}
-
-function formatFilters(filters: FilterInfo[]) {
+function formatFilters(filters: AnalysisFilterViewModel[]) {
   if (filters.length === 0) return '없음';
 
   return filters
-    .map((filter) =>
-      compactStrings([
-        filter.field ?? undefined,
-        filter.operator ?? undefined,
-        filter.value == null ? undefined : String(filter.value),
-      ]).join(' '),
-    )
+    .map((filter) => filter.label)
     .filter(Boolean)
     .join(', ');
-}
-
-function createUpdateRequest(
-  values: EditableValues,
-): UpdateQuestionCriteriaRequest {
-  return {
-    baseDateColumn: values.baseDateColumn || undefined,
-    standardPeriod: values.standardPeriod || undefined,
-    comparePeriod: values.comparePeriod || undefined,
-    groupBy: values.groupBy,
-    sortBy: values.sortBy || undefined,
-    sortDirection: values.sortDirection || undefined,
-    limitNum: values.limitNum ?? undefined,
-    filters: values.filters,
-    confirmed: true,
-  };
 }
 
 function DataWarningBlock({ warnings }: { warnings: string[] }) {
@@ -173,30 +96,19 @@ export default function QuestionAnalysisResult({
   sortByOptions,
   sortDirectionOptions,
   initialMode = 'normal',
-  warnings,
   isSubmitting = false,
   onEdit,
   onContinue,
 }: QuestionAnalysisResultProps) {
   const [mode, setMode] = useState<Mode>(initialMode);
-  const [values, setValues] = useState<EditableValues>(() =>
-    createEditableValues(criteria),
+  const [values, setValues] = useState<CriteriaEditValues>(() =>
+    createCriteriaEditValues(criteria),
   );
 
-  const criteriaWarnings = useMemo(() => {
-    const dataWarnings =
-      criteria?.dataWarning
-        ?.slice()
-        .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
-        .map((warning) => warning.content)
-        .filter((content): content is string => Boolean(content)) ?? [];
-    const needConfirm = criteria?.needConfirm ?? [];
-
-    return [...dataWarnings, ...needConfirm];
-  }, [criteria]);
-
-  const warningTexts =
-    warnings ?? (criteriaWarnings.length > 0 ? criteriaWarnings : []);
+  const warningTexts = useMemo(
+    () => criteria.warnings.map((warning) => warning.message),
+    [criteria.warnings],
+  );
 
   const rows = useMemo<RowSpec[]>(() => {
     const groupBy = values.groupBy.length > 0 ? values.groupBy : [''];
@@ -205,12 +117,12 @@ export default function QuestionAnalysisResult({
       {
         kind: 'static',
         label: '분석 방식',
-        value: criteria?.analysisType ?? DEFAULT_CRITERIA.analysisType,
+        value: criteria.analysisType.label,
       },
       {
         kind: 'static',
         label: '지표',
-        value: criteria?.metricName ?? DEFAULT_CRITERIA.metricName,
+        value: criteria.metric.label,
       },
       {
         kind: 'single',
@@ -219,7 +131,6 @@ export default function QuestionAnalysisResult({
         options: uniqueOptions([
           values.baseDateColumn,
           ...(baseDateColumnOptions ?? []),
-          DEFAULT_CRITERIA.baseDateColumn,
         ]),
       },
       {
@@ -244,23 +155,15 @@ export default function QuestionAnalysisResult({
         kind: 'multi',
         label: '비교 기준',
         key: 'groupBy',
-        options: uniqueOptions([
-          ...groupBy,
-          ...(groupByOptions ?? []),
-          ...DEFAULT_CRITERIA.groupBy,
-        ]),
+        options: uniqueOptions([...groupBy, ...(groupByOptions ?? [])]),
         maxSelect: 5,
-        headerLabel: '여러 개 선택 가능',
+        headerLabel: '여러 값 선택 가능',
       },
       {
         kind: 'single',
         label: '정렬 기준',
         key: 'sortBy',
-        options: uniqueOptions([
-          values.sortBy,
-          ...(sortByOptions ?? []),
-          DEFAULT_CRITERIA.sortBy,
-        ]),
+        options: uniqueOptions([values.sortBy, ...(sortByOptions ?? [])]),
       },
       {
         kind: 'single',
@@ -284,8 +187,8 @@ export default function QuestionAnalysisResult({
     ];
   }, [
     baseDateColumnOptions,
-    criteria?.analysisType,
-    criteria?.metricName,
+    criteria.analysisType.label,
+    criteria.metric.label,
     groupByOptions,
     sortByOptions,
     sortDirectionOptions,
@@ -299,11 +202,11 @@ export default function QuestionAnalysisResult({
 
   const handleCancelEdit = () => {
     setMode('normal');
-    setValues(createEditableValues(criteria));
+    setValues(createCriteriaEditValues(criteria));
   };
 
   const handleContinue = () => {
-    onContinue?.(createUpdateRequest(values));
+    onContinue?.(values);
   };
 
   const renderStaticValue = (row: RowSpec) => {

--- a/apps/fe/src/app/(main)/analysis/[id]/_components/QuestionAnalysisResult.tsx
+++ b/apps/fe/src/app/(main)/analysis/[id]/_components/QuestionAnalysisResult.tsx
@@ -50,7 +50,7 @@ type MultiRow = {
 type RowSpec = StaticRow | SingleRow | MultiRow;
 
 const DEFAULT_PERIOD_OPTIONS = ['이번 주', '지난 주', '이번 달', '지난 달'];
-const DEFAULT_SORT_DIRECTION_OPTIONS = ['ASC', 'DESC', 'asc', 'desc'];
+const DEFAULT_SORT_DIRECTION_OPTIONS = ['ASC', 'DESC'];
 
 function compactStrings(values: Array<string | null | undefined>) {
   return values

--- a/apps/fe/src/app/(main)/analysis/[id]/_components/VerificationResult.tsx
+++ b/apps/fe/src/app/(main)/analysis/[id]/_components/VerificationResult.tsx
@@ -13,20 +13,14 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
-import type { GetQuestionResultResponse } from '@/apis/analysis';
 import AlertIcon from '@/assets/icons/alert.svg';
-
-export type ChartDataPoint = { name: string; value: number };
+import type {
+  BarChartViewModel,
+  QuestionResultViewModel,
+} from '../_models/analysisViewModels';
 
 export type VerificationResultProps = {
-  result?: GetQuestionResultResponse;
-  title?: string;
-  description?: string;
-  channelList?: string[];
-  deviceList?: string[];
-  channelData?: ChartDataPoint[];
-  deviceData?: ChartDataPoint[];
-  warnings?: string[];
+  result: QuestionResultViewModel;
 };
 
 const BAR_COLORS = [
@@ -38,30 +32,6 @@ const BAR_COLORS = [
   'var(--color-orange-700)',
   'var(--color-orange-800)',
 ];
-
-const DEFAULT_CHANNEL_DATA: ChartDataPoint[] = [
-  { name: '이름1', value: 120 },
-  { name: '이름1', value: 200 },
-  { name: '이름3', value: 150 },
-  { name: '이름1', value: 80 },
-  { name: '이름5', value: 60 },
-  { name: '이름1', value: 110 },
-  { name: '이름', value: 130 },
-];
-
-const DEFAULT_DEVICE_DATA: ChartDataPoint[] = [
-  { name: '이름1', value: 120 },
-  { name: '이름1', value: 200 },
-  { name: '이름3', value: 150 },
-  { name: '이름1', value: 80 },
-  { name: '이름5', value: 60 },
-  { name: '이름1', value: 110 },
-  { name: '이름', value: 130 },
-];
-
-type ChartRow = {
-  name: string;
-} & Record<string, number | string>;
 
 type BalloonLabelProps = {
   x?: number;
@@ -102,162 +72,36 @@ function BalloonLabel({ x = 0, y = 0, width = 0, value }: BalloonLabelProps) {
   );
 }
 
-function createFallbackResult(
-  title: string,
-  description: string,
-  channelList: string[],
-  deviceList: string[],
-  channelData: ChartDataPoint[],
-  deviceData: ChartDataPoint[],
-): GetQuestionResultResponse {
-  return {
-    resultId: 0,
-    summaryMessage: title,
-    description,
-    criteria: {
-      groupBy: [...channelList, ...deviceList],
-      metricName: null,
-    },
-    chartData: {
-      tabs: ['채널', '디바이스'],
-      defaultTab: '디바이스',
-      tabResults: [
-        {
-          tabName: '채널',
-          chart: {
-            labels: channelData.map((item) => item.name),
-            series: [
-              {
-                name: '값',
-                values: channelData.map((item) => item.value),
-              },
-            ],
-          },
-        },
-        {
-          tabName: '디바이스',
-          chart: {
-            labels: deviceData.map((item) => item.name),
-            series: [
-              {
-                name: '값',
-                values: deviceData.map((item) => item.value),
-              },
-            ],
-          },
-        },
-      ],
-    },
-  };
-}
-
-function uniqueStrings(values: Array<string | null | undefined>) {
-  return Array.from(
-    new Set(values.map((value) => value?.trim()).filter(Boolean) as string[]),
-  );
-}
-
-function getResultTabs(result: GetQuestionResultResponse) {
-  const chartData = result.chartData;
-  const tabNames = chartData?.tabResults?.map((tab) => tab.tabName) ?? [];
-
-  return uniqueStrings([...(chartData?.tabs ?? []), ...tabNames]);
-}
-
-function getDefaultTab(result: GetQuestionResultResponse) {
-  const tabs = getResultTabs(result);
-  const defaultTab = result.chartData?.defaultTab?.trim();
-
-  if (defaultTab && tabs.includes(defaultTab)) return defaultTab;
-  return tabs[0] ?? '';
-}
-
-function getActiveTabResult(result: GetQuestionResultResponse, tab: string) {
-  const tabResults = result.chartData?.tabResults ?? [];
-
+function getActiveTabResult(chart: BarChartViewModel, tab: string) {
   return (
-    tabResults.find((item) => item.tabName === tab) ?? tabResults[0] ?? null
+    chart.tabResults.find((item) => item.name === tab) ?? chart.tabResults[0]
   );
-}
-
-function createChartRows(result: GetQuestionResultResponse, tab: string) {
-  const activeTabResult = getActiveTabResult(result, tab);
-  const chart = activeTabResult?.chart;
-  const labels = chart?.labels ?? [];
-  const series = chart?.series ?? [];
-  const seriesKeys = series.map((item, index) => ({
-    key: `series-${index}`,
-    name: item.name?.trim() || `값 ${index + 1}`,
-  }));
-
-  const rows = labels.map<ChartRow>((label, labelIndex) => {
-    const row: ChartRow = { name: label || `항목 ${labelIndex + 1}` };
-
-    seriesKeys.forEach((seriesKey, seriesIndex) => {
-      row[seriesKey.key] = series[seriesIndex]?.values?.[labelIndex] ?? 0;
-    });
-
-    return row;
-  });
-
-  return {
-    rows,
-    seriesKeys,
-    unit: chart?.unit?.trim() ?? '',
-  };
-}
-
-function formatCriteriaList(result: GetQuestionResultResponse) {
-  const criteria = result.criteria;
-  if (!criteria) return [];
-
-  return [
-    ['지표', criteria.metricName],
-    ['비교 기준', criteria.groupBy?.join(', ')],
-    ['날짜 기준', criteria.baseDateColumn],
-    ['분석 기간', criteria.standardPeriod],
-    ['비교 기간', criteria.comparePeriod],
-  ].filter((item): item is [string, string] => Boolean(item[1]?.trim()));
 }
 
 export default function VerificationResult({
   result,
-  title = '검증이 완료되었어요.',
-  description = '가입 전환율이 지난주 대비 낮은 순으로 채널/디바이스를 나열했어요.',
-  channelList = ['iOS', 'Android', 'CRM', '콜드메일', '사이트 직접 탐색'],
-  deviceList = ['iOS', 'Android', 'CRM', '콜드메일', '사이트 직접 탐색'],
-  channelData = DEFAULT_CHANNEL_DATA,
-  deviceData = DEFAULT_DEVICE_DATA,
-  warnings = [],
 }: VerificationResultProps) {
-  const resolvedResult =
-    result ??
-    createFallbackResult(
-      title,
-      description,
-      channelList,
-      deviceList,
-      channelData,
-      deviceData,
-    );
-  const tabs = getResultTabs(resolvedResult);
-  const [tab, setTab] = useState(() => getDefaultTab(resolvedResult));
-  const { rows, seriesKeys, unit } = createChartRows(resolvedResult, tab);
-  const criteriaItems = formatCriteriaList(resolvedResult);
-  const heading = resolvedResult.summaryMessage || title;
-  const body = resolvedResult.description || description;
+  const [tab, setTab] = useState(() =>
+    result.chart.type === 'bar' ? result.chart.defaultTab : '',
+  );
+  const chart = result.chart;
+  const activeTabResult =
+    chart.type === 'bar' ? getActiveTabResult(chart, tab) : null;
+  const rows = activeTabResult?.data ?? [];
+  const seriesKeys = activeTabResult?.yKeys ?? [];
+  const unit = activeTabResult?.unit ?? '';
   const hasMultipleSeries = seriesKeys.length > 1;
 
   return (
     <div className="flex w-full flex-col gap-20 rounded-20 bg-white p-24 shadow-[0_0.2rem_1.2rem_rgba(0,0,0,0.06)]">
       <div className="flex flex-col gap-4">
-        <p className="text-body3 font-semibold text-gray-900">{heading}</p>
-        <p className="text-body2 text-gray-900">{body}</p>
+        <p className="text-body3 font-semibold text-gray-900">{result.title}</p>
+        <p className="text-body2 text-gray-900">{result.insight}</p>
       </div>
 
-      {criteriaItems.length > 0 && (
+      {result.criteriaItems.length > 0 && (
         <div className="flex flex-col gap-4 text-body2 text-gray-900">
-          {criteriaItems.map(([label, value]) => (
+          {result.criteriaItems.map(({ label, value }) => (
             <p key={label}>
               <span className="font-semibold">{label}:</span> {value}
             </p>
@@ -266,9 +110,9 @@ export default function VerificationResult({
       )}
 
       <div className="rounded-12 border-2 border-gray-300 bg-white p-16">
-        {tabs.length > 1 && (
+        {chart.type === 'bar' && chart.tabs.length > 1 && (
           <div className="mb-16 flex gap-24">
-            {tabs.map((key) => {
+            {chart.tabs.map((key) => {
               const active = tab === key;
 
               return (
@@ -298,9 +142,13 @@ export default function VerificationResult({
           </p>
         )}
 
-        {rows.length === 0 || seriesKeys.length === 0 ? (
+        {chart.type === 'empty' ||
+        rows.length === 0 ||
+        seriesKeys.length === 0 ? (
           <div className="flex h-[28rem] items-center justify-center text-body2 text-gray-600">
-            표시할 차트 데이터가 없습니다.
+            {chart.type === 'empty'
+              ? chart.message
+              : '표시할 차트 데이터가 없습니다.'}
           </div>
         ) : (
           <div className="h-[28rem] w-full">
@@ -311,7 +159,7 @@ export default function VerificationResult({
               >
                 <CartesianGrid stroke="#ECECEC" vertical={false} />
                 <XAxis
-                  dataKey="name"
+                  dataKey={chart.xKey}
                   axisLine={false}
                   tickLine={false}
                   tick={{ fontSize: 12, fill: '#999999' }}
@@ -357,15 +205,17 @@ export default function VerificationResult({
         )}
       </div>
 
-      {warnings.length > 0 && (
+      {result.warnings.length > 0 && (
         <div className="flex flex-col gap-8">
           <div className="inline-flex items-center gap-4 text-body2 font-semibold text-orange-500">
             <AlertIcon aria-hidden className="icon-16 text-orange-500" />
             <span>데이터 경고</span>
           </div>
           <ul className="ml-20 flex list-disc flex-col gap-8 text-body2 text-gray-900">
-            {warnings.map((w, i) => (
-              <li key={i}>{w}</li>
+            {result.warnings.map((warning) => (
+              <li key={`${warning.code}-${warning.message}`}>
+                {warning.message}
+              </li>
             ))}
           </ul>
         </div>

--- a/apps/fe/src/app/(main)/analysis/[id]/_fixtures/analysis.fixtures.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_fixtures/analysis.fixtures.ts
@@ -1,0 +1,149 @@
+import type {
+  AnalysisStatusResponse,
+  GetQuestionCriteriaResponse,
+  GetQuestionResultResponse,
+  GetSummaryResponse,
+  ResultChartDataInfo,
+} from '@/apis/analysis';
+
+export const normalSummaryResponse = {
+  rowCount: 128,
+  columnCount: 6,
+  dataCriteria: ['signup_date'],
+  measure: ['conversion_rate'],
+  dimension: ['channel', 'device'],
+  statusCondition: ['paid'],
+  flag: ['is_internal'],
+  idCriteria: ['user_id'],
+  sourceDataWarning: null,
+  createdAt: '2026-05-26T00:00:00',
+} satisfies GetSummaryResponse;
+
+export const summaryTextNullResponse = {
+  rowCount: 0,
+  columnCount: 0,
+  dataCriteria: null,
+  measure: null,
+  dimension: [],
+  statusCondition: [],
+  flag: [],
+  idCriteria: [],
+  sourceDataWarning: null,
+  createdAt: '2026-05-26T00:00:00',
+} as unknown as GetSummaryResponse;
+
+export const normalCriteriaResponse = {
+  messageId: 11,
+  question: '지난주 대비 전환율이 낮은 채널을 알려줘',
+  message: '분석 기준을 확인해 주세요.',
+  criteria: {
+    analysisType: 'COMPARISON',
+    metricName: 'conversion_rate',
+    baseDateColumn: 'signup_date',
+    standardPeriod: '이번 주',
+    comparePeriod: '지난 주',
+    groupBy: ['channel', 'device'],
+    sortBy: 'conversion_rate_delta',
+    sortDirection: 'asc',
+    limitNum: null,
+    filters: [{ field: 'is_internal', operator: '!=', value: true }],
+    dataWarning: [],
+    needConfirm: [],
+  },
+  createdAt: '2026-05-26T00:00:00',
+} satisfies GetQuestionCriteriaResponse;
+
+export const partialNullCriteriaResponse = {
+  ...normalCriteriaResponse,
+  criteria: {
+    ...normalCriteriaResponse.criteria,
+    metricName: null,
+    baseDateColumn: null,
+    groupBy: null,
+    sortDirection: null,
+  },
+} satisfies GetQuestionCriteriaResponse;
+
+export const warningCodeOnlyCriteriaResponse = {
+  ...normalCriteriaResponse,
+  criteria: {
+    ...normalCriteriaResponse.criteria,
+    dataWarning: [{ order: 1, content: 'QUESTION_DATA_MISMATCH' }],
+    needConfirm: [],
+  },
+} satisfies GetQuestionCriteriaResponse;
+
+export const unknownWarningCodeCriteriaResponse = {
+  ...normalCriteriaResponse,
+  criteria: {
+    ...normalCriteriaResponse.criteria,
+    dataWarning: [{ order: 1, content: 'UNEXPECTED_WARNING_CODE' }],
+    needConfirm: [],
+  },
+} satisfies GetQuestionCriteriaResponse;
+
+export const normalResultResponse = {
+  resultId: 21,
+  summaryMessage: '검증이 완료되었어요.',
+  description: 'iOS 채널의 전환율이 지난주 대비 낮게 나타났어요.',
+  criteria: normalCriteriaResponse.criteria,
+  chartData: {
+    tabs: ['채널'],
+    defaultTab: '채널',
+    tabResults: [
+      {
+        tabName: '채널',
+        chart: {
+          unit: '%',
+          labels: ['iOS', 'Android'],
+          series: [{ name: '전환율', values: [12, 18] }],
+        },
+      },
+    ],
+    exportEnabled: true,
+  },
+} satisfies GetQuestionResultResponse;
+
+export const emptyChartResultResponse = {
+  ...normalResultResponse,
+  chartData: {
+    tabs: [],
+    defaultTab: null,
+    tabResults: [],
+    exportEnabled: false,
+  },
+} satisfies GetQuestionResultResponse;
+
+export const rowsNullResultResponse = {
+  ...normalResultResponse,
+  chartData: {
+    columns: ['channel', 'conversion_rate'],
+    rows: null,
+  } as unknown as ResultChartDataInfo,
+} satisfies GetQuestionResultResponse;
+
+export const failedStatusResponse = {
+  status: 'FAILED',
+} satisfies AnalysisStatusResponse;
+
+export const canceledStatusResponse = {
+  status: 'CANCELED',
+} satisfies AnalysisStatusResponse;
+
+export const llmOutputInvalidError = {
+  name: 'ApiResponseError',
+  response: {
+    success: false,
+    code: 'LLM_OUTPUT_INVALID',
+    message: null,
+  },
+};
+
+export const llmCallFailedError = {
+  name: 'ApiResponseError',
+  response: {
+    success: false,
+    code: 'LLM_CALL_FAILED',
+    message: null,
+  },
+};

--- a/apps/fe/src/app/(main)/analysis/[id]/_hooks/useAnalysisChat.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_hooks/useAnalysisChat.ts
@@ -4,12 +4,6 @@ import { useCallback, useEffect, useReducer, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useSearchParams } from 'next/navigation';
 import {
-  type GetQuestionCriteriaResponse,
-  type GetQuestionResultResponse,
-  type GetSummaryResponse,
-  type UpdateQuestionCriteriaRequest,
-} from '@/apis/analysis';
-import {
   dataSourceKeys,
   getDataSource,
   type FilePreview,
@@ -23,8 +17,13 @@ import {
   type AnalysisStartPayload,
 } from '@/lib/analysisStartPayload';
 import type { PromptInputValue } from '../../_components/PromptInput';
-import type { ColumnCandidate } from '../_components/AnalysisResult';
+import { createUpdateCriteriaRequest } from '../_adapters/normalizeCriteria';
 import type { DataTableColumn } from '../_components/DataTablePreview';
+import type {
+  CriteriaEditValues,
+  CriteriaViewModel,
+  QuestionResultViewModel,
+} from '../_models/analysisViewModels';
 import {
   analysisChatFlowReducer,
   initialAnalysisChatFlowState,
@@ -46,14 +45,14 @@ export type ChatMessage =
       id: string;
       role: 'bot';
       kind: 'criteria';
-      criteria: GetQuestionCriteriaResponse;
+      criteria: CriteriaViewModel;
       initialMode?: CriteriaInitialMode;
     }
   | {
       id: string;
       role: 'bot';
       kind: 'verification';
-      result: GetQuestionResultResponse;
+      result: QuestionResultViewModel;
     }
   | {
       id: string;
@@ -63,7 +62,7 @@ export type ChatMessage =
       tone?: 'default' | 'error';
     };
 
-const DEFAULT_PROMPT = 'CSV 파일을 분석해주세요';
+const DEFAULT_PROMPT = 'CSV 파일을 분석해 주세요';
 const STATUS_POLL_INTERVAL_MS = 1500;
 const QUESTION_ANALYSIS_TIMEOUT_MS = 120000;
 const RESULT_ANALYSIS_TIMEOUT_MS = 120000;
@@ -80,11 +79,6 @@ const UPDATE_CRITERIA_ERROR_MESSAGE =
 const GET_RESULT_ERROR_MESSAGE =
   '최종 분석 결과를 불러오지 못했어요. 잠시 후 다시 시도해 주세요.';
 
-const SUMMARY_WARNING_MESSAGE_MAP: Record<string, string> = {
-  date_field_conflict:
-    '날짜 기준을 하나로 정할 수 없어요. 어떤 날짜를 기준으로 볼지 선택해 주세요.',
-};
-
 function parsePositiveNumber(value: string | null | undefined) {
   if (!value) return null;
 
@@ -98,7 +92,7 @@ function compactStrings(values: Array<string | null | undefined>) {
     .filter((value): value is string => Boolean(value));
 }
 
-export function uniqueStrings(values: Array<string | null | undefined>) {
+function uniqueStrings(values: Array<string | null | undefined>) {
   return Array.from(new Set(compactStrings(values)));
 }
 
@@ -117,49 +111,6 @@ function createPreviewTable(preview?: FilePreview | null) {
   );
 
   return { columns, rows };
-}
-
-export function createSummaryCandidates(summary: GetSummaryResponse) {
-  const groups = [
-    { name: '데이터 기준', values: summary.dataCriteria },
-    { name: '지표', values: summary.measure },
-    { name: '차원', values: summary.dimension },
-    { name: '상태 조건', values: summary.statusCondition },
-    { name: '플래그', values: summary.flag },
-    { name: '식별 기준', values: summary.idCriteria },
-  ];
-
-  return groups.flatMap<ColumnCandidate>((group) =>
-    group.values.map((value) => ({
-      name: group.name,
-      example: value,
-    })),
-  );
-}
-
-function mapSummaryWarning(value: string) {
-  const normalized = value.trim();
-  return SUMMARY_WARNING_MESSAGE_MAP[normalized] ?? normalized;
-}
-
-export function createSummaryWarnings(summary?: GetSummaryResponse) {
-  const warning = summary?.sourceDataWarning?.trim();
-  if (!warning) return [];
-
-  return warning.split('\n').map(mapSummaryWarning).filter(Boolean);
-}
-
-function getSummaryColumnOptions(summary?: GetSummaryResponse) {
-  if (!summary) return [];
-
-  return uniqueStrings([
-    ...summary.dataCriteria,
-    ...summary.measure,
-    ...summary.dimension,
-    ...summary.statusCondition,
-    ...summary.flag,
-    ...summary.idCriteria,
-  ]);
 }
 
 function createMessageId(prefix: string) {
@@ -378,7 +329,7 @@ export function useAnalysisChat(routeConversationId: string) {
 
   function handleConfirmCriteria(
     messageId: number,
-    request: UpdateQuestionCriteriaRequest,
+    values: CriteriaEditValues,
   ) {
     if (criteriaSubmissionLocked) return;
 
@@ -394,11 +345,11 @@ export function useAnalysisChat(routeConversationId: string) {
         targetConversationId: conversationId,
         targetAnalysisFlowId: analysisFlowId,
         messageId,
-        request,
+        request: createUpdateCriteriaRequest(values),
       },
       {
         onSuccess: ({ analysisCriteriaId }) => {
-          appendNotice('분석 기준을 확정했어요.');
+          appendNotice('분석 기준이 확정되었어요.');
           resultAnalysisMutation.mutate(
             {
               targetConversationId: conversationId,
@@ -412,7 +363,10 @@ export function useAnalysisChat(routeConversationId: string) {
                 setMessages((prev) => [
                   ...prev,
                   {
-                    id: `result-${result.resultId}`,
+                    id:
+                      result.resultId === null
+                        ? createMessageId('result')
+                        : `result-${result.resultId}`,
                     role: 'bot',
                     kind: 'verification',
                     result,
@@ -513,7 +467,7 @@ export function useAnalysisChat(routeConversationId: string) {
     ) {
       return;
     }
-    if (createSummaryWarnings(summaryQuery.data).length > 0) return;
+    if (summaryQuery.data.warnings.length > 0) return;
 
     const timer = window.setTimeout(() => {
       startInitialQuestion();
@@ -528,7 +482,11 @@ export function useAnalysisChat(routeConversationId: string) {
     summaryQuery.data,
   ]);
 
-  const summaryColumnOptions = getSummaryColumnOptions(summary);
+  const summaryColumnOptions = summary?.columnOptions ?? [];
+  const summarySortOptions = uniqueStrings([
+    ...(summary?.measureOptions ?? []),
+    ...summaryColumnOptions,
+  ]);
   const shouldShowAnalyzing =
     summaryPending ||
     isQuestionAnalysisPending ||
@@ -546,7 +504,7 @@ export function useAnalysisChat(routeConversationId: string) {
     isQuestionAnalysisPending ||
     updateCriteriaMutation.isPending ||
     resultAnalysisMutation.isPending;
-  const summaryWarnings = createSummaryWarnings(summary);
+  const summaryWarnings = summary?.warnings ?? [];
   const summaryActionDisabled =
     hasStartedInitialQuestion ||
     !hasResolvedStartPayload ||
@@ -575,6 +533,7 @@ export function useAnalysisChat(routeConversationId: string) {
     summaryActionDisabled,
     summaryColumnOptions,
     summaryErrorMessage,
+    summarySortOptions,
     summaryWarnings,
     toast,
   };

--- a/apps/fe/src/app/(main)/analysis/[id]/_hooks/useCriteriaPhase.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_hooks/useCriteriaPhase.ts
@@ -10,6 +10,7 @@ import {
   type UpdateQuestionCriteriaRequest,
 } from '@/apis/analysis';
 import type { CriteriaInitialMode } from './useAnalysisChat';
+import { normalizeCriteria } from '../_adapters/normalizeCriteria';
 import { useJobPoller } from './useJobPoller';
 
 export type QuestionAnalysisVariables = {
@@ -66,7 +67,7 @@ export function useCriteriaPhase({
       };
 
       await waitForCriteriaSuccess(criteriaParams);
-      return getCriteria(criteriaParams);
+      return normalizeCriteria(await getCriteria(criteriaParams));
     },
   });
 

--- a/apps/fe/src/app/(main)/analysis/[id]/_hooks/useJobPoller.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_hooks/useJobPoller.ts
@@ -5,6 +5,11 @@ import type {
   AnalysisJobStatus,
   AnalysisStatusResponse,
 } from '@/apis/analysis';
+import {
+  isFailedAnalysisStatus,
+  normalizeAnalysisStatusError,
+  shouldPollAnalysisStatus,
+} from '../_adapters/normalizeAnalysisError';
 
 type FetchStatus<TParams> = (
   params: TParams,
@@ -21,16 +26,11 @@ function wait(ms: number) {
 }
 
 export function shouldPollJobStatus(status?: AnalysisJobStatus) {
-  return (
-    !status ||
-    status === 'QUEUED' ||
-    status === 'RUNNING' ||
-    status === 'RETRYING'
-  );
+  return shouldPollAnalysisStatus(status);
 }
 
 export function isFailedJobStatus(status?: AnalysisJobStatus) {
-  return status === 'FAILED' || status === 'CANCELED' || status === 'CANCELLED';
+  return isFailedAnalysisStatus(status);
 }
 
 export function useJobPoller<TParams>(
@@ -46,7 +46,10 @@ export function useJobPoller<TParams>(
 
         if (status === 'SUCCESS') return;
         if (isFailedJobStatus(status)) {
-          throw new Error(errorMessage);
+          throw new Error(
+            normalizeAnalysisStatusError(status, errorMessage)?.message ??
+              errorMessage,
+          );
         }
 
         await wait(intervalMs);

--- a/apps/fe/src/app/(main)/analysis/[id]/_hooks/useResultPhase.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_hooks/useResultPhase.ts
@@ -6,6 +6,7 @@ import {
   getResultStatus,
   type QuestionResultParams,
 } from '@/apis/analysis';
+import { normalizeResult } from '../_adapters/normalizeResult';
 import { useJobPoller } from './useJobPoller';
 
 export type ResultAnalysisVariables = {
@@ -50,7 +51,7 @@ export function useResultPhase({
       };
 
       await waitForResultSuccess(resultParams);
-      return getResult(resultParams);
+      return normalizeResult(await getResult(resultParams));
     },
   });
 }

--- a/apps/fe/src/app/(main)/analysis/[id]/_hooks/useSummaryPhase.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_hooks/useSummaryPhase.ts
@@ -6,7 +6,11 @@ import {
   getSummary,
   getSummaryStatus,
 } from '@/apis/analysis';
-import { getApiErrorMessage } from '@/apis/errors';
+import {
+  normalizeAnalysisError,
+  normalizeAnalysisStatusError,
+} from '../_adapters/normalizeAnalysisError';
+import { normalizeSummary } from '../_adapters/normalizeSummary';
 import { isFailedJobStatus, shouldPollJobStatus } from './useJobPoller';
 
 type UseSummaryPhaseParams = {
@@ -64,27 +68,31 @@ export function useSummaryPhase({
       return getSummary({ conversationId, analysisFlowId });
     },
     enabled: routeReady && summaryStatus === 'SUCCESS',
+    select: normalizeSummary,
   });
 
   const summary = summaryQuery.data;
+  const summaryError = !routeReady
+    ? normalizeAnalysisError(
+        new Error(invalidRouteMessage),
+        invalidRouteMessage,
+      )
+    : summaryStatusQuery.isError
+      ? normalizeAnalysisError(summaryStatusQuery.error, getSummaryErrorMessage)
+      : summaryQuery.isError
+        ? normalizeAnalysisError(summaryQuery.error, getSummaryErrorMessage)
+        : normalizeAnalysisStatusError(summaryStatus, failedSummaryMessage);
   const summaryPending =
     routeReady &&
     !summaryStatusQuery.isError &&
     !summaryQuery.isError &&
     !summary &&
     !isFailedJobStatus(summaryStatus);
-  const summaryErrorMessage = !routeReady
-    ? invalidRouteMessage
-    : summaryStatusQuery.isError
-      ? getApiErrorMessage(summaryStatusQuery.error, getSummaryErrorMessage)
-      : summaryQuery.isError
-        ? getApiErrorMessage(summaryQuery.error, getSummaryErrorMessage)
-        : isFailedJobStatus(summaryStatus)
-          ? failedSummaryMessage
-          : null;
+  const summaryErrorMessage = summaryError?.message ?? null;
 
   return {
     summary,
+    summaryError,
     summaryErrorMessage,
     summaryPending,
     summaryQuery,

--- a/apps/fe/src/app/(main)/analysis/[id]/_models/analysisErrorTypes.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_models/analysisErrorTypes.ts
@@ -1,0 +1,14 @@
+export type AnalysisUiStatus =
+  | 'idle'
+  | 'submitting'
+  | 'polling'
+  | 'success'
+  | 'failed'
+  | 'canceled';
+
+export type UserFacingAnalysisError = {
+  code: string;
+  title: string;
+  message: string;
+  retryable: boolean;
+};

--- a/apps/fe/src/app/(main)/analysis/[id]/_models/analysisViewModels.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_models/analysisViewModels.ts
@@ -1,0 +1,131 @@
+import type {
+  UserFacingAnalysisError,
+  AnalysisUiStatus,
+} from './analysisErrorTypes';
+import type { AnalysisWarningViewModel } from './analysisWarningTypes';
+
+export type SummaryKeyPointViewModel = {
+  name: string;
+  example: string;
+};
+
+export type SummaryViewModel = {
+  title: string;
+  summaryText: string;
+  keyPoints: SummaryKeyPointViewModel[];
+  warnings: AnalysisWarningViewModel[];
+  emptyMessage: string | null;
+  rowCount: number;
+  columnCount: number;
+  columnOptions: string[];
+  dateFieldOptions: string[];
+  measureOptions: string[];
+};
+
+export type AnalysisFieldViewModel = {
+  value: string | null;
+  label: string;
+  missing: boolean;
+};
+
+export type AnalysisFilterViewModel = {
+  field: string | null;
+  operator: string | null;
+  value: unknown;
+  label: string;
+};
+
+export type CriteriaPeriodViewModel = {
+  standard: string | null;
+  compare: string | null;
+  label: string;
+};
+
+export type CriteriaSortViewModel = {
+  by: string | null;
+  direction: string | null;
+  label: string;
+};
+
+export type CriteriaViewModel = {
+  messageId: number;
+  question: string;
+  message: string | null;
+  analysisType: AnalysisFieldViewModel;
+  metric: AnalysisFieldViewModel;
+  dateField: AnalysisFieldViewModel;
+  period: CriteriaPeriodViewModel;
+  groupBy: string[];
+  sort: CriteriaSortViewModel;
+  limitNum: number | null;
+  filters: AnalysisFilterViewModel[];
+  missingFields: string[];
+  warnings: AnalysisWarningViewModel[];
+  createdAt: string;
+};
+
+export type CriteriaEditValues = {
+  baseDateColumn: string;
+  standardPeriod: string;
+  comparePeriod: string;
+  groupBy: string[];
+  sortBy: string;
+  sortDirection: string;
+  limitNum: number | null;
+  filters: AnalysisFilterViewModel[];
+};
+
+export type ChartSeriesViewModel = {
+  key: string;
+  name: string;
+};
+
+export type ChartRowViewModel = {
+  name: string;
+} & Record<string, number | string>;
+
+export type ChartTabViewModel = {
+  name: string;
+  data: ChartRowViewModel[];
+  yKeys: ChartSeriesViewModel[];
+  unit: string;
+};
+
+export type BarChartViewModel = {
+  type: 'bar';
+  tabs: string[];
+  defaultTab: string;
+  data: ChartRowViewModel[];
+  xKey: 'name';
+  yKeys: ChartSeriesViewModel[];
+  unit: string;
+  tabResults: ChartTabViewModel[];
+  exportEnabled: boolean;
+};
+
+export type EmptyChartViewModel = {
+  type: 'empty';
+  reason: 'missing' | 'empty' | 'invalid';
+  message: string;
+};
+
+export type ChartViewModel = BarChartViewModel | EmptyChartViewModel;
+
+export type ResultCriteriaItemViewModel = {
+  label: string;
+  value: string;
+};
+
+export type QuestionResultViewModel = {
+  status: AnalysisUiStatus;
+  resultId: number | null;
+  title: string;
+  insight: string;
+  tableRows: ChartRowViewModel[];
+  chart: ChartViewModel;
+  criteriaItems: ResultCriteriaItemViewModel[];
+  warnings: AnalysisWarningViewModel[];
+  canRetry: boolean;
+  emptyMessage: string | null;
+  error: UserFacingAnalysisError | null;
+};

--- a/apps/fe/src/app/(main)/analysis/[id]/_models/analysisWarningTypes.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_models/analysisWarningTypes.ts
@@ -1,0 +1,9 @@
+export type AnalysisWarningSource = 'summary' | 'criteria' | 'result' | 'error';
+
+export type AnalysisWarningViewModel = {
+  code: string;
+  message: string;
+  relatedFields: string[];
+  source: AnalysisWarningSource;
+  isKnown: boolean;
+};

--- a/apps/fe/src/app/(main)/analysis/[id]/_tests/normalizeAnalysisError.test.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_tests/normalizeAnalysisError.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import {
+  canceledStatusResponse,
+  failedStatusResponse,
+  llmCallFailedError,
+  llmOutputInvalidError,
+} from '../_fixtures/analysis.fixtures';
+import {
+  normalizeAnalysisError,
+  normalizeAnalysisStatus,
+  normalizeAnalysisStatusError,
+} from '../_adapters/normalizeAnalysisError';
+
+describe('normalizeAnalysisError', () => {
+  it('normalizes LLM_OUTPUT_INVALID errors', () => {
+    const error = normalizeAnalysisError(llmOutputInvalidError);
+
+    expect(error).toMatchObject({
+      code: 'LLM_OUTPUT_INVALID',
+      retryable: false,
+    });
+  });
+
+  it('normalizes LLM_CALL_FAILED errors', () => {
+    const error = normalizeAnalysisError(llmCallFailedError);
+
+    expect(error).toMatchObject({
+      code: 'LLM_CALL_FAILED',
+      retryable: true,
+    });
+  });
+
+  it('normalizes FAILED statuses to retryable user-facing errors', () => {
+    const error = normalizeAnalysisStatusError(
+      failedStatusResponse.status,
+      '분석에 실패했습니다.',
+    );
+
+    expect(normalizeAnalysisStatus(failedStatusResponse.status)).toBe('failed');
+    expect(error).toMatchObject({
+      code: 'FAILED',
+      retryable: true,
+    });
+  });
+
+  it('normalizes CANCELED statuses to non-retryable canceled errors', () => {
+    const error = normalizeAnalysisStatusError(
+      canceledStatusResponse.status,
+      '분석이 취소되었습니다.',
+    );
+
+    expect(normalizeAnalysisStatus(canceledStatusResponse.status)).toBe(
+      'canceled',
+    );
+    expect(error).toMatchObject({
+      code: 'CANCELED',
+      retryable: false,
+    });
+  });
+
+  it('treats unexpected status strings as failed status', () => {
+    expect(normalizeAnalysisStatus('SOMETHING_NEW')).toBe('failed');
+  });
+});

--- a/apps/fe/src/app/(main)/analysis/[id]/_tests/normalizeAnalysisError.test.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_tests/normalizeAnalysisError.test.ts
@@ -58,6 +58,19 @@ describe('normalizeAnalysisError', () => {
     });
   });
 
+  it('normalizes CANCELLED alias statuses to non-retryable canceled errors', () => {
+    const error = normalizeAnalysisStatusError(
+      'CANCELLED',
+      '분석이 취소되었습니다.',
+    );
+
+    expect(normalizeAnalysisStatus('CANCELLED')).toBe('canceled');
+    expect(error).toMatchObject({
+      code: 'CANCELED',
+      retryable: false,
+    });
+  });
+
   it('treats unexpected status strings as failed status', () => {
     expect(normalizeAnalysisStatus('SOMETHING_NEW')).toBe('failed');
   });

--- a/apps/fe/src/app/(main)/analysis/[id]/_tests/normalizeCriteria.test.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_tests/normalizeCriteria.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import {
+  normalCriteriaResponse,
+  partialNullCriteriaResponse,
+  unknownWarningCodeCriteriaResponse,
+  warningCodeOnlyCriteriaResponse,
+} from '../_fixtures/analysis.fixtures';
+import {
+  createCriteriaEditValues,
+  createUpdateCriteriaRequest,
+  normalizeCriteria,
+} from '../_adapters/normalizeCriteria';
+
+describe('normalizeCriteria', () => {
+  it('creates a criteria view model from a normal response', () => {
+    const criteria = normalizeCriteria(normalCriteriaResponse);
+
+    expect(criteria.messageId).toBe(11);
+    expect(criteria.analysisType.label).toBe('비교 분석');
+    expect(criteria.metric.value).toBe('conversion_rate');
+    expect(criteria.groupBy).toEqual(['channel', 'device']);
+    expect(criteria.missingFields).toEqual([]);
+  });
+
+  it('surfaces missing fields instead of hiding them as empty strings', () => {
+    const criteria = normalizeCriteria(partialNullCriteriaResponse);
+
+    expect(criteria.metric.missing).toBe(true);
+    expect(criteria.dateField.missing).toBe(true);
+    expect(criteria.missingFields).toEqual(
+      expect.arrayContaining(['지표', '날짜 기준', '비교 기준', '정렬 순서']),
+    );
+    expect(
+      criteria.warnings.some(
+        (warning) => warning.code === 'MISSING_ANALYSIS_FIELDS',
+      ),
+    ).toBe(true);
+  });
+
+  it('maps warning-code-only criteria responses to user-facing warnings', () => {
+    const criteria = normalizeCriteria(warningCodeOnlyCriteriaResponse);
+
+    expect(criteria.warnings[0]).toMatchObject({
+      code: 'QUESTION_DATA_MISMATCH',
+      isKnown: true,
+    });
+  });
+
+  it('keeps unknown warning codes visible', () => {
+    const criteria = normalizeCriteria(unknownWarningCodeCriteriaResponse);
+
+    expect(criteria.warnings[0]).toMatchObject({
+      code: 'UNEXPECTED_WARNING_CODE',
+      isKnown: false,
+    });
+  });
+
+  it('converts edit values back to the existing update request contract', () => {
+    const criteria = normalizeCriteria(normalCriteriaResponse);
+    const request = createUpdateCriteriaRequest(
+      createCriteriaEditValues(criteria),
+    );
+
+    expect(request).toMatchObject({
+      baseDateColumn: 'signup_date',
+      standardPeriod: '이번 주',
+      comparePeriod: '지난 주',
+      groupBy: ['channel', 'device'],
+      confirmed: true,
+    });
+  });
+});

--- a/apps/fe/src/app/(main)/analysis/[id]/_tests/normalizeCriteria.test.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_tests/normalizeCriteria.test.ts
@@ -66,6 +66,7 @@ describe('normalizeCriteria', () => {
       standardPeriod: '이번 주',
       comparePeriod: '지난 주',
       groupBy: ['channel', 'device'],
+      sortDirection: 'ASC',
       confirmed: true,
     });
   });

--- a/apps/fe/src/app/(main)/analysis/[id]/_tests/normalizeResult.test.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_tests/normalizeResult.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import {
+  emptyChartResultResponse,
+  normalResultResponse,
+  rowsNullResultResponse,
+} from '../_fixtures/analysis.fixtures';
+import { normalizeChartData } from '../_adapters/normalizeChartData';
+import { normalizeResult } from '../_adapters/normalizeResult';
+
+describe('normalizeResult', () => {
+  it('creates a result view model with bar chart data', () => {
+    const result = normalizeResult(normalResultResponse);
+
+    expect(result.status).toBe('success');
+    expect(result.chart.type).toBe('bar');
+    expect(result.tableRows).toEqual([
+      { name: 'iOS', 'series-0': 12 },
+      { name: 'Android', 'series-0': 18 },
+    ]);
+    expect(result.criteriaItems).toContainEqual({
+      label: '지표',
+      value: 'conversion_rate',
+    });
+  });
+
+  it('normalizes empty chartData to an empty chart model', () => {
+    const result = normalizeResult(emptyChartResultResponse);
+
+    expect(result.chart).toMatchObject({
+      type: 'empty',
+      reason: 'empty',
+    });
+    expect(result.emptyMessage).toBe('표시할 차트 데이터가 비어 있습니다.');
+  });
+
+  it('normalizes legacy rows:null chartData to an empty chart model', () => {
+    const result = normalizeResult(rowsNullResultResponse);
+
+    expect(result.chart).toMatchObject({
+      type: 'empty',
+      reason: 'empty',
+    });
+  });
+
+  it('normalizes null result objects to failed result view models', () => {
+    const result = normalizeResult(null);
+
+    expect(result.status).toBe('failed');
+    expect(result.canRetry).toBe(true);
+    expect(result.chart.type).toBe('empty');
+  });
+});
+
+describe('normalizeChartData', () => {
+  it('treats invalid chart shapes as empty invalid charts', () => {
+    const chart = normalizeChartData({
+      tabResults: [{ chart: { labels: null } }],
+    });
+
+    expect(chart).toMatchObject({
+      type: 'empty',
+      reason: 'invalid',
+    });
+  });
+});

--- a/apps/fe/src/app/(main)/analysis/[id]/_tests/normalizeSummary.test.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_tests/normalizeSummary.test.ts
@@ -5,6 +5,8 @@ import {
 } from '../_fixtures/analysis.fixtures';
 import { normalizeSummary } from '../_adapters/normalizeSummary';
 
+const EMPTY_SUMMARY_MESSAGE = '요약할 데이터 정보를 찾지 못했습니다.';
+
 describe('normalizeSummary', () => {
   it('creates a safe summary view model from a normal response', () => {
     const summary = normalizeSummary(normalSummaryResponse);
@@ -27,6 +29,24 @@ describe('normalizeSummary', () => {
     expect(summary.rowCount).toBe(0);
     expect(summary.columnOptions).toEqual([]);
     expect(summary.keyPoints).toEqual([]);
-    expect(summary.emptyMessage).toBe('요약할 데이터 정보를 찾지 못했습니다.');
+    expect(summary.emptyMessage).toBe(EMPTY_SUMMARY_MESSAGE);
+  });
+
+  it('keeps null summary responses renderable', () => {
+    const summary = normalizeSummary(null);
+
+    expect(summary.rowCount).toBe(0);
+    expect(summary.columnOptions).toEqual([]);
+    expect(summary.keyPoints).toEqual([]);
+    expect(summary.emptyMessage).toBe(EMPTY_SUMMARY_MESSAGE);
+  });
+
+  it('keeps undefined summary responses renderable', () => {
+    const summary = normalizeSummary(undefined);
+
+    expect(summary.rowCount).toBe(0);
+    expect(summary.columnOptions).toEqual([]);
+    expect(summary.keyPoints).toEqual([]);
+    expect(summary.emptyMessage).toBe(EMPTY_SUMMARY_MESSAGE);
   });
 });

--- a/apps/fe/src/app/(main)/analysis/[id]/_tests/normalizeSummary.test.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_tests/normalizeSummary.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import {
+  normalSummaryResponse,
+  summaryTextNullResponse,
+} from '../_fixtures/analysis.fixtures';
+import { normalizeSummary } from '../_adapters/normalizeSummary';
+
+describe('normalizeSummary', () => {
+  it('creates a safe summary view model from a normal response', () => {
+    const summary = normalizeSummary(normalSummaryResponse);
+
+    expect(summary.rowCount).toBe(128);
+    expect(summary.columnCount).toBe(6);
+    expect(summary.keyPoints).toEqual(
+      expect.arrayContaining([
+        { name: '데이터 기준', example: 'signup_date' },
+        { name: '지표', example: 'conversion_rate' },
+      ]),
+    );
+    expect(summary.columnOptions).toContain('channel');
+    expect(summary.emptyMessage).toBeNull();
+  });
+
+  it('keeps empty/null summary data renderable', () => {
+    const summary = normalizeSummary(summaryTextNullResponse);
+
+    expect(summary.rowCount).toBe(0);
+    expect(summary.columnOptions).toEqual([]);
+    expect(summary.keyPoints).toEqual([]);
+    expect(summary.emptyMessage).toBe('요약할 데이터 정보를 찾지 못했습니다.');
+  });
+});

--- a/apps/fe/src/app/(main)/analysis/[id]/page.tsx
+++ b/apps/fe/src/app/(main)/analysis/[id]/page.tsx
@@ -10,12 +10,7 @@ import LoadingDataPreview from './_components/LoadingDataPreview';
 import QuestionAnalysisResult from './_components/QuestionAnalysisResult';
 import ResizableSplit from './_components/ResizableSplit';
 import VerificationResult from './_components/VerificationResult';
-import {
-  createSummaryCandidates,
-  uniqueStrings,
-  useAnalysisChat,
-  type ChatMessage,
-} from './_hooks/useAnalysisChat';
+import { useAnalysisChat, type ChatMessage } from './_hooks/useAnalysisChat';
 
 type PageParams = { id: string };
 
@@ -37,10 +32,7 @@ export default function AnalysisChatPage({
       <div key="summary" className="flex w-full justify-start">
         <div className="w-full max-w-[80%]">
           <AnalysisResult
-            rowCount={chat.summary.rowCount}
-            columnCount={chat.summary.columnCount}
-            candidates={createSummaryCandidates(chat.summary)}
-            warnings={chat.summaryWarnings}
+            summary={chat.summary}
             warningActions={
               hasWarnings
                 ? {
@@ -111,18 +103,15 @@ export default function AnalysisChatPage({
       <div key={message.id} className="flex w-full justify-start">
         <div className="w-full max-w-[80%]">
           <QuestionAnalysisResult
-            criteria={message.criteria.criteria}
+            criteria={message.criteria}
             initialMode={message.initialMode}
             baseDateColumnOptions={
-              chat.summary?.dataCriteria.length
-                ? chat.summary.dataCriteria
+              chat.summary?.dateFieldOptions.length
+                ? chat.summary.dateFieldOptions
                 : chat.summaryColumnOptions
             }
             groupByOptions={chat.summaryColumnOptions}
-            sortByOptions={uniqueStrings([
-              ...(chat.summary?.measure ?? []),
-              ...chat.summaryColumnOptions,
-            ])}
+            sortByOptions={chat.summarySortOptions}
             isSubmitting={chat.criteriaSubmitting}
             onContinue={(values) =>
               chat.handleConfirmCriteria(message.criteria.messageId, values)

--- a/apps/fe/src/types/svg.d.ts
+++ b/apps/fe/src/types/svg.d.ts
@@ -11,6 +11,7 @@ declare module '*.svg' {
 }
 
 declare module '*.gif' {
-  const src: string;
+  import type { StaticImageData } from 'next/image';
+  const src: StaticImageData;
   export default src;
 }

--- a/apps/fe/src/types/svg.d.ts
+++ b/apps/fe/src/types/svg.d.ts
@@ -9,3 +9,8 @@ declare module '*.svg' {
   const ReactComponent: FunctionComponent<SVGProps<SVGSVGElement>>;
   export default ReactComponent;
 }
+
+declare module '*.gif' {
+  const src: string;
+  export default src;
+}


### PR DESCRIPTION
## 요약
- 분석 summary/criteria/result raw DTO를 화면용 ViewModel로 바꾸는 route-colocated adapter/normalizer scaffold를 추가했습니다.
- chartData null/empty/invalid, warning code, failed/canceled/LLM error를 한 곳에서 정규화하도록 분리했습니다.
- 분석 화면 hook/component가 raw 응답 대신 ViewModel 중심으로 렌더링하도록 연결했습니다.

## 변경 사항
- [x] 기능
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - npm run test
  - npm run lint
  - npx tsc --noEmit --pretty false
  - npm run typecheck: package.json에 스크립트가 없어 실행 불가

## 스크린샷/로그 (선택)
- UI 스타일 변경 없이 adapter 계층 추가 중심이라 생략합니다.

## 롤백/리스크
- 리스크 사인: 분석 화면의 summary/criteria/result 렌더링 경계가 ViewModel으로 바뀌었으므로 실제 BE 응답에서 누락 필드가 있을 때 fallback 문구가 노출될 수 있습니다.
- 롤백 방법: 이 PR 커밋을 revert하면 기존 raw DTO 렌더링 경로로 돌아갑니다.

## 관련 이슈
Closes #210

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 분석 오류 처리 및 상태 추적 개선으로 더 정확한 오류 메시지 표시
  * 작업 상태 폴링 로직 안정화

* **새로운 기능**
  * 분석 경고 및 오류 알림 시스템 강화
  * 차트 데이터 렌더링 안정성 향상
  * 분석 결과 요약 정보 표시 개선

* **개선 사항**
  * 사용자 인터페이스 데이터 구조 표준화로 일관성 향상

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/26-ewha-capstone-logue/logue/pull/212?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->