### PR TITLE
refactor: 분석 화면 렌더링 경계 정리

### DIFF
--- a/apps/fe/src/app/(main)/analysis/[id]/_adapters/normalizeChartData.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_adapters/normalizeChartData.ts
@@ -6,6 +6,7 @@ import type {
   ChartViewModel,
   EmptyChartViewModel,
 } from '../_models/analysisViewModels';
+import { uniqueStrings } from '../_utils/stringList';
 
 const EMPTY_CHART_MESSAGES: Record<EmptyChartViewModel['reason'], string> = {
   missing: '표시할 차트 데이터가 없습니다.',
@@ -42,12 +43,6 @@ function asNumberArray(value: unknown) {
           typeof item === 'number' && Number.isFinite(item),
       )
     : [];
-}
-
-function uniqueStrings(values: string[]) {
-  return Array.from(
-    new Set(values.map((value) => value.trim()).filter(Boolean)),
-  );
 }
 
 function getChartEmptyReason(value: unknown): EmptyChartViewModel['reason'] {

--- a/apps/fe/src/app/(main)/analysis/[id]/_adapters/normalizeSummary.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_adapters/normalizeSummary.ts
@@ -3,6 +3,7 @@ import type {
   SummaryKeyPointViewModel,
   SummaryViewModel,
 } from '../_models/analysisViewModels';
+import { compactStrings, uniqueStrings } from '../_utils/stringList';
 import { normalizeWarningLines } from './normalizeWarnings';
 
 const SUMMARY_GROUPS = [
@@ -13,18 +14,6 @@ const SUMMARY_GROUPS = [
   { name: '플래그', key: 'flag' },
   { name: '식별 기준', key: 'idCriteria' },
 ] as const;
-
-function compactStrings(values: unknown) {
-  return Array.isArray(values)
-    ? values
-        .map((value) => (typeof value === 'string' ? value.trim() : ''))
-        .filter(Boolean)
-    : [];
-}
-
-function uniqueStrings(values: string[]) {
-  return Array.from(new Set(values));
-}
 
 function asNonNegativeNumber(value: unknown) {
   return typeof value === 'number' && Number.isFinite(value) && value > 0

--- a/apps/fe/src/app/(main)/analysis/[id]/_adapters/normalizeWarnings.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_adapters/normalizeWarnings.ts
@@ -3,6 +3,7 @@ import type {
   AnalysisWarningSource,
   AnalysisWarningViewModel,
 } from '../_models/analysisWarningTypes';
+import { compactStrings, uniqueStrings } from '../_utils/stringList';
 
 const WARNING_MESSAGE_BY_CODE: Record<string, string> = {
   DATE_FIELD_CONFLICT:
@@ -16,16 +17,6 @@ const WARNING_MESSAGE_BY_CODE: Record<string, string> = {
 const LEGACY_WARNING_CODE_MAP: Record<string, string> = {
   date_field_conflict: 'DATE_FIELD_CONFLICT',
 };
-
-function compactStrings(values: Array<string | null | undefined>) {
-  return values
-    .map((value) => value?.trim())
-    .filter((value): value is string => Boolean(value));
-}
-
-function uniqueStrings(values: Array<string | null | undefined>) {
-  return Array.from(new Set(compactStrings(values)));
-}
 
 function looksLikeCode(value: string) {
   return /^[A-Z][A-Z0-9_]*$/.test(value);

--- a/apps/fe/src/app/(main)/analysis/[id]/_components/AnalysisChatMessageList.tsx
+++ b/apps/fe/src/app/(main)/analysis/[id]/_components/AnalysisChatMessageList.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { ChatBubble } from '@/components';
+import AnalysisResult from './AnalysisResult';
+import AnalyzingIndicator from './AnalyzingIndicator';
+import QuestionAnalysisResult from './QuestionAnalysisResult';
+import VerificationResult from './VerificationResult';
+import type {
+  ChatMessage,
+  UseAnalysisChatResult,
+} from '../_hooks/useAnalysisChat';
+
+type AnalysisChatMessageListProps = {
+  chat: Pick<
+    UseAnalysisChatResult,
+    | 'analyzingMessage'
+    | 'criteriaSubmitting'
+    | 'handleConfirmCriteria'
+    | 'initialMessage'
+    | 'restMessages'
+    | 'shouldShowAnalyzing'
+    | 'startInitialQuestion'
+    | 'summary'
+    | 'summaryActionDisabled'
+    | 'summaryColumnOptions'
+    | 'summaryErrorMessage'
+    | 'summarySortOptions'
+  >;
+};
+
+function MessageFrame({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex w-full justify-start">
+      <div className="w-full max-w-[80%]">{children}</div>
+    </div>
+  );
+}
+
+export default function AnalysisChatMessageList({
+  chat,
+}: AnalysisChatMessageListProps) {
+  const renderSummaryMessage = () => {
+    if (!chat.summary) return null;
+
+    const hasWarnings = chat.summary.warnings.length > 0;
+
+    return (
+      <MessageFrame key="summary">
+        <AnalysisResult
+          summary={chat.summary}
+          warningActions={
+            hasWarnings
+              ? {
+                  disabled: chat.summaryActionDisabled,
+                  onEdit: () => chat.startInitialQuestion('edit'),
+                  onContinue: () => chat.startInitialQuestion(),
+                }
+              : undefined
+          }
+        />
+      </MessageFrame>
+    );
+  };
+
+  const renderErrorMessage = () => {
+    if (!chat.summaryErrorMessage) return null;
+
+    return (
+      <ChatBubble key="summary-error" role="bot">
+        <p className="text-error-500">{chat.summaryErrorMessage}</p>
+      </ChatBubble>
+    );
+  };
+
+  const renderMessage = (message: ChatMessage) => {
+    if (message.role === 'user') {
+      return (
+        <ChatBubble
+          key={message.id}
+          role="user"
+          file={
+            message.fileName
+              ? { name: message.fileName, status: 'uploaded' }
+              : undefined
+          }
+        >
+          {message.content}
+        </ChatBubble>
+      );
+    }
+
+    if (message.kind === 'notice') {
+      return (
+        <ChatBubble key={message.id} role="bot">
+          <p
+            className={
+              message.tone === 'error' ? 'text-error-500' : 'text-gray-900'
+            }
+          >
+            {message.content}
+          </p>
+        </ChatBubble>
+      );
+    }
+
+    if (message.kind === 'verification') {
+      return (
+        <MessageFrame key={message.id}>
+          <VerificationResult result={message.result} />
+        </MessageFrame>
+      );
+    }
+
+    return (
+      <MessageFrame key={message.id}>
+        <QuestionAnalysisResult
+          criteria={message.criteria}
+          initialMode={message.initialMode}
+          baseDateColumnOptions={
+            chat.summary?.dateFieldOptions.length
+              ? chat.summary.dateFieldOptions
+              : chat.summaryColumnOptions
+          }
+          groupByOptions={chat.summaryColumnOptions}
+          sortByOptions={chat.summarySortOptions}
+          isSubmitting={chat.criteriaSubmitting}
+          onContinue={(values) =>
+            chat.handleConfirmCriteria(message.criteria.messageId, values)
+          }
+        />
+      </MessageFrame>
+    );
+  };
+
+  return (
+    <>
+      {chat.initialMessage ? renderMessage(chat.initialMessage) : null}
+      {renderSummaryMessage()}
+      {renderErrorMessage()}
+      {chat.restMessages.map(renderMessage)}
+      {chat.shouldShowAnalyzing && (
+        <MessageFrame>
+          <AnalyzingIndicator message={chat.analyzingMessage} />
+        </MessageFrame>
+      )}
+    </>
+  );
+}

--- a/apps/fe/src/app/(main)/analysis/[id]/_components/AnalysisResult.tsx
+++ b/apps/fe/src/app/(main)/analysis/[id]/_components/AnalysisResult.tsx
@@ -2,8 +2,8 @@
 
 import { useState } from 'react';
 import ArrowDownIcon from '@/assets/icons/arrow-down.svg';
-import AlertIcon from '@/assets/icons/alert.svg';
 import type { SummaryViewModel } from '../_models/analysisViewModels';
+import AnalysisWarningList from './AnalysisWarningList';
 
 export type AnalysisResultProps = {
   summary: SummaryViewModel;
@@ -99,17 +99,11 @@ export default function AnalysisResult({
 
       {hasWarnings && (
         <div className="flex flex-col gap-8">
-          <div className="inline-flex items-center gap-4 text-body4 text-orange-500">
-            <AlertIcon aria-hidden className="icon-16 text-orange-500" />
-            <span>데이터 경고</span>
-          </div>
-          <ul className="ml-20 list-disc text-body2 text-gray-900">
-            {summary.warnings.map((warning) => (
-              <li key={`${warning.code}-${warning.message}`}>
-                {warning.message}
-              </li>
-            ))}
-          </ul>
+          <AnalysisWarningList
+            warnings={summary.warnings}
+            titleClassName="text-body4"
+            listClassName="ml-20 list-disc text-body2 text-gray-900"
+          />
           {warningActions && (
             <div className="mt-8 flex justify-end gap-8">
               <button

--- a/apps/fe/src/app/(main)/analysis/[id]/_components/AnalysisWarningList.tsx
+++ b/apps/fe/src/app/(main)/analysis/[id]/_components/AnalysisWarningList.tsx
@@ -1,0 +1,34 @@
+import AlertIcon from '@/assets/icons/alert.svg';
+import type { AnalysisWarningViewModel } from '../_models/analysisWarningTypes';
+
+export type AnalysisWarningListProps = {
+  warnings: AnalysisWarningViewModel[];
+  titleClassName?: string;
+  listClassName?: string;
+};
+
+export default function AnalysisWarningList({
+  warnings,
+  titleClassName = 'text-body2 font-semibold',
+  listClassName = 'ml-20 flex list-disc flex-col gap-8 text-body2 text-gray-900',
+}: AnalysisWarningListProps) {
+  if (warnings.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-8">
+      <div
+        className={`inline-flex items-center gap-4 text-orange-500 ${titleClassName}`}
+      >
+        <AlertIcon aria-hidden className="icon-16 text-orange-500" />
+        <span>?곗씠??寃쎄퀬</span>
+      </div>
+      <ul className={listClassName}>
+        {warnings.map((warning) => (
+          <li key={`${warning.source}-${warning.code}-${warning.message}`}>
+            {warning.message}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/fe/src/app/(main)/analysis/[id]/_components/QuestionAnalysisResult.tsx
+++ b/apps/fe/src/app/(main)/analysis/[id]/_components/QuestionAnalysisResult.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import { useMemo, useState } from 'react';
-import AlertIcon from '@/assets/icons/alert.svg';
 import { createCriteriaEditValues } from '../_adapters/normalizeCriteria';
 import type {
   AnalysisFilterViewModel,
   CriteriaEditValues,
   CriteriaViewModel,
 } from '../_models/analysisViewModels';
+import { uniqueStrings as uniqueOptions } from '../_utils/stringList';
+import AnalysisWarningList from './AnalysisWarningList';
 import CriterionSelect from './CriterionSelect';
 
 type Mode = 'normal' | 'edit';
@@ -52,16 +53,6 @@ type RowSpec = StaticRow | SingleRow | MultiRow;
 const DEFAULT_PERIOD_OPTIONS = ['이번 주', '지난 주', '이번 달', '지난 달'];
 const DEFAULT_SORT_DIRECTION_OPTIONS = ['ASC', 'DESC'];
 
-function compactStrings(values: Array<string | null | undefined>) {
-  return values
-    .map((value) => value?.trim())
-    .filter((value): value is string => Boolean(value));
-}
-
-function uniqueOptions(values: Array<string | null | undefined>) {
-  return Array.from(new Set(compactStrings(values)));
-}
-
 function formatFilters(filters: AnalysisFilterViewModel[]) {
   if (filters.length === 0) return '없음';
 
@@ -69,24 +60,6 @@ function formatFilters(filters: AnalysisFilterViewModel[]) {
     .map((filter) => filter.label)
     .filter(Boolean)
     .join(', ');
-}
-
-function DataWarningBlock({ warnings }: { warnings: string[] }) {
-  if (warnings.length === 0) return null;
-
-  return (
-    <div className="flex flex-col gap-8">
-      <div className="inline-flex items-center gap-4 text-body2 font-semibold text-orange-500">
-        <AlertIcon aria-hidden className="icon-16 text-orange-500" />
-        <span>데이터 경고</span>
-      </div>
-      <ul className="ml-20 flex list-disc flex-col gap-8 text-body2 text-gray-900">
-        {warnings.map((warning) => (
-          <li key={warning}>{warning}</li>
-        ))}
-      </ul>
-    </div>
-  );
 }
 
 export default function QuestionAnalysisResult({
@@ -103,11 +76,6 @@ export default function QuestionAnalysisResult({
   const [mode, setMode] = useState<Mode>(initialMode);
   const [values, setValues] = useState<CriteriaEditValues>(() =>
     createCriteriaEditValues(criteria),
-  );
-
-  const warningTexts = useMemo(
-    () => criteria.warnings.map((warning) => warning.message),
-    [criteria.warnings],
   );
 
   const rows = useMemo<RowSpec[]>(() => {
@@ -275,7 +243,7 @@ export default function QuestionAnalysisResult({
         </table>
       </div>
 
-      <DataWarningBlock warnings={warningTexts} />
+      <AnalysisWarningList warnings={criteria.warnings} />
 
       {mode === 'normal' ? (
         <div className="flex justify-end gap-8">

--- a/apps/fe/src/app/(main)/analysis/[id]/_components/VerificationResult.tsx
+++ b/apps/fe/src/app/(main)/analysis/[id]/_components/VerificationResult.tsx
@@ -13,11 +13,11 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
-import AlertIcon from '@/assets/icons/alert.svg';
 import type {
   BarChartViewModel,
   QuestionResultViewModel,
 } from '../_models/analysisViewModels';
+import AnalysisWarningList from './AnalysisWarningList';
 
 export type VerificationResultProps = {
   result: QuestionResultViewModel;
@@ -205,21 +205,7 @@ export default function VerificationResult({
         )}
       </div>
 
-      {result.warnings.length > 0 && (
-        <div className="flex flex-col gap-8">
-          <div className="inline-flex items-center gap-4 text-body2 font-semibold text-orange-500">
-            <AlertIcon aria-hidden className="icon-16 text-orange-500" />
-            <span>데이터 경고</span>
-          </div>
-          <ul className="ml-20 flex list-disc flex-col gap-8 text-body2 text-gray-900">
-            {result.warnings.map((warning) => (
-              <li key={`${warning.code}-${warning.message}`}>
-                {warning.message}
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
+      <AnalysisWarningList warnings={result.warnings} />
     </div>
   );
 }

--- a/apps/fe/src/app/(main)/analysis/[id]/_hooks/useAnalysisChat.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_hooks/useAnalysisChat.ts
@@ -24,6 +24,7 @@ import type {
   CriteriaViewModel,
   QuestionResultViewModel,
 } from '../_models/analysisViewModels';
+import { uniqueStrings } from '../_utils/stringList';
 import {
   analysisChatFlowReducer,
   initialAnalysisChatFlowState,
@@ -84,16 +85,6 @@ function parsePositiveNumber(value: string | null | undefined) {
 
   const parsed = Number(value);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
-}
-
-function compactStrings(values: Array<string | null | undefined>) {
-  return values
-    .map((value) => value?.trim())
-    .filter((value): value is string => Boolean(value));
-}
-
-function uniqueStrings(values: Array<string | null | undefined>) {
-  return Array.from(new Set(compactStrings(values)));
 }
 
 function createPreviewTable(preview?: FilePreview | null) {
@@ -552,3 +543,5 @@ export function useAnalysisChat({
     toast,
   };
 }
+
+export type UseAnalysisChatResult = ReturnType<typeof useAnalysisChat>;

--- a/apps/fe/src/app/(main)/analysis/[id]/_utils/stringList.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_utils/stringList.ts
@@ -1,0 +1,15 @@
+export function compactStrings(
+  values: readonly (string | null | undefined)[] | null | undefined,
+) {
+  return (
+    values
+      ?.map((value) => value?.trim())
+      .filter((value): value is string => Boolean(value)) ?? []
+  );
+}
+
+export function uniqueStrings(
+  values: readonly (string | null | undefined)[] | null | undefined,
+) {
+  return Array.from(new Set(compactStrings(values)));
+}

--- a/apps/fe/src/app/(main)/analysis/[id]/page.tsx
+++ b/apps/fe/src/app/(main)/analysis/[id]/page.tsx
@@ -1,17 +1,14 @@
 'use client';
 
 import { use, useState } from 'react';
-import { ChatBubble, ToastPortal } from '@/components';
+import { ToastPortal } from '@/components';
 import { useAuthSession } from '@/providers/AuthProvider';
 import PromptInput from '../_components/PromptInput';
-import AnalysisResult from './_components/AnalysisResult';
-import AnalyzingIndicator from './_components/AnalyzingIndicator';
+import AnalysisChatMessageList from './_components/AnalysisChatMessageList';
 import DataTablePreview from './_components/DataTablePreview';
 import LoadingDataPreview from './_components/LoadingDataPreview';
-import QuestionAnalysisResult from './_components/QuestionAnalysisResult';
 import ResizableSplit from './_components/ResizableSplit';
-import VerificationResult from './_components/VerificationResult';
-import { useAnalysisChat, type ChatMessage } from './_hooks/useAnalysisChat';
+import { useAnalysisChat } from './_hooks/useAnalysisChat';
 
 type PageParams = { id: string };
 
@@ -28,105 +25,6 @@ export default function AnalysisChatPage({
     hasAccessToken: isAuthenticated,
     routeConversationId: id,
   });
-
-  const renderSummaryMessage = () => {
-    if (!chat.summary) return null;
-
-    const hasWarnings = chat.summaryWarnings.length > 0;
-
-    return (
-      <div key="summary" className="flex w-full justify-start">
-        <div className="w-full max-w-[80%]">
-          <AnalysisResult
-            summary={chat.summary}
-            warningActions={
-              hasWarnings
-                ? {
-                    disabled: chat.summaryActionDisabled,
-                    onEdit: () => chat.startInitialQuestion('edit'),
-                    onContinue: () => chat.startInitialQuestion(),
-                  }
-                : undefined
-            }
-          />
-        </div>
-      </div>
-    );
-  };
-
-  const renderErrorMessage = () => {
-    if (!chat.summaryErrorMessage) return null;
-
-    return (
-      <ChatBubble key="summary-error" role="bot">
-        <p className="text-error-500">{chat.summaryErrorMessage}</p>
-      </ChatBubble>
-    );
-  };
-
-  const renderMessage = (message: ChatMessage) => {
-    if (message.role === 'user') {
-      return (
-        <ChatBubble
-          key={message.id}
-          role="user"
-          file={
-            message.fileName
-              ? { name: message.fileName, status: 'uploaded' }
-              : undefined
-          }
-        >
-          {message.content}
-        </ChatBubble>
-      );
-    }
-
-    if (message.kind === 'notice') {
-      return (
-        <ChatBubble key={message.id} role="bot">
-          <p
-            className={
-              message.tone === 'error' ? 'text-error-500' : 'text-gray-900'
-            }
-          >
-            {message.content}
-          </p>
-        </ChatBubble>
-      );
-    }
-
-    if (message.kind === 'verification') {
-      return (
-        <div key={message.id} className="flex w-full justify-start">
-          <div className="w-full max-w-[80%]">
-            <VerificationResult result={message.result} />
-          </div>
-        </div>
-      );
-    }
-
-    return (
-      <div key={message.id} className="flex w-full justify-start">
-        <div className="w-full max-w-[80%]">
-          <QuestionAnalysisResult
-            criteria={message.criteria}
-            initialMode={message.initialMode}
-            baseDateColumnOptions={
-              chat.summary?.dateFieldOptions.length
-                ? chat.summary.dateFieldOptions
-                : chat.summaryColumnOptions
-            }
-            groupByOptions={chat.summaryColumnOptions}
-            sortByOptions={chat.summarySortOptions}
-            isSubmitting={chat.criteriaSubmitting}
-            onContinue={(values) =>
-              chat.handleConfirmCriteria(message.criteria.messageId, values)
-            }
-          />
-        </div>
-      </div>
-    );
-  };
 
   return (
     <ResizableSplit
@@ -147,17 +45,7 @@ export default function AnalysisChatPage({
       right={
         <div className="flex h-full min-h-0 flex-col">
           <div className="scrollbar-hide flex min-h-0 flex-1 flex-col gap-24 overflow-y-auto px-24 pt-32 pb-24">
-            {chat.initialMessage ? renderMessage(chat.initialMessage) : null}
-            {renderSummaryMessage()}
-            {renderErrorMessage()}
-            {chat.restMessages.map(renderMessage)}
-            {chat.shouldShowAnalyzing && (
-              <div className="flex w-full justify-start">
-                <div className="w-full max-w-[80%]">
-                  <AnalyzingIndicator message={chat.analyzingMessage} />
-                </div>
-              </div>
-            )}
+            <AnalysisChatMessageList chat={chat} />
           </div>
 
           <div className="shrink-0 px-24 pt-12 pb-24">


### PR DESCRIPTION
﻿## 요약
- 분석 화면의 메시지 타입별 렌더링을 `AnalysisChatMessageList`로 분리했습니다.
- 데이터 경고 UI를 `AnalysisWarningList`로 공통화했습니다.
- 분석 화면의 문자열 compact/unique 유틸 중복을 `_utils/stringList.ts`로 모았습니다.

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `eslint .`
  - `vitest run --project unit`
  - `NEXT_PUBLIC_API_URL=http://localhost:8080 next build --webpack`

## 스크린샷/로그 (선택)
- UI 구조만 분리한 변경이라 별도 첨부 없음

## 롤백/리스크
- 리스크 요인: 분석 채팅 메시지 렌더링 경계 이동으로 인한 표시 회귀
- 롤백 방법: 이 PR revert

## 관련 이슈
Refs #193 #206 #213 #215
