### PR TITLE
refactor: 데이터 소스 경계 정리

### DIFF
--- a/apps/fe/src/apis/dataSourceRepository.ts
+++ b/apps/fe/src/apis/dataSourceRepository.ts
@@ -1,0 +1,46 @@
+import {
+  deleteDataSource as deleteDataSourceRequest,
+  deleteDataSources as deleteDataSourcesRequest,
+  getDataSource as getDataSourceRequest,
+  getDataSources as getDataSourcesRequest,
+  type GetDataSourceListParams,
+} from './datasource';
+import {
+  getMockDataSource,
+  getMockDataSourceListResponse,
+  isMockDataSourceId,
+  withMockDataSource,
+} from './mockDataSource';
+
+export async function getDataSources(params: GetDataSourceListParams) {
+  try {
+    const response = await getDataSourcesRequest(params);
+    return withMockDataSource(response, params);
+  } catch {
+    return getMockDataSourceListResponse(params);
+  }
+}
+
+export async function getDataSource(dataSourceId: number) {
+  if (isMockDataSourceId(dataSourceId)) {
+    return getMockDataSource();
+  }
+
+  return getDataSourceRequest(dataSourceId);
+}
+
+export async function deleteDataSources(dataSourceIds: number[]) {
+  const serverDataSourceIds = dataSourceIds.filter(
+    (dataSourceId) => !isMockDataSourceId(dataSourceId),
+  );
+
+  if (serverDataSourceIds.length === 0) return;
+
+  return deleteDataSourcesRequest(serverDataSourceIds);
+}
+
+export async function deleteDataSource(dataSourceId: number) {
+  if (isMockDataSourceId(dataSourceId)) return;
+
+  return deleteDataSourceRequest(dataSourceId);
+}

--- a/apps/fe/src/apis/datasource.ts
+++ b/apps/fe/src/apis/datasource.ts
@@ -1,10 +1,4 @@
 import instance from '@/lib/axios';
-import {
-  getMockDataSource,
-  getMockDataSourceListResponse,
-  isMockDataSourceId,
-  withMockDataSource,
-} from './mockDataSource';
 import { unwrapApiResponse, type ApiResponse } from './types';
 
 export type DataSourceSort = 'LATEST' | 'MOST_USED';
