### PR TITLE
fix: CSV 업로드 필드 너비 보정

### DIFF
--- a/apps/fe/src/components/FileUploadZone/FileUploadZone.tsx
+++ b/apps/fe/src/components/FileUploadZone/FileUploadZone.tsx
@@ -242,7 +242,7 @@ export default function FileUploadZone({
           onDragOver={handleDragOver}
           onDragLeave={handleDragLeave}
           onDrop={handleDrop}
-          className={`flex h-[18.2rem] cursor-pointer flex-col items-center justify-center rounded-8 border-[1.5px] border-dashed transition-colors ${dropzoneBorderClass} ${
+          className={`flex h-[18.2rem] w-full cursor-pointer flex-col items-center justify-center rounded-8 border-[1.5px] border-dashed transition-colors ${dropzoneBorderClass} ${
             disabled ? 'cursor-not-allowed' : ''
           }`}
         >


### PR DESCRIPTION
﻿## 요약
- CSV 업로드 모달의 기본 드롭 영역이 모달 내부 가용 폭을 채우도록 수정했습니다.
- 드롭존 버튼에 `w-full`을 명시해 우측 빈 공간이 남는 레이아웃 문제를 보정했습니다.

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `npm run lint`
  - `git diff --check`
  - Storybook `Components/FileUploadModal` 스토리에서 드롭 영역이 모달 내부 폭을 채우는지 확인

## 스크린샷/로그 (선택)
- Storybook 확인 결과: 바깥 업로드 박스 648px, 드롭 영역 605px로 좌우 패딩을 제외한 폭을 정상 점유합니다.

## 롤백/리스크
- 리스크 사인: 기본 업로드 상태의 드롭존 폭만 변경되어 영향 범위가 낮습니다.
- 롤백 방법: `FileUploadZone` 기본 드롭존 버튼의 `w-full` 클래스를 제거합니다.

## 관련 이슈
Closes #216
