### PR TITLE
refactor: 리팩토링 백로그 후속 정리

### DIFF
--- a/apps/fe/src/app/(main)/analysis/[id]/_components/AnalysisResult.tsx
+++ b/apps/fe/src/app/(main)/analysis/[id]/_components/AnalysisResult.tsx
@@ -5,6 +5,12 @@ import ArrowDownIcon from '@/assets/icons/arrow-down.svg';
 import type { SummaryViewModel } from '../_models/analysisViewModels';
 import AnalysisActionButtons from './AnalysisActionButtons';
 import AnalysisCard from './AnalysisCard';
+import {
+  AnalysisTable,
+  AnalysisTableCell,
+  AnalysisTableHeaderCell,
+  AnalysisTableRow,
+} from './AnalysisTable';
 import AnalysisWarningList from './AnalysisWarningList';
 
 export type AnalysisResultProps = {
@@ -57,45 +63,42 @@ export default function AnalysisResult({
         </button>
 
         {summaryOpen && (
-          <div className="overflow-hidden rounded-12 border border-gray-300">
-            <table className="w-full border-collapse text-body4">
-              <thead>
-                <tr className="bg-gray-100">
-                  <th className="w-[14rem] border-b border-gray-300 px-16 py-12 text-left font-semibold text-gray-900">
-                    Name
-                  </th>
-                  <th className="border-b border-gray-300 px-16 py-12 text-left font-semibold text-gray-900">
-                    예시
-                  </th>
+          <AnalysisTable tableClassName="text-body4">
+            <thead>
+              <tr className="bg-gray-100">
+                <AnalysisTableHeaderCell className="w-[14rem]">
+                  Name
+                </AnalysisTableHeaderCell>
+                <AnalysisTableHeaderCell>예시</AnalysisTableHeaderCell>
+              </tr>
+            </thead>
+            <tbody>
+              {summary.keyPoints.length === 0 ? (
+                <tr>
+                  <AnalysisTableCell
+                    colSpan={2}
+                    className="text-center text-gray-600"
+                  >
+                    {summary.emptyMessage ??
+                      '표시할 데이터 요약 항목이 없습니다.'}
+                  </AnalysisTableCell>
                 </tr>
-              </thead>
-              <tbody>
-                {summary.keyPoints.length === 0 ? (
-                  <tr>
-                    <td
-                      colSpan={2}
-                      className="px-16 py-12 text-center text-gray-600"
-                    >
-                      {summary.emptyMessage ??
-                        '표시할 데이터 요약 항목이 없습니다.'}
-                    </td>
-                  </tr>
-                ) : (
-                  summary.keyPoints.map((item, index) => (
-                    <tr
-                      key={`${item.name}-${item.example}-${index}`}
-                      className="border-b border-gray-200 last:border-b-0"
-                    >
-                      <td className="px-16 py-12 text-gray-900">{item.name}</td>
-                      <td className="px-16 py-12 text-orange-500">
-                        {item.example}
-                      </td>
-                    </tr>
-                  ))
-                )}
-              </tbody>
-            </table>
-          </div>
+              ) : (
+                summary.keyPoints.map((item, index) => (
+                  <AnalysisTableRow
+                    key={`${item.name}-${item.example}-${index}`}
+                  >
+                    <AnalysisTableCell className="text-gray-900">
+                      {item.name}
+                    </AnalysisTableCell>
+                    <AnalysisTableCell className="text-orange-500">
+                      {item.example}
+                    </AnalysisTableCell>
+                  </AnalysisTableRow>
+                ))
+              )}
+            </tbody>
+          </AnalysisTable>
         )}
       </div>
 

--- a/apps/fe/src/app/(main)/analysis/[id]/_components/AnalysisTable.tsx
+++ b/apps/fe/src/app/(main)/analysis/[id]/_components/AnalysisTable.tsx
@@ -1,0 +1,75 @@
+import type {
+  ReactNode,
+  TableHTMLAttributes,
+  TdHTMLAttributes,
+  ThHTMLAttributes,
+} from 'react';
+
+type AnalysisTableProps = {
+  children: ReactNode;
+  className?: string;
+  tableClassName?: string;
+} & Omit<TableHTMLAttributes<HTMLTableElement>, 'className'>;
+
+export function AnalysisTable({
+  children,
+  className = '',
+  tableClassName = 'text-body2',
+  ...props
+}: AnalysisTableProps) {
+  return (
+    <div
+      className={`overflow-hidden rounded-12 border border-gray-300 ${className}`.trim()}
+    >
+      <table
+        className={`w-full border-collapse ${tableClassName}`.trim()}
+        {...props}
+      >
+        {children}
+      </table>
+    </div>
+  );
+}
+
+export function AnalysisTableHeaderCell({
+  children,
+  className = '',
+  ...props
+}: ThHTMLAttributes<HTMLTableCellElement>) {
+  return (
+    <th
+      className={`border-b border-gray-300 px-16 py-12 text-left font-semibold text-gray-900 ${className}`.trim()}
+      {...props}
+    >
+      {children}
+    </th>
+  );
+}
+
+export function AnalysisTableRow({
+  children,
+  className = '',
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <tr
+      className={`border-b border-gray-200 last:border-b-0 ${className}`.trim()}
+    >
+      {children}
+    </tr>
+  );
+}
+
+export function AnalysisTableCell({
+  children,
+  className = '',
+  ...props
+}: TdHTMLAttributes<HTMLTableCellElement>) {
+  return (
+    <td className={`px-16 py-12 ${className}`.trim()} {...props}>
+      {children}
+    </td>
+  );
+}

--- a/apps/fe/src/app/(main)/analysis/[id]/_components/CriterionSelect.tsx
+++ b/apps/fe/src/app/(main)/analysis/[id]/_components/CriterionSelect.tsx
@@ -1,7 +1,11 @@
 'use client';
 
 import ArrowDownIcon from '@/assets/icons/arrow-down.svg';
-import { ListboxDropdownShell } from '@/components';
+import {
+  ListboxDropdownShell,
+  LISTBOX_DROPDOWN_PANEL_BASE_CLASS,
+  LISTBOX_DROPDOWN_TRIGGER_BASE_CLASS,
+} from '@/components';
 
 type CommonProps = {
   options: string[];
@@ -42,7 +46,7 @@ export default function CriterionSelect(props: CriterionSelectProps) {
     <ListboxDropdownShell
       className={props.className}
       optionSelector={optionFocusSelector}
-      triggerClassName="inline-flex min-w-[12rem] items-center justify-between gap-8 rounded-12 border border-gray-300 bg-white px-12 py-8 text-body2 text-gray-900 transition-colors hover:bg-gray-100"
+      triggerClassName={`${LISTBOX_DROPDOWN_TRIGGER_BASE_CLASS} text-body2 text-gray-900`}
       trigger={({ open }) => (
         <>
           <span>{buttonLabel}</span>
@@ -58,7 +62,7 @@ export default function CriterionSelect(props: CriterionSelectProps) {
         <div
           {...panelProps}
           aria-multiselectable={props.multi ? true : undefined}
-          className="absolute left-0 z-10 mt-4 w-max min-w-full overflow-hidden rounded-12 border border-gray-300 bg-white shadow-[0_0.4rem_1.2rem_rgba(0,0,0,0.08)]"
+          className={`${LISTBOX_DROPDOWN_PANEL_BASE_CLASS} w-max min-w-full`}
         >
           {props.multi && props.headerLabel && (
             <div className="border-b border-gray-200 px-12 py-8 text-body4 text-gray-600">

--- a/apps/fe/src/app/(main)/analysis/[id]/_components/QuestionAnalysisResult.tsx
+++ b/apps/fe/src/app/(main)/analysis/[id]/_components/QuestionAnalysisResult.tsx
@@ -10,6 +10,12 @@ import type {
 import { uniqueStrings as uniqueOptions } from '../_utils/stringList';
 import AnalysisActionButtons from './AnalysisActionButtons';
 import AnalysisCard from './AnalysisCard';
+import {
+  AnalysisTable,
+  AnalysisTableCell,
+  AnalysisTableHeaderCell,
+  AnalysisTableRow,
+} from './AnalysisTable';
 import AnalysisWarningList from './AnalysisWarningList';
 import CriterionSelect from './CriterionSelect';
 
@@ -196,54 +202,49 @@ export default function QuestionAnalysisResult({
         </p>
       </div>
 
-      <div className="overflow-hidden rounded-12 border border-gray-300">
-        <table className="w-full border-collapse text-body2">
-          <thead>
-            <tr>
-              <th className="w-[14rem] border-b border-gray-300 px-16 py-12 text-left font-semibold text-gray-900">
-                항목
-              </th>
-              <th className="border-b border-gray-300 px-16 py-12 text-left font-semibold text-gray-900">
-                필드명
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map((row) => (
-              <tr
-                key={row.label}
-                className="border-b border-gray-200 last:border-b-0"
-              >
-                <td className="px-16 py-12 text-gray-700">{row.label}</td>
-                <td className="px-16 py-12 text-gray-900">
-                  {mode === 'normal' || row.kind === 'static' ? (
-                    renderStaticValue(row)
-                  ) : row.kind === 'single' ? (
-                    <CriterionSelect
-                      options={row.options}
-                      value={values[row.key]}
-                      onChange={(next) =>
-                        setValues((prev) => ({ ...prev, [row.key]: next }))
-                      }
-                    />
-                  ) : (
-                    <CriterionSelect
-                      multi
-                      options={row.options}
-                      values={values.groupBy}
-                      maxSelect={row.maxSelect}
-                      headerLabel={row.headerLabel}
-                      onChange={(next) =>
-                        setValues((prev) => ({ ...prev, groupBy: next }))
-                      }
-                    />
-                  )}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+      <AnalysisTable>
+        <thead>
+          <tr>
+            <AnalysisTableHeaderCell className="w-[14rem]">
+              항목
+            </AnalysisTableHeaderCell>
+            <AnalysisTableHeaderCell>필드명</AnalysisTableHeaderCell>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <AnalysisTableRow key={row.label}>
+              <AnalysisTableCell className="text-gray-700">
+                {row.label}
+              </AnalysisTableCell>
+              <AnalysisTableCell className="text-gray-900">
+                {mode === 'normal' || row.kind === 'static' ? (
+                  renderStaticValue(row)
+                ) : row.kind === 'single' ? (
+                  <CriterionSelect
+                    options={row.options}
+                    value={values[row.key]}
+                    onChange={(next) =>
+                      setValues((prev) => ({ ...prev, [row.key]: next }))
+                    }
+                  />
+                ) : (
+                  <CriterionSelect
+                    multi
+                    options={row.options}
+                    values={values.groupBy}
+                    maxSelect={row.maxSelect}
+                    headerLabel={row.headerLabel}
+                    onChange={(next) =>
+                      setValues((prev) => ({ ...prev, groupBy: next }))
+                    }
+                  />
+                )}
+              </AnalysisTableCell>
+            </AnalysisTableRow>
+          ))}
+        </tbody>
+      </AnalysisTable>
 
       <AnalysisWarningList warnings={criteria.warnings} />
 

--- a/apps/fe/src/app/(main)/data/_components/SortDropdown.tsx
+++ b/apps/fe/src/app/(main)/data/_components/SortDropdown.tsx
@@ -1,7 +1,11 @@
 'use client';
 
 import DownIcon from '@/assets/icons/down.svg';
-import { ListboxDropdownShell } from '@/components';
+import {
+  ListboxDropdownShell,
+  LISTBOX_DROPDOWN_PANEL_BASE_CLASS,
+  LISTBOX_DROPDOWN_TRIGGER_BASE_CLASS,
+} from '@/components';
 
 export type SortOption<T extends string = string> = {
   value: T;
@@ -23,7 +27,7 @@ export default function SortDropdown<T extends string>({
 
   return (
     <ListboxDropdownShell
-      triggerClassName="inline-flex min-w-[12rem] items-center justify-between gap-8 rounded-12 border border-gray-300 bg-white px-12 py-8 text-body4 text-gray-700 transition-colors hover:bg-gray-100"
+      triggerClassName={`${LISTBOX_DROPDOWN_TRIGGER_BASE_CLASS} text-body4 text-gray-700`}
       trigger={({ open }) => (
         <>
           <span>{selectedLabel}</span>
@@ -38,7 +42,7 @@ export default function SortDropdown<T extends string>({
       panel={({ closeAndFocusButton, panelProps }) => (
         <div
           {...panelProps}
-          className="absolute left-0 z-10 mt-4 min-w-[14rem] overflow-hidden rounded-12 border border-gray-300 bg-white py-8 shadow-[0_0.4rem_1.2rem_rgba(0,0,0,0.08)]"
+          className={`${LISTBOX_DROPDOWN_PANEL_BASE_CLASS} min-w-[14rem] py-8`}
         >
           {options.map((opt) => {
             const selected = opt.value === value;

--- a/apps/fe/src/components/ListboxDropdownShell/ListboxDropdownShell.tsx
+++ b/apps/fe/src/components/ListboxDropdownShell/ListboxDropdownShell.tsx
@@ -5,6 +5,12 @@ import ListboxDropdown, {
   type ListboxDropdownListboxProps,
 } from '../ListboxDropdown/ListboxDropdown';
 
+export const LISTBOX_DROPDOWN_TRIGGER_BASE_CLASS =
+  'inline-flex min-w-[12rem] items-center justify-between gap-8 rounded-12 border border-gray-300 bg-white px-12 py-8 transition-colors hover:bg-gray-100';
+
+export const LISTBOX_DROPDOWN_PANEL_BASE_CLASS =
+  'absolute left-0 z-10 mt-4 overflow-hidden rounded-12 border border-gray-300 bg-white shadow-[0_0.4rem_1.2rem_rgba(0,0,0,0.08)]';
+
 export type ListboxDropdownShellPanelProps = {
   closeAndFocusButton: () => void;
   open: boolean;

--- a/apps/fe/src/components/index.ts
+++ b/apps/fe/src/components/index.ts
@@ -77,7 +77,11 @@ export type {
   ListboxDropdownProps,
   ListboxDropdownRenderProps,
 } from './ListboxDropdown/ListboxDropdown';
-export { default as ListboxDropdownShell } from './ListboxDropdownShell/ListboxDropdownShell';
+export {
+  default as ListboxDropdownShell,
+  LISTBOX_DROPDOWN_PANEL_BASE_CLASS,
+  LISTBOX_DROPDOWN_TRIGGER_BASE_CLASS,
+} from './ListboxDropdownShell/ListboxDropdownShell';
 export type {
   ListboxDropdownShellPanelProps,
   ListboxDropdownShellProps,

--- a/apps/fe/src/hooks/useAuthLifecycle.ts
+++ b/apps/fe/src/hooks/useAuthLifecycle.ts
@@ -1,0 +1,199 @@
+'use client';
+
+import { useCallback, useEffect } from 'react';
+import type { QueryClient } from '@tanstack/react-query';
+import {
+  ACCESS_TOKEN_STORAGE_KEY,
+  AUTH_TOKENS_CHANGED_EVENT,
+  LEGACY_ACCESS_TOKEN_STORAGE_KEY,
+  REFRESH_TOKEN_STORAGE_KEY,
+  consumeAuthEntryRedirectBypass,
+  consumePrivatePathRedirectBypass,
+  getAccessToken,
+  readAuthTokensFromSearchParams,
+  setAuthTokens,
+} from '@/lib/auth';
+import {
+  consumeOAuthPopupState,
+  getOAuthPopupCallbackRelay,
+  isAllowedOAuthPopupOrigin,
+  readOAuthPopupCallbackMessage,
+} from '@/lib/authRedirect';
+import {
+  AUTH_REDIRECT_PATH,
+  getLoginRedirectPath,
+  getPostAuthRedirectPath,
+  shouldRedirectAuthenticatedUser,
+  shouldRedirectPrivatePath,
+  type AuthStatus,
+} from '@/lib/authSession';
+
+type SetAuthStatus = (status: AuthStatus) => void;
+
+function removeTokenParamsFromCurrentUrl(url: URL) {
+  const shouldReplace =
+    url.searchParams.has('accessToken') || url.searchParams.has('refreshToken');
+
+  if (!shouldReplace) return;
+
+  url.searchParams.delete('accessToken');
+  url.searchParams.delete('refreshToken');
+  window.history.replaceState(
+    window.history.state,
+    '',
+    `${url.pathname}${url.search}${url.hash}`,
+  );
+}
+
+function replaceLocation(pathname: string) {
+  window.location.replace(pathname);
+}
+
+function useAuthTokenSync({
+  pathname,
+  queryClient,
+  setStatus,
+}: {
+  pathname: string;
+  queryClient: QueryClient;
+  setStatus: SetAuthStatus;
+}) {
+  return useCallback(() => {
+    const nextStatus: AuthStatus = getAccessToken()
+      ? 'authenticated'
+      : 'anonymous';
+
+    setStatus(nextStatus);
+
+    if (nextStatus === 'anonymous') {
+      queryClient.clear();
+
+      if (
+        shouldRedirectPrivatePath(nextStatus, pathname) &&
+        !consumePrivatePathRedirectBypass()
+      ) {
+        replaceLocation(getLoginRedirectPath(new URL(window.location.href)));
+      }
+    }
+
+    return nextStatus;
+  }, [pathname, queryClient, setStatus]);
+}
+
+function useOAuthCallbackHandler({
+  pathname,
+  queryClient,
+}: {
+  pathname: string;
+  queryClient: QueryClient;
+}) {
+  return useCallback(() => {
+    const currentUrl = new URL(window.location.href);
+    const redirectedTokens = readAuthTokensFromSearchParams(
+      currentUrl.searchParams,
+    );
+
+    if (!redirectedTokens) return false;
+
+    const popupRelay = getOAuthPopupCallbackRelay(currentUrl, window.name);
+
+    if (popupRelay && window.opener) {
+      removeTokenParamsFromCurrentUrl(currentUrl);
+      window.opener.postMessage(popupRelay.message, popupRelay.targetOrigin);
+      window.close();
+      return true;
+    }
+
+    setAuthTokens(redirectedTokens);
+    removeTokenParamsFromCurrentUrl(currentUrl);
+    queryClient.clear();
+    replaceLocation(getPostAuthRedirectPath(pathname));
+    return true;
+  }, [pathname, queryClient]);
+}
+
+function useOAuthPopupMessageHandler({
+  queryClient,
+  setStatus,
+}: {
+  queryClient: QueryClient;
+  setStatus: SetAuthStatus;
+}) {
+  return useCallback(
+    (event: MessageEvent) => {
+      if (!isAllowedOAuthPopupOrigin(event.origin)) return;
+
+      const message = readOAuthPopupCallbackMessage(event.data);
+      if (!message) return;
+      if (!consumeOAuthPopupState(message.state)) return;
+
+      setAuthTokens(message.tokens);
+      queryClient.clear();
+      setStatus('authenticated');
+      replaceLocation(message.redirectPath);
+    },
+    [queryClient, setStatus],
+  );
+}
+
+export function useAuthLifecycle({
+  pathname,
+  queryClient,
+  setStatus,
+}: {
+  pathname: string;
+  queryClient: QueryClient;
+  setStatus: SetAuthStatus;
+}) {
+  const syncAccessToken = useAuthTokenSync({
+    pathname,
+    queryClient,
+    setStatus,
+  });
+  const handleOAuthCallback = useOAuthCallbackHandler({
+    pathname,
+    queryClient,
+  });
+  const handleMessage = useOAuthPopupMessageHandler({
+    queryClient,
+    setStatus,
+  });
+
+  useEffect(() => {
+    if (handleOAuthCallback()) return;
+
+    const nextStatus = syncAccessToken();
+    const shouldBypassAuthEntryRedirect =
+      shouldRedirectAuthenticatedUser(pathname) &&
+      consumeAuthEntryRedirectBypass();
+
+    if (
+      nextStatus === 'authenticated' &&
+      shouldRedirectAuthenticatedUser(pathname) &&
+      !shouldBypassAuthEntryRedirect
+    ) {
+      replaceLocation(AUTH_REDIRECT_PATH);
+      return;
+    }
+
+    const handleStorage = (event: StorageEvent) => {
+      if (
+        event.key === ACCESS_TOKEN_STORAGE_KEY ||
+        event.key === REFRESH_TOKEN_STORAGE_KEY ||
+        event.key === LEGACY_ACCESS_TOKEN_STORAGE_KEY
+      ) {
+        syncAccessToken();
+      }
+    };
+
+    window.addEventListener(AUTH_TOKENS_CHANGED_EVENT, syncAccessToken);
+    window.addEventListener('message', handleMessage);
+    window.addEventListener('storage', handleStorage);
+
+    return () => {
+      window.removeEventListener(AUTH_TOKENS_CHANGED_EVENT, syncAccessToken);
+      window.removeEventListener('message', handleMessage);
+      window.removeEventListener('storage', handleStorage);
+    };
+  }, [handleMessage, handleOAuthCallback, pathname, syncAccessToken]);
+}

--- a/apps/fe/src/providers/AuthProvider.tsx
+++ b/apps/fe/src/providers/AuthProvider.tsx
@@ -2,40 +2,15 @@
 
 import {
   createContext,
-  useCallback,
   useContext,
-  useEffect,
   useMemo,
   useState,
   type ReactNode,
 } from 'react';
-import { useQueryClient, type QueryClient } from '@tanstack/react-query';
+import { useQueryClient } from '@tanstack/react-query';
 import { usePathname } from 'next/navigation';
-import {
-  ACCESS_TOKEN_STORAGE_KEY,
-  AUTH_TOKENS_CHANGED_EVENT,
-  LEGACY_ACCESS_TOKEN_STORAGE_KEY,
-  REFRESH_TOKEN_STORAGE_KEY,
-  consumeAuthEntryRedirectBypass,
-  consumePrivatePathRedirectBypass,
-  getAccessToken,
-  readAuthTokensFromSearchParams,
-  setAuthTokens,
-} from '@/lib/auth';
-import {
-  consumeOAuthPopupState,
-  getOAuthPopupCallbackRelay,
-  isAllowedOAuthPopupOrigin,
-  readOAuthPopupCallbackMessage,
-} from '@/lib/authRedirect';
-import {
-  AUTH_REDIRECT_PATH,
-  getLoginRedirectPath,
-  getPostAuthRedirectPath,
-  shouldRedirectAuthenticatedUser,
-  shouldRedirectPrivatePath,
-  type AuthStatus,
-} from '@/lib/authSession';
+import type { AuthStatus } from '@/lib/authSession';
+import { useAuthLifecycle } from '@/hooks/useAuthLifecycle';
 
 type AuthContextValue = {
   status: AuthStatus;
@@ -43,176 +18,6 @@ type AuthContextValue = {
 };
 
 const AuthContext = createContext<AuthContextValue | null>(null);
-
-type SetAuthStatus = (status: AuthStatus) => void;
-
-function removeTokenParamsFromCurrentUrl(url: URL) {
-  const shouldReplace =
-    url.searchParams.has('accessToken') || url.searchParams.has('refreshToken');
-
-  if (!shouldReplace) return;
-
-  url.searchParams.delete('accessToken');
-  url.searchParams.delete('refreshToken');
-  window.history.replaceState(
-    window.history.state,
-    '',
-    `${url.pathname}${url.search}${url.hash}`,
-  );
-}
-
-function replaceLocation(pathname: string) {
-  window.location.replace(pathname);
-}
-
-function useAuthTokenSync({
-  pathname,
-  queryClient,
-  setStatus,
-}: {
-  pathname: string;
-  queryClient: QueryClient;
-  setStatus: SetAuthStatus;
-}) {
-  return useCallback(() => {
-    const nextStatus: AuthStatus = getAccessToken()
-      ? 'authenticated'
-      : 'anonymous';
-
-    setStatus(nextStatus);
-
-    if (nextStatus === 'anonymous') {
-      queryClient.clear();
-
-      if (
-        shouldRedirectPrivatePath(nextStatus, pathname) &&
-        !consumePrivatePathRedirectBypass()
-      ) {
-        replaceLocation(getLoginRedirectPath(new URL(window.location.href)));
-      }
-    }
-
-    return nextStatus;
-  }, [pathname, queryClient, setStatus]);
-}
-
-function useOAuthCallbackHandler({
-  pathname,
-  queryClient,
-}: {
-  pathname: string;
-  queryClient: QueryClient;
-}) {
-  return useCallback(() => {
-    const currentUrl = new URL(window.location.href);
-    const redirectedTokens = readAuthTokensFromSearchParams(
-      currentUrl.searchParams,
-    );
-
-    if (!redirectedTokens) return false;
-
-    const popupRelay = getOAuthPopupCallbackRelay(currentUrl, window.name);
-
-    if (popupRelay && window.opener) {
-      removeTokenParamsFromCurrentUrl(currentUrl);
-      window.opener.postMessage(popupRelay.message, popupRelay.targetOrigin);
-      window.close();
-      return true;
-    }
-
-    setAuthTokens(redirectedTokens);
-    removeTokenParamsFromCurrentUrl(currentUrl);
-    queryClient.clear();
-    replaceLocation(getPostAuthRedirectPath(pathname));
-    return true;
-  }, [pathname, queryClient]);
-}
-
-function useOAuthPopupMessageHandler({
-  queryClient,
-  setStatus,
-}: {
-  queryClient: QueryClient;
-  setStatus: SetAuthStatus;
-}) {
-  return useCallback(
-    (event: MessageEvent) => {
-      if (!isAllowedOAuthPopupOrigin(event.origin)) return;
-
-      const message = readOAuthPopupCallbackMessage(event.data);
-      if (!message) return;
-      if (!consumeOAuthPopupState(message.state)) return;
-
-      setAuthTokens(message.tokens);
-      queryClient.clear();
-      setStatus('authenticated');
-      replaceLocation(message.redirectPath);
-    },
-    [queryClient, setStatus],
-  );
-}
-
-function useAuthLifecycle({
-  pathname,
-  queryClient,
-  setStatus,
-}: {
-  pathname: string;
-  queryClient: QueryClient;
-  setStatus: SetAuthStatus;
-}) {
-  const syncAccessToken = useAuthTokenSync({
-    pathname,
-    queryClient,
-    setStatus,
-  });
-  const handleOAuthCallback = useOAuthCallbackHandler({
-    pathname,
-    queryClient,
-  });
-  const handleMessage = useOAuthPopupMessageHandler({
-    queryClient,
-    setStatus,
-  });
-
-  useEffect(() => {
-    if (handleOAuthCallback()) return;
-
-    const nextStatus = syncAccessToken();
-    const shouldBypassAuthEntryRedirect =
-      shouldRedirectAuthenticatedUser(pathname) &&
-      consumeAuthEntryRedirectBypass();
-
-    if (
-      nextStatus === 'authenticated' &&
-      shouldRedirectAuthenticatedUser(pathname) &&
-      !shouldBypassAuthEntryRedirect
-    ) {
-      replaceLocation(AUTH_REDIRECT_PATH);
-      return;
-    }
-
-    const handleStorage = (event: StorageEvent) => {
-      if (
-        event.key === ACCESS_TOKEN_STORAGE_KEY ||
-        event.key === REFRESH_TOKEN_STORAGE_KEY ||
-        event.key === LEGACY_ACCESS_TOKEN_STORAGE_KEY
-      ) {
-        syncAccessToken();
-      }
-    };
-
-    window.addEventListener(AUTH_TOKENS_CHANGED_EVENT, syncAccessToken);
-    window.addEventListener('message', handleMessage);
-    window.addEventListener('storage', handleStorage);
-
-    return () => {
-      window.removeEventListener(AUTH_TOKENS_CHANGED_EVENT, syncAccessToken);
-      window.removeEventListener('message', handleMessage);
-      window.removeEventListener('storage', handleStorage);
-    };
-  }, [handleMessage, handleOAuthCallback, pathname, syncAccessToken]);
-}
 
 export default function AuthProvider({ children }: { children: ReactNode }) {
   const pathname = usePathname();


### PR DESCRIPTION
﻿## 요약
- Issue #226 리팩토링 백로그 중 최신 dev 기준으로 still-valid인 항목만 최소 범위로 정리했습니다.
- 드롭다운 shell의 공통 trigger/panel 클래스 중복을 상수로 모았습니다.
- AuthProvider 내부 lifecycle 훅을 `useAuthLifecycle` 모듈로 이동했습니다.
- 분석 결과 테이블 크롬을 `AnalysisTable` 계열 컴포넌트로 공유했습니다.

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 처리 항목
- [x] `ListboxDropdownShell` 공통 trigger/panel 클래스 상수화 및 `SortDropdown`/`CriterionSelect` 적용
- [x] `AuthProvider` 인증 lifecycle 훅을 `src/hooks/useAuthLifecycle.ts`로 추출
- [x] `AnalysisTable`, `AnalysisTableHeaderCell`, `AnalysisTableRow`, `AnalysisTableCell` 추가 및 분석 결과 테이블에 적용

## Skip
- `useAnalysisChat` 오케스트레이션 추가 분리는 PR #222에서 라우트/payload/messages/poller 경계가 이미 분리되었고, 남은 제안은 action/phase 재설계라 이번 최소 리팩토링 범위에서 제외

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `yarn lint`
  - `yarn test`
  - `NEXT_PUBLIC_API_URL='http://localhost:8080' yarn build`

## 스크린샷/로그 (선택)
- 해당 없음

## 롤백/리스크
- 리스크 사인: 드롭다운 공통 클래스 적용, AuthProvider lifecycle 훅 이동, 분석 테이블 공통 컴포넌트 적용
- 롤백 방법: 이 PR revert

## 관련 이슈
Closes #226