@@ -65,16 +59,12 @@ export const dataSourceKeys = {
 };
 
 export async function getDataSources(params: GetDataSourceListParams) {
-  try {
-    const { data } = await instance.get<ApiResponse<GetDataSourceListResponse>>(
-      '/api/datasources',
-      { params },
-    );
+  const { data } = await instance.get<ApiResponse<GetDataSourceListResponse>>(
+    '/api/datasources',
+    { params },
+  );
 
-    return withMockDataSource(unwrapApiResponse(data), params);
-  } catch {
-    return getMockDataSourceListResponse(params);
-  }
+  return unwrapApiResponse(data);
 }
 
 export async function uploadDataSource(file: File) {
@@ -90,24 +80,14 @@ export async function uploadDataSource(file: File) {
 }
 
 export async function deleteDataSources(dataSourceIds: number[]) {
-  const serverDataSourceIds = dataSourceIds.filter(
-    (dataSourceId) => !isMockDataSourceId(dataSourceId),
-  );
-
-  if (serverDataSourceIds.length === 0) return;
-
   const { data } = await instance.delete<ApiResponse<unknown>>(
-    getDeleteDataSourcesPath(serverDataSourceIds),
+    getDeleteDataSourcesPath(dataSourceIds),
   );
 
   unwrapApiResponse(data);
 }
 
 export async function getDataSource(dataSourceId: number) {
-  if (isMockDataSourceId(dataSourceId)) {
-    return getMockDataSource();
-  }
-
   const { data } = await instance.get<ApiResponse<GetFileResponse>>(
     `/api/datasources/${dataSourceId}`,
   );
@@ -116,8 +96,6 @@ export async function getDataSource(dataSourceId: number) {
 }
 
 export async function deleteDataSource(dataSourceId: number) {
-  if (isMockDataSourceId(dataSourceId)) return;
-
   const { data } = await instance.delete<ApiResponse<unknown>>(
     `/api/datasources/${dataSourceId}`,
   );

--- a/apps/fe/src/app/(main)/data/[id]/_components/DataDetailStatus.tsx
+++ b/apps/fe/src/app/(main)/data/[id]/_components/DataDetailStatus.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+type DataDetailStatusProps = {
+  message: string;
+};
+
+export default function DataDetailStatus({ message }: DataDetailStatusProps) {
+  const router = useRouter();
+
+  return (
+    <main className="scrollbar-hide flex min-h-0 flex-1 flex-col items-center justify-center overflow-y-auto px-40 pt-32 pb-40">
+      <p className="mb-16 text-body3 text-gray-700">{message}</p>
+      <button
+        type="button"
+        onClick={() => router.push('/data')}
+        className="rounded-full bg-orange-500 px-16 py-8 text-body4 font-medium text-white transition-colors hover:bg-orange-600"
+      >
+        목록으로 돌아가기
+      </button>
+    </main>
+  );
+}

--- a/apps/fe/src/app/(main)/data/[id]/_components/DataDetailView.tsx
+++ b/apps/fe/src/app/(main)/data/[id]/_components/DataDetailView.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import type { GetFileResponse } from '@/apis/datasource';
+import { ConfirmModal } from '@/components';
+import { formatDateTime } from '@/lib/dateTime';
+import { formatFileSize } from '@/lib/fileValidation';
+import DataChartCard from '../../_components/DataChartCard';
+
+type DataDetailViewProps = {
+  deleteOpen: boolean;
+  deletePending: boolean;
+  detail: GetFileResponse;
+  onChat: () => void;
+  onDelete: () => void;
+  onDeleteClose: () => void;
+  onDeleteConfirm: () => void;
+};
+
+const DELETE_ILLUST_SRC = '/illusts/delete.svg';
+
+export default function DataDetailView({
+  deleteOpen,
+  deletePending,
+  detail,
+  onChat,
+  onDelete,
+  onDeleteClose,
+  onDeleteConfirm,
+}: DataDetailViewProps) {
+  return (
+    <main className="scrollbar-hide flex min-h-0 flex-1 flex-col overflow-y-auto px-40 pt-32 pb-40">
+      <DataChartCard
+        fileName={detail.fileName}
+        fileSize={formatFileSize(detail.fileSize)}
+        uploadedAt={formatDateTime(detail.uploadedAt)}
+        preview={detail.preview}
+        onChat={onChat}
+        onDelete={onDelete}
+      />
+
+      <ConfirmModal
+        open={deleteOpen}
+        onClose={onDeleteClose}
+        onConfirm={onDeleteConfirm}
+        title="파일을 삭제하시겠어요?"
+        description="삭제 후에는 복구할 수 없어요."
+        confirmLabel={deletePending ? '삭제 중' : '삭제하기'}
+        cancelLabel="취소하기"
+        confirmDisabled={deletePending}
+        cancelDisabled={deletePending}
+        icon={
+          <>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={DELETE_ILLUST_SRC}
+              alt=""
+              aria-hidden
+              className="h-[8rem] w-auto"
+            />
+          </>
+        }
+      />
+    </main>
+  );
+}

--- a/apps/fe/src/app/(main)/data/[id]/_hooks/useDataDetail.ts
+++ b/apps/fe/src/app/(main)/data/[id]/_hooks/useDataDetail.ts
@@ -1,0 +1,38 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { getDataSource, deleteDataSource } from '@/apis/dataSourceRepository';
+import { dataSourceKeys } from '@/apis/datasource';
+
+type UseDataDetailParams = {
+  dataSourceId: number;
+  enabled: boolean;
+};
+
+export function useDataDetail({ dataSourceId, enabled }: UseDataDetailParams) {
+  const queryClient = useQueryClient();
+  const detailQuery = useQuery({
+    queryKey: dataSourceKeys.detail(dataSourceId),
+    queryFn: () => getDataSource(dataSourceId),
+    enabled,
+  });
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteDataSource(dataSourceId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: dataSourceKeys.lists(),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: dataSourceKeys.detail(dataSourceId),
+      });
+    },
+  });
+
+  return {
+    detail: detailQuery.data,
+    deleteDataSource: deleteMutation.mutateAsync,
+    deletePending: deleteMutation.isPending,
+    isError: detailQuery.isError,
+    isLoading: detailQuery.isLoading,
+  };
+}

