### PR TITLE
refactor: 인증 프로바이더 흐름 분리

### DIFF
--- a/apps/fe/src/providers/AuthProvider.tsx
+++ b/apps/fe/src/providers/AuthProvider.tsx
@@ -2,13 +2,14 @@
 
 import {
   createContext,
+  useCallback,
   useContext,
   useEffect,
   useMemo,
   useState,
   type ReactNode,
 } from 'react';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQueryClient, type QueryClient } from '@tanstack/react-query';
 import { usePathname } from 'next/navigation';
 import {
   ACCESS_TOKEN_STORAGE_KEY,
@@ -43,6 +44,8 @@ type AuthContextValue = {
 
 const AuthContext = createContext<AuthContextValue | null>(null);
 
+type SetAuthStatus = (status: AuthStatus) => void;
+
 function removeTokenParamsFromCurrentUrl(url: URL) {
   const shouldReplace =
     url.searchParams.has('accessToken') || url.searchParams.has('refreshToken');
@@ -62,54 +65,118 @@ function replaceLocation(pathname: string) {
   window.location.replace(pathname);
 }
 
-export default function AuthProvider({ children }: { children: ReactNode }) {
-  const pathname = usePathname();
-  const queryClient = useQueryClient();
-  const [status, setStatus] = useState<AuthStatus>('initializing');
+function useAuthTokenSync({
+  pathname,
+  queryClient,
+  setStatus,
+}: {
+  pathname: string;
+  queryClient: QueryClient;
+  setStatus: SetAuthStatus;
+}) {
+  return useCallback(() => {
+    const nextStatus: AuthStatus = getAccessToken()
+      ? 'authenticated'
+      : 'anonymous';
 
-  useEffect(() => {
-    const syncAccessToken = () => {
-      const nextStatus: AuthStatus = getAccessToken()
-        ? 'authenticated'
-        : 'anonymous';
+    setStatus(nextStatus);
 
-      setStatus(nextStatus);
+    if (nextStatus === 'anonymous') {
+      queryClient.clear();
 
-      if (nextStatus === 'anonymous') {
-        queryClient.clear();
-
-        if (
-          shouldRedirectPrivatePath(nextStatus, pathname) &&
-          !consumePrivatePathRedirectBypass()
-        ) {
-          replaceLocation(getLoginRedirectPath(new URL(window.location.href)));
-        }
+      if (
+        shouldRedirectPrivatePath(nextStatus, pathname) &&
+        !consumePrivatePathRedirectBypass()
+      ) {
+        replaceLocation(getLoginRedirectPath(new URL(window.location.href)));
       }
+    }
 
-      return nextStatus;
-    };
+    return nextStatus;
+  }, [pathname, queryClient, setStatus]);
+}
 
+function useOAuthCallbackHandler({
+  pathname,
+  queryClient,
+}: {
+  pathname: string;
+  queryClient: QueryClient;
+}) {
+  return useCallback(() => {
     const currentUrl = new URL(window.location.href);
     const redirectedTokens = readAuthTokensFromSearchParams(
       currentUrl.searchParams,
     );
 
-    if (redirectedTokens) {
-      const popupRelay = getOAuthPopupCallbackRelay(currentUrl, window.name);
+    if (!redirectedTokens) return false;
 
-      if (popupRelay && window.opener) {
-        removeTokenParamsFromCurrentUrl(currentUrl);
-        window.opener.postMessage(popupRelay.message, popupRelay.targetOrigin);
-        window.close();
-        return;
-      }
+    const popupRelay = getOAuthPopupCallbackRelay(currentUrl, window.name);
 
-      setAuthTokens(redirectedTokens);
+    if (popupRelay && window.opener) {
       removeTokenParamsFromCurrentUrl(currentUrl);
-      queryClient.clear();
-      replaceLocation(getPostAuthRedirectPath(pathname));
-      return;
+      window.opener.postMessage(popupRelay.message, popupRelay.targetOrigin);
+      window.close();
+      return true;
     }
+
+    setAuthTokens(redirectedTokens);
+    removeTokenParamsFromCurrentUrl(currentUrl);
+    queryClient.clear();
+    replaceLocation(getPostAuthRedirectPath(pathname));
+    return true;
+  }, [pathname, queryClient]);
+}
+
+function useOAuthPopupMessageHandler({
+  queryClient,
+  setStatus,
+}: {
+  queryClient: QueryClient;
+  setStatus: SetAuthStatus;
+}) {
+  return useCallback(
+    (event: MessageEvent) => {
+      if (!isAllowedOAuthPopupOrigin(event.origin)) return;
+
+      const message = readOAuthPopupCallbackMessage(event.data);
+      if (!message) return;
+      if (!consumeOAuthPopupState(message.state)) return;
+
+      setAuthTokens(message.tokens);
+      queryClient.clear();
+      setStatus('authenticated');
+      replaceLocation(message.redirectPath);
+    },
+    [queryClient, setStatus],
+  );
+}
+
+function useAuthLifecycle({
+  pathname,
+  queryClient,
+  setStatus,
+}: {
+  pathname: string;
+  queryClient: QueryClient;
+  setStatus: SetAuthStatus;
+}) {
+  const syncAccessToken = useAuthTokenSync({
+    pathname,
+    queryClient,
+    setStatus,
+  });
+  const handleOAuthCallback = useOAuthCallbackHandler({
+    pathname,
+    queryClient,
+  });
+  const handleMessage = useOAuthPopupMessageHandler({
+    queryClient,
+    setStatus,
+  });
+
+  useEffect(() => {
+    if (handleOAuthCallback()) return;
 
     const nextStatus = syncAccessToken();
     const shouldBypassAuthEntryRedirect =
@@ -135,19 +202,6 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
       }
     };
 
-    const handleMessage = (event: MessageEvent) => {
-      if (!isAllowedOAuthPopupOrigin(event.origin)) return;
-
-      const message = readOAuthPopupCallbackMessage(event.data);
-      if (!message) return;
-      if (!consumeOAuthPopupState(message.state)) return;
-
-      setAuthTokens(message.tokens);
-      queryClient.clear();
-      setStatus('authenticated');
-      replaceLocation(message.redirectPath);
-    };
-
     window.addEventListener(AUTH_TOKENS_CHANGED_EVENT, syncAccessToken);
     window.addEventListener('message', handleMessage);
     window.addEventListener('storage', handleStorage);
@@ -157,7 +211,19 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
       window.removeEventListener('message', handleMessage);
       window.removeEventListener('storage', handleStorage);
     };
-  }, [pathname, queryClient]);
+  }, [handleMessage, handleOAuthCallback, pathname, syncAccessToken]);
+}
+
+export default function AuthProvider({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const queryClient = useQueryClient();
+  const [status, setStatus] = useState<AuthStatus>('initializing');
+
+  useAuthLifecycle({
+    pathname,
+    queryClient,
+    setStatus,
+  });
 
   const hasAccessToken = status === 'authenticated';
   const value = useMemo(


### PR DESCRIPTION
﻿## 요약
- `AuthProvider`의 인증 lifecycle effect를 내부 훅 단위로 분리했습니다.
- URL token callback, popup relay, token sync, popup postMessage 처리 순서는 기존 흐름과 동일하게 유지했습니다.
- Provider 컴포넌트는 상태와 context 조립에 집중하도록 줄였습니다.

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `eslint .`
  - `vitest run --project unit`
  - `NEXT_PUBLIC_API_URL=http://localhost:8080 next build --webpack`

## 스크린샷/로그 (선택)
- 인증 흐름 구조 분리라 별도 첨부 없음

## 롤백/리스크
- 리스크 요인: OAuth callback/popup/storage sync 순서 회귀
- 롤백 방법: 이 PR revert

## 관련 이슈
Refs #193 #206 #213 #215
