### PR TITLE
refactor: 리팩토링 백로그 정리

### DIFF
--- a/apps/fe/src/apis/dataSourceRepository.ts
+++ b/apps/fe/src/apis/dataSourceRepository.ts
@@ -4,6 +4,7 @@ import {
   getDataSource as getDataSourceRequest,
   getDataSources as getDataSourcesRequest,
   type GetDataSourceListParams,
+  type GetFileResponse,
 } from './datasource';
 import {
   getMockDataSource,
@@ -11,6 +12,47 @@ import {
   isMockDataSourceId,
   withMockDataSource,
 } from './mockDataSource';
+
+type DataSourceDetailReader = (
+  dataSourceId: number,
+) => Promise<GetFileResponse>;
+type DataSourcesDeleteRequest = (dataSourceIds: number[]) => Promise<void>;
+type DataSourceDeleteRequest = (dataSourceId: number) => Promise<void>;
+
+function getServerDataSourceIds(dataSourceIds: number[]) {
+  return dataSourceIds.filter(
+    (dataSourceId) => !isMockDataSourceId(dataSourceId),
+  );
+}
+
+async function getMockAwareDataSource(
+  dataSourceId: number,
+  readDataSource: DataSourceDetailReader,
+) {
+  return isMockDataSourceId(dataSourceId)
+    ? getMockDataSource()
+    : readDataSource(dataSourceId);
+}
+
+async function deleteMockAwareDataSources(
+  dataSourceIds: number[],
+  deleteDataSources: DataSourcesDeleteRequest,
+) {
+  const serverDataSourceIds = getServerDataSourceIds(dataSourceIds);
+
+  if (serverDataSourceIds.length === 0) return;
+
+  return deleteDataSources(serverDataSourceIds);
+}
+
+async function deleteMockAwareDataSource(
+  dataSourceId: number,
+  deleteDataSource: DataSourceDeleteRequest,
+) {
+  if (isMockDataSourceId(dataSourceId)) return;
+
+  return deleteDataSource(dataSourceId);
+}
 
 export async function getDataSources(params: GetDataSourceListParams) {
   try {
@@ -22,25 +64,13 @@ export async function getDataSources(params: GetDataSourceListParams) {
 }
 
 export async function getDataSource(dataSourceId: number) {
-  if (isMockDataSourceId(dataSourceId)) {
-    return getMockDataSource();
-  }
-
-  return getDataSourceRequest(dataSourceId);
+  return getMockAwareDataSource(dataSourceId, getDataSourceRequest);
 }
 
 export async function deleteDataSources(dataSourceIds: number[]) {
-  const serverDataSourceIds = dataSourceIds.filter(
-    (dataSourceId) => !isMockDataSourceId(dataSourceId),
-  );
-
-  if (serverDataSourceIds.length === 0) return;
-
-  return deleteDataSourcesRequest(serverDataSourceIds);
+  return deleteMockAwareDataSources(dataSourceIds, deleteDataSourcesRequest);
 }
 
 export async function deleteDataSource(dataSourceId: number) {
-  if (isMockDataSourceId(dataSourceId)) return;
-
-  return deleteDataSourceRequest(dataSourceId);
+  return deleteMockAwareDataSource(dataSourceId, deleteDataSourceRequest);
 }

--- a/apps/fe/src/app/(main)/_components/DataSourceSearchInput.tsx
+++ b/apps/fe/src/app/(main)/_components/DataSourceSearchInput.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import SearchIcon from '@/assets/icons/search.svg';
+
+const SEARCH_PARAM_KEY = 'q';
+const SEARCH_DEBOUNCE_MS = 250;
+
+export default function DataSourceSearchInput({
+  pathname,
+}: {
+  pathname: string;
+}) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const searchParamsString = searchParams.toString();
+  const querySearchValue = searchParams.get(SEARCH_PARAM_KEY) ?? '';
+  const [searchDraft, setSearchDraft] = useState(() => ({
+    sourceQueryValue: querySearchValue,
+    value: querySearchValue,
+  }));
+  const searchValue =
+    searchDraft.sourceQueryValue === querySearchValue
+      ? searchDraft.value
+      : querySearchValue;
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      const params = new URLSearchParams(searchParamsString);
+      const trimmedValue = searchValue.trim();
+
+      if (trimmedValue) {
+        params.set(SEARCH_PARAM_KEY, trimmedValue);
+      } else {
+        params.delete(SEARCH_PARAM_KEY);
+      }
+
+      const queryString = params.toString();
+      const nextUrl = queryString ? `${pathname}?${queryString}` : pathname;
+      const currentUrl = searchParamsString
+        ? `${pathname}?${searchParamsString}`
+        : pathname;
+
+      if (currentUrl !== nextUrl) {
+        router.replace(nextUrl, { scroll: false });
+      }
+    }, SEARCH_DEBOUNCE_MS);
+
+    return () => window.clearTimeout(timer);
+  }, [pathname, router, searchParamsString, searchValue]);
+
+  return (
+    <div className="flex items-center gap-8 rounded-full border border-gray-300 bg-white px-12 py-8">
+      <SearchIcon aria-hidden className="icon-16 text-gray-500" />
+      <input
+        type="search"
+        aria-label="데이터 소스 검색"
+        value={searchValue}
+        onChange={(event) =>
+          setSearchDraft({
+            sourceQueryValue: querySearchValue,
+            value: event.target.value,
+          })
+        }
+        placeholder="찾고 싶은 데이터 소스를 입력해주세요."
+        className="w-[26rem] bg-transparent text-body4 text-gray-900 outline-none placeholder:text-gray-500"
+      />
+    </div>
+  );
+}

