### PR TITLE
refactor: 드롭다운 셸 공통화

### DIFF
--- a/apps/fe/src/app/(main)/analysis/[id]/_components/CriterionSelect.tsx
+++ b/apps/fe/src/app/(main)/analysis/[id]/_components/CriterionSelect.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import ArrowDownIcon from '@/assets/icons/arrow-down.svg';
-import { ListboxDropdown } from '@/components';
+import { ListboxDropdownShell } from '@/components';
 
 type CommonProps = {
   options: string[];
@@ -39,113 +39,107 @@ export default function CriterionSelect(props: CriterionSelectProps) {
     : props.value;
 
   return (
-    <ListboxDropdown
+    <ListboxDropdownShell
       className={props.className}
       optionSelector={optionFocusSelector}
-    >
-      {({ closeAndFocusButton, listboxProps, open, triggerProps }) => (
+      triggerClassName="inline-flex min-w-[12rem] items-center justify-between gap-8 rounded-12 border border-gray-300 bg-white px-12 py-8 text-body2 text-gray-900 transition-colors hover:bg-gray-100"
+      trigger={({ open }) => (
         <>
-          <button
-            {...triggerProps}
-            className="inline-flex min-w-[12rem] items-center justify-between gap-8 rounded-12 border border-gray-300 bg-white px-12 py-8 text-body2 text-gray-900 transition-colors hover:bg-gray-100"
-          >
-            <span>{buttonLabel}</span>
-            <ArrowDownIcon
-              aria-hidden
-              className={`icon-12 text-gray-700 transition-transform ${
-                open ? 'rotate-180' : ''
-              }`}
-            />
-          </button>
-
-          {open && (
-            <div
-              {...listboxProps}
-              aria-multiselectable={props.multi ? true : undefined}
-              className="absolute left-0 z-10 mt-4 w-max min-w-full overflow-hidden rounded-12 border border-gray-300 bg-white shadow-[0_0.4rem_1.2rem_rgba(0,0,0,0.08)]"
-            >
-              {props.multi && props.headerLabel && (
-                <div className="border-b border-gray-200 px-12 py-8 text-body4 text-gray-600">
-                  {props.headerLabel}
-                </div>
-              )}
-
-              {props.options.map((opt) => {
-                if (props.multi) {
-                  const checked = props.values.includes(opt);
-                  const disabled =
-                    !checked &&
-                    props.maxSelect !== undefined &&
-                    props.values.length >= props.maxSelect;
-                  const handleToggle = () => {
-                    if (disabled) return;
-
-                    const next = checked
-                      ? props.values.filter((v) => v !== opt)
-                      : [...props.values, opt];
-                    props.onChange(next);
-                  };
-
-                  return (
-                    <label
-                      key={opt}
-                      role="option"
-                      aria-selected={checked}
-                      aria-disabled={disabled}
-                      tabIndex={disabled ? -1 : 0}
-                      onClick={(event) => {
-                        event.preventDefault();
-                        handleToggle();
-                      }}
-                      onKeyDown={(event) => {
-                        if (event.key !== 'Enter' && event.key !== ' ') return;
-
-                        event.preventDefault();
-                        handleToggle();
-                      }}
-                      className={`flex cursor-pointer items-center gap-8 px-12 py-8 text-body2 transition-colors hover:bg-gray-100 ${
-                        disabled
-                          ? 'cursor-not-allowed text-gray-500'
-                          : 'text-gray-900'
-                      }`}
-                    >
-                      <input
-                        type="checkbox"
-                        aria-hidden
-                        tabIndex={-1}
-                        checked={checked}
-                        disabled={disabled}
-                        readOnly
-                        className="h-16 w-16 accent-orange-500"
-                      />
-                      <span>{opt}</span>
-                    </label>
-                  );
-                }
-
-                const selected = props.value === opt;
-                return (
-                  <button
-                    key={opt}
-                    type="button"
-                    role="option"
-                    aria-selected={selected}
-                    onClick={() => {
-                      props.onChange(opt);
-                      closeAndFocusButton();
-                    }}
-                    className={`block w-full px-12 py-8 text-left text-body2 transition-colors hover:bg-gray-100 ${
-                      selected ? 'text-orange-500' : 'text-gray-900'
-                    }`}
-                  >
-                    {opt}
-                  </button>
-                );
-              })}
-            </div>
-          )}
+          <span>{buttonLabel}</span>
+          <ArrowDownIcon
+            aria-hidden
+            className={`icon-12 text-gray-700 transition-transform ${
+              open ? 'rotate-180' : ''
+            }`}
+          />
         </>
       )}
-    </ListboxDropdown>
+      panel={({ closeAndFocusButton, panelProps }) => (
+        <div
+          {...panelProps}
+          aria-multiselectable={props.multi ? true : undefined}
+          className="absolute left-0 z-10 mt-4 w-max min-w-full overflow-hidden rounded-12 border border-gray-300 bg-white shadow-[0_0.4rem_1.2rem_rgba(0,0,0,0.08)]"
+        >
+          {props.multi && props.headerLabel && (
+            <div className="border-b border-gray-200 px-12 py-8 text-body4 text-gray-600">
+              {props.headerLabel}
+            </div>
+          )}
+
+          {props.options.map((opt) => {
+            if (props.multi) {
+              const checked = props.values.includes(opt);
+              const disabled =
+                !checked &&
+                props.maxSelect !== undefined &&
+                props.values.length >= props.maxSelect;
+              const handleToggle = () => {
+                if (disabled) return;
+
+                const next = checked
+                  ? props.values.filter((v) => v !== opt)
+                  : [...props.values, opt];
+                props.onChange(next);
+              };
+
+              return (
+                <label
+                  key={opt}
+                  role="option"
+                  aria-selected={checked}
+                  aria-disabled={disabled}
+                  tabIndex={disabled ? -1 : 0}
+                  onClick={(event) => {
+                    event.preventDefault();
+                    handleToggle();
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key !== 'Enter' && event.key !== ' ') return;
+
+                    event.preventDefault();
+                    handleToggle();
+                  }}
+                  className={`flex cursor-pointer items-center gap-8 px-12 py-8 text-body2 transition-colors hover:bg-gray-100 ${
+                    disabled
+                      ? 'cursor-not-allowed text-gray-500'
+                      : 'text-gray-900'
+                  }`}
+                >
+                  <input
+                    type="checkbox"
+                    aria-hidden
+                    tabIndex={-1}
+                    checked={checked}
+                    disabled={disabled}
+                    readOnly
+                    className="h-16 w-16 accent-orange-500"
+                  />
+                  <span>{opt}</span>
+                </label>
+              );
+            }
+
+            const selected = props.value === opt;
+            return (
+              <button
+                key={opt}
+                type="button"
+                role="option"
+                aria-selected={selected}
+                onClick={() => {
+                  props.onChange(opt);
+                  closeAndFocusButton();
+                }}
+                className={`block w-full px-12 py-8 text-left text-body2 transition-colors hover:bg-gray-100 ${
+                  selected ? 'text-orange-500' : 'text-gray-900'
+                }`}
+              >
+                {opt}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    />
   );
 }

--- a/apps/fe/src/app/(main)/data/_components/SortDropdown.tsx
+++ b/apps/fe/src/app/(main)/data/_components/SortDropdown.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import DownIcon from '@/assets/icons/down.svg';
-import { ListboxDropdown } from '@/components';
+import { ListboxDropdownShell } from '@/components';
 
 export type SortOption<T extends string = string> = {
   value: T;
@@ -22,60 +22,55 @@ export default function SortDropdown<T extends string>({
   const selectedLabel = options.find((o) => o.value === value)?.label ?? '';
 
   return (
-    <ListboxDropdown>
-      {({ closeAndFocusButton, listboxProps, open, triggerProps }) => (
+    <ListboxDropdownShell
+      triggerClassName="inline-flex min-w-[12rem] items-center justify-between gap-8 rounded-12 border border-gray-300 bg-white px-12 py-8 text-body4 text-gray-700 transition-colors hover:bg-gray-100"
+      trigger={({ open }) => (
         <>
-          <button
-            {...triggerProps}
-            className="inline-flex min-w-[12rem] items-center justify-between gap-8 rounded-12 border border-gray-300 bg-white px-12 py-8 text-body4 text-gray-700 transition-colors hover:bg-gray-100"
-          >
-            <span>{selectedLabel}</span>
-            <DownIcon
-              aria-hidden
-              className={`icon-16 text-gray-900 transition-transform ${
-                open ? 'rotate-180' : ''
-              }`}
-            />
-          </button>
-
-          {open && (
-            <div
-              {...listboxProps}
-              className="absolute left-0 z-10 mt-4 min-w-[14rem] overflow-hidden rounded-12 border border-gray-300 bg-white py-8 shadow-[0_0.4rem_1.2rem_rgba(0,0,0,0.08)]"
-            >
-              {options.map((opt) => {
-                const selected = opt.value === value;
-                return (
-                  <button
-                    key={opt.value}
-                    type="button"
-                    role="option"
-                    aria-selected={selected}
-                    onClick={() => {
-                      onChange(opt.value);
-                      closeAndFocusButton();
-                    }}
-                    className={`flex w-full items-center gap-12 px-16 py-12 text-left text-body4 transition-colors hover:bg-gray-100 ${
-                      selected ? 'text-orange-500' : 'text-gray-500'
-                    }`}
-                  >
-                    <span
-                      className={`flex h-16 w-16 shrink-0 items-center justify-center rounded-full border-2 ${
-                        selected ? 'border-orange-500' : 'border-gray-400'
-                      }`}
-                    >
-                      {selected && (
-                        <span className="h-8 w-8 rounded-full bg-orange-500" />
-                      )}
-                    </span>
-                    <span>{opt.label}</span>
-                  </button>
-                );
-              })}
-            </div>
-          )}
+          <span>{selectedLabel}</span>
+          <DownIcon
+            aria-hidden
+            className={`icon-16 text-gray-900 transition-transform ${
+              open ? 'rotate-180' : ''
+            }`}
+          />
         </>
       )}
-    </ListboxDropdown>
+      panel={({ closeAndFocusButton, panelProps }) => (
+        <div
+          {...panelProps}
+          className="absolute left-0 z-10 mt-4 min-w-[14rem] overflow-hidden rounded-12 border border-gray-300 bg-white py-8 shadow-[0_0.4rem_1.2rem_rgba(0,0,0,0.08)]"
+        >
+          {options.map((opt) => {
+            const selected = opt.value === value;
+            return (
+              <button
+                key={opt.value}
+                type="button"
+                role="option"
+                aria-selected={selected}
+                onClick={() => {
+                  onChange(opt.value);
+                  closeAndFocusButton();
+                }}
+                className={`flex w-full items-center gap-12 px-16 py-12 text-left text-body4 transition-colors hover:bg-gray-100 ${
+                  selected ? 'text-orange-500' : 'text-gray-500'
+                }`}
+              >
+                <span
+                  className={`flex h-16 w-16 shrink-0 items-center justify-center rounded-full border-2 ${
+                    selected ? 'border-orange-500' : 'border-gray-400'
+                  }`}
+                >
+                  {selected && (
+                    <span className="h-8 w-8 rounded-full bg-orange-500" />
+                  )}
+                </span>
+                <span>{opt.label}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    />
   );
 }

--- a/apps/fe/src/components/Dropdown/Dropdown.tsx
+++ b/apps/fe/src/components/Dropdown/Dropdown.tsx
@@ -2,7 +2,7 @@
 
 import { type ReactNode } from 'react';
 import DropdownDetails from '../DropdownDetails/DropdownDetails';
-import ListboxDropdown from '../ListboxDropdown/ListboxDropdown';
+import ListboxDropdownShell from '../ListboxDropdownShell/ListboxDropdownShell';
 
 export type DropdownOption = {
   label: string;
@@ -31,51 +31,47 @@ export default function Dropdown({
   const selected = options.find((o) => o.value === value);
 
   return (
-    <ListboxDropdown className={className}>
-      {({ closeAndFocusButton, listboxProps, open, triggerProps }) => (
+    <ListboxDropdownShell
+      className={className}
+      triggerClassName="inline-flex h-[3.4rem] items-center justify-center gap-12 rounded-8 border border-gray-800 bg-white pl-16 pr-12 text-body2 text-gray-800 transition-colors hover:border-gray-900"
+      trigger={({ open }) => (
         <>
-          <button
-            {...triggerProps}
-            className="inline-flex h-[3.4rem] items-center justify-center gap-12 rounded-8 border border-gray-800 bg-white pl-16 pr-12 text-body2 text-gray-800 transition-colors hover:border-gray-900"
+          {icon && <span className="shrink-0 [&>svg]:icon-16">{icon}</span>}
+          <span>{selected?.label ?? placeholder}</span>
+          <svg
+            width="12"
+            height="8"
+            viewBox="0 0 12 8"
+            fill="none"
+            aria-hidden
+            className={`shrink-0 transition-transform ${
+              open ? 'rotate-180' : ''
+            }`}
           >
-            {icon && <span className="shrink-0 [&>svg]:icon-16">{icon}</span>}
-            <span>{selected?.label ?? placeholder}</span>
-            <svg
-              width="12"
-              height="8"
-              viewBox="0 0 12 8"
-              fill="none"
-              aria-hidden
-              className={`shrink-0 transition-transform ${
-                open ? 'rotate-180' : ''
-              }`}
-            >
-              <path
-                d="M1 1.5l5 5 5-5"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
-          </button>
-
-          {open && (
-            <DropdownDetails
-              {...listboxProps}
-              type="radio"
-              options={options}
-              selectedValues={value ? [value] : []}
-              helperText={helperText}
-              onSelect={(nextValue) => {
-                onChange?.(nextValue);
-                closeAndFocusButton();
-              }}
-              className="absolute left-0 top-full z-10 mt-4"
+            <path
+              d="M1 1.5l5 5 5-5"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
             />
-          )}
+          </svg>
         </>
       )}
-    </ListboxDropdown>
+      panel={({ closeAndFocusButton, panelProps }) => (
+        <DropdownDetails
+          {...panelProps}
+          type="radio"
+          options={options}
+          selectedValues={value ? [value] : []}
+          helperText={helperText}
+          onSelect={(nextValue) => {
+            onChange?.(nextValue);
+            closeAndFocusButton();
+          }}
+          className="absolute left-0 top-full z-10 mt-4"
+        />
+      )}
+    />
   );
 }

--- a/apps/fe/src/components/ListboxDropdownShell/ListboxDropdownShell.tsx
+++ b/apps/fe/src/components/ListboxDropdownShell/ListboxDropdownShell.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import ListboxDropdown, {
+  type ListboxDropdownListboxProps,
+} from '../ListboxDropdown/ListboxDropdown';
+
+export type ListboxDropdownShellPanelProps = {
+  closeAndFocusButton: () => void;
+  open: boolean;
+  panelProps: ListboxDropdownListboxProps;
+};
+
+export type ListboxDropdownShellProps = {
+  className?: string;
+  optionSelector?: string;
+  panel: (props: ListboxDropdownShellPanelProps) => ReactNode;
+  trigger: (props: { open: boolean }) => ReactNode;
+  triggerClassName: string;
+};
+
+export default function ListboxDropdownShell({
+  className,
+  optionSelector,
+  panel,
+  trigger,
+  triggerClassName,
+}: ListboxDropdownShellProps) {
+  return (
+    <ListboxDropdown className={className} optionSelector={optionSelector}>
+      {({ closeAndFocusButton, listboxProps, open, triggerProps }) => (
+        <>
+          <button {...triggerProps} className={triggerClassName}>
+            {trigger({ open })}
+          </button>
+          {open &&
+            panel({
+              closeAndFocusButton,
+              open,
+              panelProps: listboxProps,
+            })}
+        </>
+      )}
+    </ListboxDropdown>
+  );
+}

--- a/apps/fe/src/components/index.ts
+++ b/apps/fe/src/components/index.ts
@@ -77,6 +77,11 @@ export type {
   ListboxDropdownProps,
   ListboxDropdownRenderProps,
 } from './ListboxDropdown/ListboxDropdown';
+export { default as ListboxDropdownShell } from './ListboxDropdownShell/ListboxDropdownShell';
+export type {
+  ListboxDropdownShellPanelProps,
+  ListboxDropdownShellProps,
+} from './ListboxDropdownShell/ListboxDropdownShell';
 
 export { default as MenuTab } from './MenuTab/MenuTab';
 export type { MenuTabProps } from './MenuTab/MenuTab';


### PR DESCRIPTION
﻿## 요약
- `ListboxDropdownShell`을 추가해 listbox trigger 버튼과 열린 panel 연결을 공통화했습니다.
- `Dropdown`, `SortDropdown`, `CriterionSelect`를 shell 기반으로 옮겼습니다.
- 각 dropdown의 옵션 UI와 단일/멀티 선택 동작은 유지했습니다.

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `eslint .`
  - `storybook build`

## 스크린샷/로그 (선택)
- Storybook production build 통과

## 롤백/리스크
- 리스크 요인: dropdown trigger/panel 렌더링 경계 이동으로 인한 keyboard/focus 회귀
- 롤백 방법: 이 PR revert

## 관련 이슈
Refs #193 #206 #213 #215