--- a/apps/fe/src/app/(main)/data/[id]/page.tsx
+++ b/apps/fe/src/app/(main)/data/[id]/page.tsx
@@ -1,40 +1,15 @@
 'use client';
 
 import { use, useState } from 'react';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
-import {
-  dataSourceKeys,
-  deleteDataSource,
-  getDataSource,
-} from '@/apis/datasource';
-import { ConfirmModal, ToastPortal } from '@/components';
+import { ToastPortal } from '@/components';
 import { useToast } from '@/hooks/useToast';
-import { formatDateTime } from '@/lib/dateTime';
-import { formatFileSize } from '@/lib/fileValidation';
 import { useAuthSession } from '@/providers/AuthProvider';
-import DataChartCard from '../_components/DataChartCard';
+import DataDetailStatus from './_components/DataDetailStatus';
+import DataDetailView from './_components/DataDetailView';
+import { useDataDetail } from './_hooks/useDataDetail';
 
 type PageParams = { id: string };
-
-const DELETE_ILLUST_SRC = '/illusts/delete.svg';
-
-function DataDetailStatus({ message }: { message: string }) {
-  const router = useRouter();
-
-  return (
-    <main className="scrollbar-hide flex min-h-0 flex-1 flex-col items-center justify-center overflow-y-auto px-40 pt-32 pb-40">
-      <p className="mb-16 text-body3 text-gray-700">{message}</p>
-      <button
-        type="button"
-        onClick={() => router.push('/data')}
-        className="rounded-full bg-orange-500 px-16 py-8 text-body4 font-medium text-white transition-colors hover:bg-orange-600"
-      >
-        목록으로 돌아가기
-      </button>
-    </main>
-  );
-}
 
 export default function DataDetailPage({
   params,
@@ -43,7 +18,6 @@ export default function DataDetailPage({
 }) {
   const { id } = use(params);
   const router = useRouter();
-  const queryClient = useQueryClient();
   const { hasAccessToken, status } = useAuthSession();
   const isAuthenticated = status === 'authenticated';
   const [deleteOpen, setDeleteOpen] = useState(false);
@@ -52,36 +26,14 @@ export default function DataDetailPage({
   const dataSourceId = Number(id);
   const isValidDataSourceId =
     Number.isSafeInteger(dataSourceId) && dataSourceId > 0;
-
-  const {
-    data: detail,
-    isError,
-    isLoading,
-  } = useQuery({
-    queryKey: dataSourceKeys.detail(dataSourceId),
-    queryFn: () => getDataSource(dataSourceId),
+  const dataDetail = useDataDetail({
+    dataSourceId: isValidDataSourceId ? dataSourceId : 0,
     enabled: isAuthenticated && isValidDataSourceId,
   });
 
-  const deleteMutation = useMutation({
-    mutationFn: () => deleteDataSource(dataSourceId),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({
-        queryKey: dataSourceKeys.lists(),
-      });
-      void queryClient.invalidateQueries({
-        queryKey: dataSourceKeys.detail(dataSourceId),
-      });
-    },
-  });
-
-  const handleChat = () => {
-    router.push(`/analysis/${id}`);
-  };
-
   const handleDeleteConfirm = async () => {
     try {
-      await deleteMutation.mutateAsync();
+      await dataDetail.deleteDataSource();
       setDeleteOpen(false);
       router.push('/data');
     } catch {
@@ -104,49 +56,26 @@ export default function DataDetailPage({
     );
   }
 
-  if (isLoading) {
+  if (dataDetail.isLoading) {
     return <DataDetailStatus message="데이터 소스를 불러오는 중입니다." />;
   }
 
-  if (isError || !detail) {
+  if (dataDetail.isError || !dataDetail.detail) {
     return <DataDetailStatus message="데이터 소스를 불러오지 못했습니다." />;
   }
 
   return (
-    <main className="scrollbar-hide flex min-h-0 flex-1 flex-col overflow-y-auto px-40 pt-32 pb-40">
-      <DataChartCard
-        fileName={detail.fileName}
-        fileSize={formatFileSize(detail.fileSize)}
-        uploadedAt={formatDateTime(detail.uploadedAt)}
-        preview={detail.preview}
-        onChat={handleChat}
+    <>
+      <DataDetailView
+        deleteOpen={deleteOpen}
+        deletePending={dataDetail.deletePending}
+        detail={dataDetail.detail}
+        onChat={() => router.push(`/analysis/${id}`)}
         onDelete={() => setDeleteOpen(true)}
+        onDeleteClose={() => setDeleteOpen(false)}
+        onDeleteConfirm={() => void handleDeleteConfirm()}
       />
-
-      <ConfirmModal
-        open={deleteOpen}
-        onClose={() => setDeleteOpen(false)}
-        onConfirm={() => void handleDeleteConfirm()}
-        title="파일을 삭제하시겠어요?"
-        description="삭제 후에는 복구할 수 없어요."
-        confirmLabel={deleteMutation.isPending ? '삭제 중' : '삭제하기'}
-        cancelLabel="취소하기"
-        confirmDisabled={deleteMutation.isPending}
-        cancelDisabled={deleteMutation.isPending}
-        icon={
-          <>
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src={DELETE_ILLUST_SRC}
-              alt=""
-              aria-hidden
-              className="h-[8rem] w-auto"
-            />
-          </>
-        }
-      />
-
       <ToastPortal toast={toast} />
-    </main>
+    </>
   );
 }

--- a/apps/fe/src/app/(main)/data/_hooks/useDataSourceList.ts
+++ b/apps/fe/src/app/(main)/data/_hooks/useDataSourceList.ts
@@ -2,11 +2,8 @@
 
 import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import {
-  dataSourceKeys,
-  getDataSources,
-  type DataSourceSort,
-} from '@/apis/datasource';
+import { dataSourceKeys, type DataSourceSort } from '@/apis/datasource';
+import { getDataSources } from '@/apis/dataSourceRepository';
 import { getApiErrorMessage } from '@/apis/errors';
 import { getMockDataSourceListResponse } from '@/apis/mockDataSource';
 

--- a/apps/fe/src/app/(main)/data/_hooks/useDeleteDataSources.ts
+++ b/apps/fe/src/app/(main)/data/_hooks/useDeleteDataSources.ts
@@ -2,7 +2,8 @@
 
 import { useCallback } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { dataSourceKeys, deleteDataSources } from '@/apis/datasource';
+import { deleteDataSources } from '@/apis/dataSourceRepository';
+import { dataSourceKeys } from '@/apis/datasource';
 import { getApiErrorMessage } from '@/apis/errors';
 
 type UseDeleteDataSourcesOptions = {


### PR DESCRIPTION
﻿## 요약
- 데이터 소스 API 함수에서 mock fallback/no-op 분기를 제거하고 `dataSourceRepository`로 이동했습니다.
- 데이터 상세 페이지의 조회/삭제/invalidation 로직을 `useDataDetail`로 분리했습니다.
- 상세 페이지의 상태 화면과 상세 본문을 작은 컴포넌트로 분리했습니다.

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `eslint .`
  - `vitest run --project unit`
  - `NEXT_PUBLIC_API_URL=http://localhost:8080 next build --webpack`

## 스크린샷/로그 (선택)
- UI 동작 유지 목적의 구조 분리라 별도 첨부 없음

## 롤백/리스크
- 리스크 요인: mock 데이터 소스 fallback 및 삭제 no-op 경계 이동으로 인한 데이터 페이지 회귀
- 롤백 방법: 이 PR revert

## 관련 이슈
Refs #193 #206 #213 #215