--- a/apps/fe/src/app/(main)/_components/UserProfileSlot.tsx
+++ b/apps/fe/src/app/(main)/_components/UserProfileSlot.tsx
@@ -1,0 +1,57 @@
+import type { CSSProperties } from 'react';
+import type { GetUserInfoResponse } from '@/apis/user';
+
+function getUserInitial(user: GetUserInfoResponse | undefined) {
+  return user?.name?.trim().slice(0, 1).toUpperCase() || 'U';
+}
+
+function getProfileImageStyle(
+  profileImageUrl: string | null | undefined,
+): CSSProperties | undefined {
+  const imageUrl = profileImageUrl?.trim();
+  if (!imageUrl) return undefined;
+
+  return {
+    backgroundImage: `url("${imageUrl.replace(/["\\]/g, '\\$&')}")`,
+  };
+}
+
+export default function UserProfileSlot({
+  user,
+  isLoading,
+  isError,
+}: {
+  user: GetUserInfoResponse | undefined;
+  isLoading: boolean;
+  isError: boolean;
+}) {
+  if (isLoading) {
+    return (
+      <span
+        aria-label="Loading profile"
+        className="inline-flex h-36 w-36 animate-pulse rounded-full bg-gray-300"
+      />
+    );
+  }
+
+  const profileImageStyle = getProfileImageStyle(user?.profileImageUrl);
+
+  return (
+    <span
+      aria-label={
+        isError
+          ? 'Profile unavailable'
+          : user?.name
+            ? `${user.name} profile`
+            : 'Profile'
+      }
+      title={isError ? undefined : user?.email}
+      style={profileImageStyle}
+      className={`inline-flex h-36 w-36 items-center justify-center overflow-hidden rounded-full bg-gray-300 text-body3 font-semibold text-gray-700 ${
+        profileImageStyle ? 'bg-cover bg-center text-transparent' : ''
+      }`.trim()}
+    >
+      {getUserInitial(user)}
+    </span>
+  );
+}

