### PR TITLE
refactor: 분석 채팅 훅 경계 정리

### DIFF
--- a/apps/fe/src/app/(main)/analysis/[id]/_hooks/useAnalysisChat.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_hooks/useAnalysisChat.ts
@@ -1,8 +1,7 @@
 'use client';
 
-import { useCallback, useEffect, useReducer, useRef, useState } from 'react';
+import { useCallback, useEffect, useReducer } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { useSearchParams } from 'next/navigation';
 import {
   dataSourceKeys,
   getDataSource,
@@ -10,57 +9,29 @@ import {
 } from '@/apis/datasource';
 import { getApiErrorMessage } from '@/apis/errors';
 import { useToast } from '@/hooks/useToast';
-import {
-  hasAnalysisStartPayloadConsumed,
-  markAnalysisStartPayloadConsumed,
-  readAnalysisStartPayload,
-  type AnalysisStartPayload,
-} from '@/lib/analysisStartPayload';
+import { markAnalysisStartPayloadConsumed } from '@/lib/analysisStartPayload';
 import type { PromptInputValue } from '../../_components/PromptInput';
 import { createUpdateCriteriaRequest } from '../_adapters/normalizeCriteria';
 import type { DataTableColumn } from '../_components/DataTablePreview';
-import type {
-  CriteriaEditValues,
-  CriteriaViewModel,
-  QuestionResultViewModel,
-} from '../_models/analysisViewModels';
+import type { CriteriaEditValues } from '../_models/analysisViewModels';
+import {
+  useAnalysisChatMessages,
+  type CriteriaInitialMode,
+} from './useAnalysisChatMessages';
 import {
   analysisChatFlowReducer,
   initialAnalysisChatFlowState,
 } from './useAnalysisChatFlow';
+import { useAnalysisRouteParams } from './useAnalysisRouteParams';
+import { useAnalysisStartPayload } from './useAnalysisStartPayload';
 import { useCriteriaPhase } from './useCriteriaPhase';
 import { useResultPhase } from './useResultPhase';
 import { useSummaryPhase } from './useSummaryPhase';
 
-export type CriteriaInitialMode = 'normal' | 'edit';
-
-export type ChatMessage =
-  | {
-      id: string;
-      role: 'user';
-      content: string;
-      fileName?: string | null;
-    }
-  | {
-      id: string;
-      role: 'bot';
-      kind: 'criteria';
-      criteria: CriteriaViewModel;
-      initialMode?: CriteriaInitialMode;
-    }
-  | {
-      id: string;
-      role: 'bot';
-      kind: 'verification';
-      result: QuestionResultViewModel;
-    }
-  | {
-      id: string;
-      role: 'bot';
-      kind: 'notice';
-      content: string;
-      tone?: 'default' | 'error';
-    };
+export type {
+  ChatMessage,
+  CriteriaInitialMode,
+} from './useAnalysisChatMessages';
 
 const DEFAULT_PROMPT = 'CSV 파일을 분석해 주세요';
 const STATUS_POLL_INTERVAL_MS = 1500;
@@ -78,13 +49,6 @@ const UPDATE_CRITERIA_ERROR_MESSAGE =
   '분석 기준을 확정하지 못했어요. 잠시 후 다시 시도해 주세요.';
 const GET_RESULT_ERROR_MESSAGE =
   '최종 분석 결과를 불러오지 못했어요. 잠시 후 다시 시도해 주세요.';
-
-function parsePositiveNumber(value: string | null | undefined) {
-  if (!value) return null;
-
-  const parsed = Number(value);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
-}
 
 function compactStrings(values: Array<string | null | undefined>) {
   return values
@@ -113,10 +77,6 @@ function createPreviewTable(preview?: FilePreview | null) {
   return { columns, rows };
 }
 
-function createMessageId(prefix: string) {
-  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-}
-
 type UseAnalysisChatParams = {
   hasAccessToken: boolean;
   routeConversationId: string;
@@ -126,34 +86,27 @@ export function useAnalysisChat({
   hasAccessToken,
   routeConversationId,
 }: UseAnalysisChatParams) {
-  const searchParams = useSearchParams();
-  const conversationId = parsePositiveNumber(routeConversationId);
-  const analysisFlowId = parsePositiveNumber(
-    searchParams.get('analysisFlowId'),
-  );
-  const dataSourceId = parsePositiveNumber(searchParams.get('dataSourceId'));
-  const routeReady = conversationId !== null && analysisFlowId !== null;
-
-  const [startPayload, setStartPayload] = useState<AnalysisStartPayload>(
-    () => ({
-      prompt: DEFAULT_PROMPT,
-      fileName: null,
-    }),
-  );
-  const [messages, setMessages] = useState<ChatMessage[]>(() => [
-    {
-      id: 'init-user',
-      role: 'user',
-      content: DEFAULT_PROMPT,
-      fileName: null,
-    },
-  ]);
+  const { analysisFlowId, conversationId, dataSourceId, routeReady } =
+    useAnalysisRouteParams(routeConversationId);
   const { toast, showToast } = useToast();
   const [flow, dispatchFlow] = useReducer(
     analysisChatFlowReducer,
     initialAnalysisChatFlowState,
   );
-  const readStartPayloadConversationIdRef = useRef<number | null>(null);
+  const { fileName, initialPrompt } = useAnalysisStartPayload({
+    conversationId,
+    defaultPrompt: DEFAULT_PROMPT,
+    dispatchFlow,
+  });
+  const {
+    appendCriteriaMessage,
+    appendNotice,
+    appendResultMessage,
+    appendUserQuestion,
+    initialMessage,
+    restMessages,
+    updateInitialMessage,
+  } = useAnalysisChatMessages(DEFAULT_PROMPT);
   const {
     canAutoStartInitialQuestion,
     criteriaSubmissionLocked,
@@ -161,9 +114,6 @@ export function useAnalysisChat({
     hasStartedInitialQuestion,
     questionSubmissionLocked,
   } = flow;
-
-  const initialPrompt = startPayload.prompt || DEFAULT_PROMPT;
-  const fileName = startPayload.fileName ?? null;
 
   const dataSourceQuery = useQuery({
     queryKey: dataSourceKeys.detail(dataSourceId ?? 0),
@@ -204,22 +154,6 @@ export function useAnalysisChat({
     statusPollIntervalMs: STATUS_POLL_INTERVAL_MS,
   });
 
-  const appendNotice = useCallback(
-    (content: string, tone: 'default' | 'error' = 'default') => {
-      setMessages((prev) => [
-        ...prev,
-        {
-          id: createMessageId('notice'),
-          role: 'bot',
-          kind: 'notice',
-          content,
-          tone,
-        },
-      ]);
-    },
-    [setMessages],
-  );
-
   const startQuestion = useCallback(
     (
       question: string,
@@ -240,14 +174,7 @@ export function useAnalysisChat({
       dispatchFlow({ type: 'question-submission-started' });
 
       if (appendUserMessage) {
-        setMessages((prev) => [
-          ...prev,
-          {
-            id: createMessageId('user'),
-            role: 'user',
-            content: normalizedQuestion,
-          },
-        ]);
+        appendUserQuestion(normalizedQuestion);
       }
 
       mutateQuestionAnalysis(
@@ -260,16 +187,7 @@ export function useAnalysisChat({
         {
           onSuccess: (criteria, variables) => {
             dispatchFlow({ type: 'question-submission-finished' });
-            setMessages((prev) => [
-              ...prev,
-              {
-                id: `criteria-${criteria.messageId}`,
-                role: 'bot',
-                kind: 'criteria',
-                criteria,
-                initialMode: variables.initialMode,
-              },
-            ]);
+            appendCriteriaMessage(criteria, variables.initialMode);
           },
           onError: (error) => {
             dispatchFlow({ type: 'question-submission-finished' });
@@ -285,12 +203,13 @@ export function useAnalysisChat({
     },
     [
       analysisFlowId,
+      appendCriteriaMessage,
       appendNotice,
+      appendUserQuestion,
       conversationId,
       dispatchFlow,
       mutateQuestionAnalysis,
       questionSubmissionLocked,
-      setMessages,
       showToast,
     ],
   );
@@ -372,18 +291,7 @@ export function useAnalysisChat({
             {
               onSuccess: (result) => {
                 dispatchFlow({ type: 'criteria-submission-finished' });
-                setMessages((prev) => [
-                  ...prev,
-                  {
-                    id:
-                      result.resultId === null
-                        ? createMessageId('result')
-                        : `result-${result.resultId}`,
-                    role: 'bot',
-                    kind: 'verification',
-                    result,
-                  },
-                ]);
+                appendResultMessage(result);
               },
               onError: (error) => {
                 dispatchFlow({ type: 'criteria-submission-finished' });
@@ -411,64 +319,14 @@ export function useAnalysisChat({
   }
 
   useEffect(() => {
-    if (
-      conversationId !== null &&
-      readStartPayloadConversationIdRef.current === conversationId
-    ) {
-      return;
-    }
-
-    dispatchFlow({ type: 'start-payload-loading' });
-
-    const timer = window.setTimeout(() => {
-      if (conversationId === null) {
-        setStartPayload({ prompt: DEFAULT_PROMPT, fileName: null });
-        dispatchFlow({
-          type: 'start-payload-resolved',
-          canAutoStartInitialQuestion: false,
-        });
-        return;
-      }
-
-      readStartPayloadConversationIdRef.current = conversationId;
-
-      const storedPayload = readAnalysisStartPayload(conversationId);
-      const canAutoStart =
-        storedPayload !== null &&
-        !hasAnalysisStartPayloadConsumed(conversationId);
-
-      setStartPayload({
-        prompt: storedPayload?.prompt || DEFAULT_PROMPT,
-        fileName: storedPayload?.fileName ?? null,
-      });
-      dispatchFlow({
-        type: 'start-payload-resolved',
-        canAutoStartInitialQuestion: canAutoStart,
-      });
-    }, 0);
-
-    return () => window.clearTimeout(timer);
-  }, [conversationId]);
-
-  useEffect(() => {
     if (!hasResolvedStartPayload) return;
 
     const timer = window.setTimeout(() => {
-      setMessages((prev) =>
-        prev.map((message) =>
-          message.id === 'init-user' && message.role === 'user'
-            ? {
-                ...message,
-                content: initialPrompt,
-                fileName,
-              }
-            : message,
-        ),
-      );
+      updateInitialMessage(initialPrompt, fileName);
     }, 0);
 
     return () => window.clearTimeout(timer);
-  }, [fileName, hasResolvedStartPayload, initialPrompt]);
+  }, [fileName, hasResolvedStartPayload, initialPrompt, updateInitialMessage]);
 
   useEffect(() => {
     if (
@@ -529,8 +387,6 @@ export function useAnalysisChat({
     criteriaSubmissionLocked ||
     updateCriteriaMutation.isPending ||
     resultAnalysisMutation.isPending;
-  const [initialMessage, ...restMessages] = messages;
-
   return {
     analyzingMessage,
     criteriaSubmitting,

--- a/apps/fe/src/app/(main)/analysis/[id]/_hooks/useAnalysisChatMessages.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_hooks/useAnalysisChatMessages.ts
@@ -1,0 +1,139 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import type {
+  CriteriaViewModel,
+  QuestionResultViewModel,
+} from '../_models/analysisViewModels';
+
+export type CriteriaInitialMode = 'normal' | 'edit';
+
+export type ChatMessage =
+  | {
+      id: string;
+      role: 'user';
+      content: string;
+      fileName?: string | null;
+    }
+  | {
+      id: string;
+      role: 'bot';
+      kind: 'criteria';
+      criteria: CriteriaViewModel;
+      initialMode?: CriteriaInitialMode;
+    }
+  | {
+      id: string;
+      role: 'bot';
+      kind: 'verification';
+      result: QuestionResultViewModel;
+    }
+  | {
+      id: string;
+      role: 'bot';
+      kind: 'notice';
+      content: string;
+      tone?: 'default' | 'error';
+    };
+
+function createMessageId(prefix: string) {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+export function useAnalysisChatMessages(defaultPrompt: string) {
+  const [messages, setMessages] = useState<ChatMessage[]>(() => [
+    {
+      id: 'init-user',
+      role: 'user',
+      content: defaultPrompt,
+      fileName: null,
+    },
+  ]);
+
+  const appendNotice = useCallback(
+    (content: string, tone: 'default' | 'error' = 'default') => {
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: createMessageId('notice'),
+          role: 'bot',
+          kind: 'notice',
+          content,
+          tone,
+        },
+      ]);
+    },
+    [],
+  );
+
+  const appendUserQuestion = useCallback((content: string) => {
+    setMessages((prev) => [
+      ...prev,
+      {
+        id: createMessageId('user'),
+        role: 'user',
+        content,
+      },
+    ]);
+  }, []);
+
+  const appendCriteriaMessage = useCallback(
+    (criteria: CriteriaViewModel, initialMode?: CriteriaInitialMode) => {
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: `criteria-${criteria.messageId}`,
+          role: 'bot',
+          kind: 'criteria',
+          criteria,
+          initialMode,
+        },
+      ]);
+    },
+    [],
+  );
+
+  const appendResultMessage = useCallback((result: QuestionResultViewModel) => {
+    setMessages((prev) => [
+      ...prev,
+      {
+        id:
+          result.resultId === null
+            ? createMessageId('result')
+            : `result-${result.resultId}`,
+        role: 'bot',
+        kind: 'verification',
+        result,
+      },
+    ]);
+  }, []);
+
+  const updateInitialMessage = useCallback(
+    (content: string, fileName: string | null) => {
+      setMessages((prev) =>
+        prev.map((message) =>
+          message.id === 'init-user' && message.role === 'user'
+            ? {
+                ...message,
+                content,
+                fileName,
+              }
+            : message,
+        ),
+      );
+    },
+    [],
+  );
+
+  const [initialMessage, ...restMessages] = messages;
+
+  return {
+    appendCriteriaMessage,
+    appendNotice,
+    appendResultMessage,
+    appendUserQuestion,
+    initialMessage,
+    restMessages,
+    updateInitialMessage,
+  };
+}

--- a/apps/fe/src/app/(main)/analysis/[id]/_hooks/useAnalysisRouteParams.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_hooks/useAnalysisRouteParams.ts
@@ -1,0 +1,26 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+
+function parsePositiveNumber(value: string | null | undefined) {
+  if (!value) return null;
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+export function useAnalysisRouteParams(routeConversationId: string) {
+  const searchParams = useSearchParams();
+  const conversationId = parsePositiveNumber(routeConversationId);
+  const analysisFlowId = parsePositiveNumber(
+    searchParams.get('analysisFlowId'),
+  );
+  const dataSourceId = parsePositiveNumber(searchParams.get('dataSourceId'));
+
+  return {
+    analysisFlowId,
+    conversationId,
+    dataSourceId,
+    routeReady: conversationId !== null && analysisFlowId !== null,
+  };
+}

--- a/apps/fe/src/app/(main)/analysis/[id]/_hooks/useAnalysisStartPayload.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_hooks/useAnalysisStartPayload.ts
@@ -1,0 +1,75 @@
+'use client';
+
+import { useEffect, useRef, useState, type Dispatch } from 'react';
+import {
+  hasAnalysisStartPayloadConsumed,
+  readAnalysisStartPayload,
+  type AnalysisStartPayload,
+} from '@/lib/analysisStartPayload';
+import type { AnalysisChatFlowAction } from './useAnalysisChatFlow';
+
+type UseAnalysisStartPayloadParams = {
+  conversationId: number | null;
+  defaultPrompt: string;
+  dispatchFlow: Dispatch<AnalysisChatFlowAction>;
+};
+
+export function useAnalysisStartPayload({
+  conversationId,
+  defaultPrompt,
+  dispatchFlow,
+}: UseAnalysisStartPayloadParams) {
+  const readStartPayloadConversationIdRef = useRef<number | null>(null);
+  const [startPayload, setStartPayload] = useState<AnalysisStartPayload>(
+    () => ({
+      prompt: defaultPrompt,
+      fileName: null,
+    }),
+  );
+
+  useEffect(() => {
+    if (
+      conversationId !== null &&
+      readStartPayloadConversationIdRef.current === conversationId
+    ) {
+      return;
+    }
+
+    dispatchFlow({ type: 'start-payload-loading' });
+
+    const timer = window.setTimeout(() => {
+      if (conversationId === null) {
+        setStartPayload({ prompt: defaultPrompt, fileName: null });
+        dispatchFlow({
+          type: 'start-payload-resolved',
+          canAutoStartInitialQuestion: false,
+        });
+        return;
+      }
+
+      readStartPayloadConversationIdRef.current = conversationId;
+
+      const storedPayload = readAnalysisStartPayload(conversationId);
+      const canAutoStart =
+        storedPayload !== null &&
+        !hasAnalysisStartPayloadConsumed(conversationId);
+
+      setStartPayload({
+        prompt: storedPayload?.prompt || defaultPrompt,
+        fileName: storedPayload?.fileName ?? null,
+      });
+      dispatchFlow({
+        type: 'start-payload-resolved',
+        canAutoStartInitialQuestion: canAutoStart,
+      });
+    }, 0);
+
+    return () => window.clearTimeout(timer);
+  }, [conversationId, defaultPrompt, dispatchFlow]);
+
+  return {
+    fileName: startPayload.fileName ?? null,
+    initialPrompt: startPayload.prompt || defaultPrompt,
+    startPayload,
+  };
+}

--- a/apps/fe/src/app/(main)/analysis/[id]/_hooks/useCriteriaPhase.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_hooks/useCriteriaPhase.ts
@@ -11,7 +11,7 @@ import {
 } from '@/apis/analysis';
 import type { CriteriaInitialMode } from './useAnalysisChat';
 import { normalizeCriteria } from '../_adapters/normalizeCriteria';
-import { useJobPoller } from './useJobPoller';
+import { createPolledFetcher, useJobPoller } from './useJobPoller';
 
 export type QuestionAnalysisVariables = {
   initialMode: CriteriaInitialMode;
@@ -46,6 +46,11 @@ export function useCriteriaPhase({
       timeoutMs: questionAnalysisTimeoutMs,
     },
   );
+  const getCriteriaAfterPolling = createPolledFetcher(
+    waitForCriteriaSuccess,
+    async (params: QuestionCriteriaParams) =>
+      normalizeCriteria(await getCriteria(params)),
+  );
 
   const questionAnalysisMutation = useMutation({
     mutationFn: async ({
@@ -66,8 +71,7 @@ export function useCriteriaPhase({
         messageId: createdQuestion.messageId,
       };
 
-      await waitForCriteriaSuccess(criteriaParams);
-      return normalizeCriteria(await getCriteria(criteriaParams));
+      return getCriteriaAfterPolling(criteriaParams);
     },
   });
 

--- a/apps/fe/src/app/(main)/analysis/[id]/_hooks/useJobPoller.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_hooks/useJobPoller.ts
@@ -60,3 +60,13 @@ export function useJobPoller<TParams>(
     [errorMessage, fetchStatus, intervalMs, timeoutMs],
   );
 }
+
+export function createPolledFetcher<TParams, TResult>(
+  waitForSuccess: (params: TParams) => Promise<void>,
+  fetchResult: (params: TParams) => Promise<TResult>,
+) {
+  return async (params: TParams) => {
+    await waitForSuccess(params);
+    return fetchResult(params);
+  };
+}

--- a/apps/fe/src/app/(main)/analysis/[id]/_hooks/useResultPhase.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_hooks/useResultPhase.ts
@@ -7,7 +7,7 @@ import {
   type QuestionResultParams,
 } from '@/apis/analysis';
 import { normalizeResult } from '../_adapters/normalizeResult';
-import { useJobPoller } from './useJobPoller';
+import { createPolledFetcher, useJobPoller } from './useJobPoller';
 
 export type ResultAnalysisVariables = {
   targetConversationId: number;
@@ -35,6 +35,11 @@ export function useResultPhase({
       timeoutMs: resultAnalysisTimeoutMs,
     },
   );
+  const getResultAfterPolling = createPolledFetcher(
+    waitForResultSuccess,
+    async (params: QuestionResultParams) =>
+      normalizeResult(await getResult(params)),
+  );
 
   return useMutation({
     mutationFn: async ({
@@ -50,8 +55,7 @@ export function useResultPhase({
         analysisCriteriaId,
       };
 
-      await waitForResultSuccess(resultParams);
-      return normalizeResult(await getResult(resultParams));
+      return getResultAfterPolling(resultParams);
     },
   });
 }


### PR DESCRIPTION
﻿## 요약
- `useAnalysisChat`의 route param 파싱, 시작 payload 처리, 메시지 상태 관리를 별도 훅으로 분리했습니다.
- criteria/result phase의 “poll 성공 대기 후 fetch” 패턴을 `createPolledFetcher`로 정리했습니다.
- page가 소비하는 `useAnalysisChat` 반환 shape은 유지했습니다.

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `eslint .`
  - `vitest run --project unit`
  - `NEXT_PUBLIC_API_URL=http://localhost:8080 next build --webpack`

## 스킵한 항목
- `ToastPortal` 복붙 제거: 현재 `dev` 기준 이미 `ToastPortal`로 정리되어 있어 추가 수정 없음
- `data/page.tsx` 목록 훅/행 분리: 현재 `dev` 기준 `useDataSourceList`, `useUploadDataSource`, `useDeleteDataSources`, `DataSourceRow`가 이미 적용되어 있어 추가 수정 없음
- `_adapters/*` 경로 없음 판단: 현재 `dev`에는 `_adapters`가 존재하므로 stale 판단을 취소하고, 아직 중복으로 남은 항목만 앞선 PR에서 처리함

## 스크린샷/로그 (선택)
- 훅 경계 정리라 별도 첨부 없음

## 롤백/리스크
- 리스크 요인: 분석 채팅 자동 시작, 기준 확정, 결과 append 흐름 회귀
- 롤백 방법: 이 PR revert

## 관련 이슈
Closes #193 #206 #213 #215