--- a/apps/fe/src/app/(main)/analysis/[id]/_components/AnalysisActionButtons.tsx
+++ b/apps/fe/src/app/(main)/analysis/[id]/_components/AnalysisActionButtons.tsx
@@ -1,0 +1,38 @@
+type AnalysisActionButtonsProps = {
+  editLabel?: string;
+  continueLabel?: string;
+  disabled?: boolean;
+  onEdit?: () => void;
+  onContinue?: () => void;
+  className?: string;
+};
+
+export default function AnalysisActionButtons({
+  editLabel = '수정하기',
+  continueLabel = '이 기준으로 계속 할게요',
+  disabled = false,
+  onEdit,
+  onContinue,
+  className = '',
+}: AnalysisActionButtonsProps) {
+  return (
+    <div className={`flex justify-end gap-8 ${className}`.trim()}>
+      <button
+        type="button"
+        onClick={onEdit}
+        disabled={disabled}
+        className="rounded-20 bg-gray-300 px-16 py-8 text-body2 text-gray-700 transition-colors hover:bg-gray-400 disabled:cursor-not-allowed disabled:text-gray-500"
+      >
+        {editLabel}
+      </button>
+      <button
+        type="button"
+        onClick={onContinue}
+        disabled={disabled}
+        className="rounded-20 bg-orange-500 px-16 py-8 text-body2 text-white transition-colors hover:bg-orange-600 disabled:cursor-not-allowed disabled:bg-gray-400 disabled:text-gray-600"
+      >
+        {continueLabel}
+      </button>
+    </div>
+  );
+}

--- a/apps/fe/src/app/(main)/analysis/[id]/_components/AnalysisCard.tsx
+++ b/apps/fe/src/app/(main)/analysis/[id]/_components/AnalysisCard.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react';
+
+type AnalysisCardProps = {
+  children: ReactNode;
+  className?: string;
+};
+
+export default function AnalysisCard({
+  children,
+  className = 'gap-16',
+}: AnalysisCardProps) {
+  return (
+    <div
+      className={`flex w-full flex-col rounded-20 bg-white p-24 shadow-[0_0.2rem_1.2rem_rgba(0,0,0,0.06)] ${className}`.trim()}
+    >
+      {children}
+    </div>
+  );
+}

--- a/apps/fe/src/app/(main)/analysis/[id]/_components/AnalysisResult.tsx
+++ b/apps/fe/src/app/(main)/analysis/[id]/_components/AnalysisResult.tsx
@@ -3,6 +3,8 @@
 import { useState } from 'react';
 import ArrowDownIcon from '@/assets/icons/arrow-down.svg';
 import type { SummaryViewModel } from '../_models/analysisViewModels';
+import AnalysisActionButtons from './AnalysisActionButtons';
+import AnalysisCard from './AnalysisCard';
 import AnalysisWarningList from './AnalysisWarningList';
 
 export type AnalysisResultProps = {
@@ -24,7 +26,7 @@ export default function AnalysisResult({
   const hasWarnings = summary.warnings.length > 0;
 
   return (
-    <div className="flex w-full flex-col gap-16 rounded-20 bg-white p-24 shadow-[0_0.2rem_1.2rem_rgba(0,0,0,0.06)]">
+    <AnalysisCard>
       <div className="flex flex-col gap-8">
         <p className="text-body2 text-gray-900">{summary.title}</p>
         <p className="text-body2 text-gray-900">
@@ -105,27 +107,17 @@ export default function AnalysisResult({
             listClassName="ml-20 list-disc text-body2 text-gray-900"
           />
           {warningActions && (
-            <div className="mt-8 flex justify-end gap-8">
-              <button
-                type="button"
-                onClick={warningActions.onEdit}
-                disabled={warningActions.disabled}
-                className="rounded-20 bg-gray-300 px-16 py-8 text-body2 text-gray-700 transition-colors hover:bg-gray-400 disabled:cursor-not-allowed disabled:text-gray-500"
-              >
-                {warningActions.editLabel ?? '수정하기'}
-              </button>
-              <button
-                type="button"
-                onClick={warningActions.onContinue}
-                disabled={warningActions.disabled}
-                className="rounded-20 bg-orange-500 px-16 py-8 text-body2 text-white transition-colors hover:bg-orange-600 disabled:cursor-not-allowed disabled:bg-gray-400 disabled:text-gray-600"
-              >
-                {warningActions.continueLabel ?? '이 기준으로 계속 할게요'}
-              </button>
-            </div>
+            <AnalysisActionButtons
+              className="mt-8"
+              editLabel={warningActions.editLabel}
+              continueLabel={warningActions.continueLabel}
+              disabled={warningActions.disabled}
+              onEdit={warningActions.onEdit}
+              onContinue={warningActions.onContinue}
+            />
           )}
         </div>
       )}
-    </div>
+    </AnalysisCard>
   );
 }

--- a/apps/fe/src/app/(main)/analysis/[id]/_components/QuestionAnalysisResult.tsx
+++ b/apps/fe/src/app/(main)/analysis/[id]/_components/QuestionAnalysisResult.tsx
@@ -8,6 +8,8 @@ import type {
   CriteriaViewModel,
 } from '../_models/analysisViewModels';
 import { uniqueStrings as uniqueOptions } from '../_utils/stringList';
+import AnalysisActionButtons from './AnalysisActionButtons';
+import AnalysisCard from './AnalysisCard';
 import AnalysisWarningList from './AnalysisWarningList';
 import CriterionSelect from './CriterionSelect';
 
@@ -184,7 +186,7 @@ export default function QuestionAnalysisResult({
   };
 
   return (
-    <div className="flex w-full flex-col gap-16 rounded-20 bg-white p-24 shadow-[0_0.2rem_1.2rem_rgba(0,0,0,0.06)]">
+    <AnalysisCard>
       <div className="flex flex-col gap-4">
         <p className="text-body3 font-semibold text-gray-900">
           질문 분석이 완료되었어요.
@@ -246,46 +248,23 @@ export default function QuestionAnalysisResult({
       <AnalysisWarningList warnings={criteria.warnings} />
 
       {mode === 'normal' ? (
-        <div className="flex justify-end gap-8">
-          <button
-            type="button"
-            onClick={handleEdit}
-            disabled={isSubmitting}
-            className="rounded-20 bg-gray-300 px-16 py-8 text-body2 text-gray-700 transition-colors hover:bg-gray-400 disabled:cursor-not-allowed disabled:text-gray-500"
-          >
-            수정하기
-          </button>
-          <button
-            type="button"
-            onClick={handleContinue}
-            disabled={isSubmitting}
-            className="rounded-20 bg-orange-500 px-16 py-8 text-body2 text-white transition-colors hover:bg-orange-600 disabled:cursor-not-allowed disabled:bg-gray-400 disabled:text-gray-600"
-          >
-            {isSubmitting ? '확정 중' : '이 기준으로 계속 할게요'}
-          </button>
-        </div>
+        <AnalysisActionButtons
+          disabled={isSubmitting}
+          continueLabel={isSubmitting ? '확정 중' : '이 기준으로 계속 할게요'}
+          onEdit={handleEdit}
+          onContinue={handleContinue}
+        />
       ) : (
         <div className="flex flex-col gap-16">
-          <div className="flex justify-end gap-8">
-            <button
-              type="button"
-              onClick={handleCancelEdit}
-              disabled={isSubmitting}
-              className="rounded-20 bg-gray-300 px-16 py-8 text-body2 text-gray-700 transition-colors hover:bg-gray-400 disabled:cursor-not-allowed disabled:text-gray-500"
-            >
-              취소
-            </button>
-            <button
-              type="button"
-              onClick={handleContinue}
-              disabled={isSubmitting}
-              className="rounded-20 bg-orange-500 px-16 py-8 text-body2 text-white transition-colors hover:bg-orange-600 disabled:cursor-not-allowed disabled:bg-gray-400 disabled:text-gray-600"
-            >
-              {isSubmitting ? '확정 중' : '이 기준으로 계속 할게요'}
-            </button>
-          </div>
+          <AnalysisActionButtons
+            editLabel="취소"
+            disabled={isSubmitting}
+            continueLabel={isSubmitting ? '확정 중' : '이 기준으로 계속 할게요'}
+            onEdit={handleCancelEdit}
+            onContinue={handleContinue}
+          />
         </div>
       )}
-    </div>
+    </AnalysisCard>
   );
 }

--- a/apps/fe/src/app/(main)/analysis/[id]/_components/VerificationResult.tsx
+++ b/apps/fe/src/app/(main)/analysis/[id]/_components/VerificationResult.tsx
@@ -17,6 +17,7 @@ import type {
   BarChartViewModel,
   QuestionResultViewModel,
 } from '../_models/analysisViewModels';
+import AnalysisCard from './AnalysisCard';
 import AnalysisWarningList from './AnalysisWarningList';
 
 export type VerificationResultProps = {
@@ -93,7 +94,7 @@ export default function VerificationResult({
   const hasMultipleSeries = seriesKeys.length > 1;
 
   return (
-    <div className="flex w-full flex-col gap-20 rounded-20 bg-white p-24 shadow-[0_0.2rem_1.2rem_rgba(0,0,0,0.06)]">
+    <AnalysisCard className="gap-20">
       <div className="flex flex-col gap-4">
         <p className="text-body3 font-semibold text-gray-900">{result.title}</p>
         <p className="text-body2 text-gray-900">{result.insight}</p>
@@ -206,6 +207,6 @@ export default function VerificationResult({
       </div>
 
       <AnalysisWarningList warnings={result.warnings} />
-    </div>
+    </AnalysisCard>
   );
 }

--- a/apps/fe/src/app/(main)/layout.tsx
+++ b/apps/fe/src/app/(main)/layout.tsx
@@ -1,15 +1,14 @@
 'use client';
 
-import { Suspense, useEffect, useState, type CSSProperties } from 'react';
+import { Suspense, type ReactNode } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { logoutAuth } from '@/apis/auth';
-import { userKeys, type GetUserInfoResponse } from '@/apis/user';
+import { userKeys } from '@/apis/user';
 import { Header, type NavItem } from '@/components';
 import FileIcon from '@/assets/icons/file.svg';
 import GTapIcon from '@/assets/icons/G-tap.svg';
 import GHistoryIcon from '@/assets/icons/G-history.svg';
-import SearchIcon from '@/assets/icons/search.svg';
 import {
   clearAuthTokens,
   getRefreshToken,
@@ -22,6 +21,8 @@ import {
 } from '@/lib/authRedirect';
 import { useMyInfo } from '@/hooks/useMyInfo';
 import { useAuthSession } from '@/providers/AuthProvider';
+import DataSourceSearchInput from './_components/DataSourceSearchInput';
+import UserProfileSlot from './_components/UserProfileSlot';
 
 const NAV_ITEMS: NavItem[] = [
   { label: '파일분석', href: '/analysis', Icon: FileIcon },
@@ -29,128 +30,7 @@ const NAV_ITEMS: NavItem[] = [
   { label: '히스토리', href: '/history', Icon: GHistoryIcon },
 ];
 
-const SEARCH_PARAM_KEY = 'q';
-const SEARCH_DEBOUNCE_MS = 250;
-function DataSourceSearchInput({ pathname }: { pathname: string }) {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const searchParamsString = searchParams.toString();
-  const querySearchValue = searchParams.get(SEARCH_PARAM_KEY) ?? '';
-  const [searchDraft, setSearchDraft] = useState(() => ({
-    sourceQueryValue: querySearchValue,
-    value: querySearchValue,
-  }));
-  const searchValue =
-    searchDraft.sourceQueryValue === querySearchValue
-      ? searchDraft.value
-      : querySearchValue;
-
-  useEffect(() => {
-    const timer = window.setTimeout(() => {
-      const params = new URLSearchParams(searchParamsString);
-      const trimmedValue = searchValue.trim();
-
-      if (trimmedValue) {
-        params.set(SEARCH_PARAM_KEY, trimmedValue);
-      } else {
-        params.delete(SEARCH_PARAM_KEY);
-      }
-
-      const queryString = params.toString();
-      const nextUrl = queryString ? `${pathname}?${queryString}` : pathname;
-      const currentUrl = searchParamsString
-        ? `${pathname}?${searchParamsString}`
-        : pathname;
-
-      if (currentUrl !== nextUrl) {
-        router.replace(nextUrl, { scroll: false });
-      }
-    }, SEARCH_DEBOUNCE_MS);
-
-    return () => window.clearTimeout(timer);
-  }, [pathname, router, searchParamsString, searchValue]);
-
-  // TODO: URL searchParams 연동 / 디바운스 등
-  return (
-    <div className="flex items-center gap-8 rounded-full border border-gray-300 bg-white px-12 py-8">
-      <SearchIcon aria-hidden className="icon-16 text-gray-500" />
-      <input
-        type="search"
-        aria-label="데이터 소스 검색"
-        value={searchValue}
-        onChange={(event) =>
-          setSearchDraft({
-            sourceQueryValue: querySearchValue,
-            value: event.target.value,
-          })
-        }
-        placeholder="찾고 싶은 데이터 소스를 입력해주세요."
-        className="w-[26rem] bg-transparent text-body4 text-gray-900 outline-none placeholder:text-gray-500"
-      />
-    </div>
-  );
-}
-
-function getUserInitial(user: GetUserInfoResponse | undefined) {
-  return user?.name?.trim().slice(0, 1).toUpperCase() || 'U';
-}
-
-function getProfileImageStyle(
-  profileImageUrl: string | null | undefined,
-): CSSProperties | undefined {
-  const imageUrl = profileImageUrl?.trim();
-  if (!imageUrl) return undefined;
-
-  return {
-    backgroundImage: `url("${imageUrl.replace(/["\\]/g, '\\$&')}")`,
-  };
-}
-
-function UserProfileSlot({
-  user,
-  isLoading,
-  isError,
-}: {
-  user: GetUserInfoResponse | undefined;
-  isLoading: boolean;
-  isError: boolean;
-}) {
-  if (isLoading) {
-    return (
-      <span
-        aria-label="Loading profile"
-        className="inline-flex h-36 w-36 animate-pulse rounded-full bg-gray-300"
-      />
-    );
-  }
-
-  const profileImageStyle = getProfileImageStyle(user?.profileImageUrl);
-
-  return (
-    <span
-      aria-label={
-        isError
-          ? 'Profile unavailable'
-          : user?.name
-            ? `${user.name} profile`
-            : 'Profile'
-      }
-      title={isError ? undefined : user?.email}
-      style={profileImageStyle}
-      className={`inline-flex h-36 w-36 items-center justify-center overflow-hidden rounded-full bg-gray-300 text-body3 font-semibold text-gray-700 ${
-        profileImageStyle ? 'bg-cover bg-center text-transparent' : ''
-      }`.trim()}
-    >
-      {getUserInitial(user)}
-    </span>
-  );
-}
-
-export default function MainLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default function MainLayout({ children }: { children: ReactNode }) {
   const router = useRouter();
   const pathname = usePathname();
   const queryClient = useQueryClient();


### PR DESCRIPTION
﻿## 요약
- Issue #223 리팩토링 백로그 중 최신 dev 기준으로 아직 유효한 항목만 최소 범위로 정리했습니다.
- 분석 결과 카드의 반복 쉘/액션 버튼을 도메인 컴포넌트로 분리했습니다.
- main layout 내부 검색/프로필 렌더링을 하위 컴포넌트로 추출했습니다.
- DataSource repository의 mock 상세/삭제 분기를 mock-aware helper로 모았습니다.

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 처리 항목
- [x] `AnalysisCard`, `AnalysisActionButtons` 추가 및 `AnalysisResult`, `QuestionAnalysisResult`, `VerificationResult`에 적용
- [x] `DataSourceSearchInput`, `UserProfileSlot` 추출로 `layout.tsx` 책임 축소
- [x] `dataSourceRepository` mock 상세/삭제 분기 helper화

## Skip
- `useAnalysisChat` 단일 훅 책임 분리는 PR #222가 최신 dev에 merge되어 이미 해결됨

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `yarn lint`
  - `yarn test`
  - `NEXT_PUBLIC_API_URL='http://localhost:8080' yarn build`

## 스크린샷/로그 (선택)
- 해당 없음

## 롤백/리스크
- 리스크 사인: 분석 결과 카드 공통 래퍼/버튼, layout 컴포넌트 추출, mock-aware repository helper 경계
- 롤백 방법: 이 PR revert

## 관련 이슈
Closes #223
