### PR TITLE
feat: AI LLMClient 공통화 (OpenAI Structured Outputs + 1회 retry)

### DIFF
--- a/apps/ai/README.md
+++ b/apps/ai/README.md
@@ -19,6 +19,42 @@ Python 3.11 + FastAPI + uv 기반 프로젝트 스캐폴드입니다.
 - Override with env var: UPSTREAM_HEALTH_URL
 - Timeout seconds env var: UPSTREAM_TIMEOUT_SEC (default: 3)
 
+## LLM client (apps/ai/llm/)
+
+질문분석·결과 요약 두 엔드포인트가 공유하는 OpenAI Structured Outputs 호출 boundary 입니다. 서비스 레이어는 OpenAI SDK 를 직접 다루지 않고 `LLMClient.complete_structured()` 만 호출합니다.
+
+### 환경변수
+
+| 변수 | 기본값 | 설명 |
+|---|---|---|
+| `OPENAI_API_KEY` | 없음 (필수) | OpenAI API 키. 운영은 SSM Parameter Store 에서 주입 |
+| `OPENAI_TIMEOUT_SEC` | `30` | OpenAI 호출 타임아웃 (초) |
+| `ANAL_LLM_MOCK` | `false` | `true` 면 질문분석·결과 요약 모두 LLM 호출 없이 결정론적 mock 응답 반환 (테스트·통합 검증용) |
+
+### 사용 예 (서비스 레이어)
+
+```python
+from llm import LLMClient
+from schemas.analysis_summary import AnalysisSummaryResponse
+
+client = LLMClient()  # OPENAI_API_KEY 자동 로드
+response = client.complete_structured(
+    system_prompt=load_system_prompt("result_summary_v1"),
+    user_payload={"analysis_criteria": ..., "chart_data": ...},
+    response_model=AnalysisSummaryResponse,
+    model="gpt-4.1-nano",
+    temperature=0.1,
+    max_output_tokens=300,
+)
+```
+
+### 동작 규칙
+
+- **Structured Outputs**: `response_format` 에 Pydantic 모델 클래스를 전달, OpenAI 가 schema 강제. parsed 결과를 `BaseModel` 인스턴스로 반환.
+- **재시도**: `llm/retry.py` 의 `with_retry` 가 1회만 재시도 (미팅노트 5️⃣ 실패 처리). 대상: `APIConnectionError`, `APITimeoutError`, `RateLimitError`, `APIError`, `ValidationError`, `json.JSONDecodeError`.
+- **예외 통과**: 모든 raise 는 그대로 서비스 레이어로 통과. 서비스 레이어가 `LLMCallFailedError` 로 래핑해 502 `LLM_CALL_FAILED` 응답으로 매핑됨.
+- **빈 응답**: OpenAI 가 `parsed=None` (refusal·컨텐츠 필터) 을 반환하면 `LLMResponseEmptyError` 로 raise.
+
 ## Local setup
 
 1. Install dependencies:

--- a/apps/ai/core/llm_client.py
+++ b/apps/ai/core/llm_client.py
@@ -1,5 +1,0 @@
-class LLMClient:
-    """OpenAI SDK boundary for future model-backed implementations."""
-
-    async def complete_json(self, prompt: str) -> dict:
-        raise NotImplementedError("LLM integration is not wired in the API structure task.")

--- a/apps/ai/llm/__init__.py
+++ b/apps/ai/llm/__init__.py
@@ -1,0 +1,11 @@
+"""LLM 호출 공통 모듈 (OpenAI Structured Outputs)."""
+
+from llm.client import LLMClient, LLMResponseEmptyError
+from llm.retry import RETRYABLE_EXCEPTIONS, with_retry
+
+__all__ = [
+    "LLMClient",
+    "LLMResponseEmptyError",
+    "RETRYABLE_EXCEPTIONS",
+    "with_retry",
+]

--- a/apps/ai/llm/client.py
+++ b/apps/ai/llm/client.py
@@ -1,0 +1,94 @@
+"""OpenAI Structured Outputs 기반 LLM 호출 공통 클라이언트.
+
+질문분석·결과 요약 두 엔드포인트가 공유하는 단일 boundary. 호출부는 system prompt /
+user payload / Pydantic response_model / model 식별자 / temperature / max_output_tokens
+만 전달한다. OpenAI SDK 의존성은 이 모듈 안에만 가둔다 — 서비스 레이어는 SDK 예외를
+직접 다루지 않고, 본 모듈이 raise 한 예외를 그대로 받아 `LLMCallFailedError` 로 래핑한다.
+
+재시도는 `llm.retry.with_retry` 로 1회 (미팅노트 5️⃣ 실패 처리).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, TypeVar
+
+from openai import OpenAI
+from pydantic import BaseModel
+
+from llm.retry import RETRYABLE_EXCEPTIONS, with_retry
+
+
+logger = logging.getLogger("logue_ai")
+
+T = TypeVar("T", bound=BaseModel)
+
+
+DEFAULT_TIMEOUT_SEC = float(os.getenv("OPENAI_TIMEOUT_SEC", "30"))
+
+
+class LLMResponseEmptyError(Exception):
+    """OpenAI 가 parsed=None (refusal · 컨텐츠 필터 등) 을 반환한 경우."""
+
+
+class LLMClient:
+    """OpenAI Structured Outputs 호출 공통 클라이언트."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        timeout_sec: float = DEFAULT_TIMEOUT_SEC,
+    ) -> None:
+        resolved_key = api_key or os.getenv("OPENAI_API_KEY")
+        if not resolved_key:
+            raise RuntimeError(
+                "OPENAI_API_KEY 환경변수가 설정되지 않았습니다. "
+                "SSM/.env 에서 키를 주입하거나 mock 모드(ANAL_LLM_MOCK=true) 로 호출하세요."
+            )
+        self._client = OpenAI(api_key=resolved_key, timeout=timeout_sec)
+
+    @with_retry(RETRYABLE_EXCEPTIONS, max_attempts=2)
+    def complete_structured(
+        self,
+        *,
+        system_prompt: str,
+        user_payload: dict[str, Any] | str,
+        response_model: type[T],
+        model: str,
+        temperature: float = 0.0,
+        max_output_tokens: int | None = None,
+    ) -> T:
+        """system_prompt + user_payload 를 OpenAI 에 전달해 response_model 인스턴스를 반환한다.
+
+        - user_payload 가 dict 면 JSON 직렬화 (ensure_ascii=False — 한글 그대로)
+        - response_format 에 Pydantic 모델 클래스를 전달하여 Structured Outputs 강제
+        - parsed=None (refusal 등) 은 `LLMResponseEmptyError` 로 raise
+        """
+        user_message = (
+            user_payload
+            if isinstance(user_payload, str)
+            else json.dumps(user_payload, ensure_ascii=False)
+        )
+
+        params: dict[str, Any] = {
+            "model": model,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_message},
+            ],
+            "temperature": temperature,
+            "response_format": response_model,
+        }
+        if max_output_tokens is not None:
+            params["max_tokens"] = max_output_tokens
+
+        completion = self._client.chat.completions.parse(**params)
+        parsed = completion.choices[0].message.parsed
+        if parsed is None:
+            raise LLMResponseEmptyError(
+                "OpenAI 응답이 비어있습니다 (parsed=None — refusal 또는 컨텐츠 필터 가능성)."
+            )
+        return parsed

--- a/apps/ai/llm/retry.py
+++ b/apps/ai/llm/retry.py
@@ -1,0 +1,69 @@
+"""LLM 호출 재시도 정책.
+
+미팅노트 5️⃣ 실패 처리 기준: provider error · timeout · JSON parse · schema validation
+실패는 1회 retry, 재실패 시 raise. business validation 실패는 LLM 재호출하지 않으므로
+호출부(서비스 레이어) 가 별도로 처리한다.
+"""
+
+from __future__ import annotations
+
+import functools
+import json
+import logging
+from typing import Callable, ParamSpec, TypeVar
+
+from openai import (
+    APIConnectionError,
+    APIError,
+    APITimeoutError,
+    RateLimitError,
+)
+from pydantic import ValidationError
+
+
+logger = logging.getLogger("logue_ai")
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+RETRYABLE_EXCEPTIONS: tuple[type[Exception], ...] = (
+    APIConnectionError,
+    APITimeoutError,
+    RateLimitError,
+    APIError,
+    ValidationError,
+    json.JSONDecodeError,
+)
+
+
+def with_retry(
+    retryable: tuple[type[Exception], ...],
+    *,
+    max_attempts: int = 2,
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    """retryable 예외에 한해 max_attempts 번까지 재시도하는 데코레이터.
+
+    `max_attempts=2` 면 최초 호출 + 1회 retry (미팅노트 기준).
+    """
+
+    def decorator(fn: Callable[P, R]) -> Callable[P, R]:
+        @functools.wraps(fn)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            for attempt in range(1, max_attempts + 1):
+                try:
+                    return fn(*args, **kwargs)
+                except retryable as exc:
+                    if attempt >= max_attempts:
+                        raise
+                    logger.warning(
+                        "LLM call attempt %d/%d failed (%s) — retrying",
+                        attempt,
+                        max_attempts,
+                        type(exc).__name__,
+                    )
+            raise RuntimeError("with_retry: unreachable")  # pragma: no cover
+
+        return wrapper
+
+    return decorator

--- a/apps/ai/pyproject.toml
+++ b/apps/ai/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
 	"fastapi>=0.115.0",
-	"openai>=1.0.0",
+	"openai>=1.50.0",
 	"pydantic>=2.8.0,<3.0.0",
 	"httpx>=0.28.0",
 	"uvicorn[standard]>=0.30.0",

--- a/apps/ai/services/analysis_summary.py
+++ b/apps/ai/services/analysis_summary.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from fastapi import HTTPException
 from schemas.analysis_summary import (
     AnalysisSummaryRequest, AnalysisSummaryResponse,
@@ -6,6 +7,8 @@ from schemas.analysis_summary import (
 )
 
 logger = logging.getLogger("logue_ai")
+
+_MOCK_ENV = "ANAL_LLM_MOCK"
 
 
 def _validate_response(request: AnalysisSummaryRequest, response: AnalysisSummaryResponse) -> None:
@@ -59,10 +62,21 @@ async def summarize_analysis_result(request: AnalysisSummaryRequest) -> Analysis
         HTTPException(502): 응답 segments-plain_text 불일치 시 (LLM_OUTPUT_INVALID)
     """
 
-    # TODO: AI 담당자분이 이 파일에 실제 LLM 호출 로직 채워넣으면 됩니다
-    # 인계 가이드: apps/ai/README.md - "결과 요약 API (AI 개발자 인계)" 섹션
+    if os.getenv(_MOCK_ENV, "").lower() == "true":
+        response = _build_mock_response(request)
+    else:
+        raise NotImplementedError(
+            "결과 요약 LLM 연동은 아직 구현되지 않았습니다 (#236). "
+            f"개발/통합 테스트는 {_MOCK_ENV}=true 로 mock 응답을 사용할 수 있습니다."
+        )
 
-    response = AnalysisSummaryResponse(
+    _validate_response(request, response)
+    return response
+
+
+def _build_mock_response(request: AnalysisSummaryRequest) -> AnalysisSummaryResponse:
+    """LLM 없이 segments↔plain_text 계약을 만족하는 결정론적 mock."""
+    return AnalysisSummaryResponse(
         request_id=request.request_id,
         description=Description(
             segments=[
@@ -73,7 +87,3 @@ async def summarize_analysis_result(request: AnalysisSummaryRequest) -> Analysis
             plain_text="더미 요약: 실제 LLM 응답으로 교체 예정.",
         ),
     )
-
-    _validate_response(request, response)
-
-    return response

--- a/apps/ai/tests/test_analysis_summary.py
+++ b/apps/ai/tests/test_analysis_summary.py
@@ -1,3 +1,4 @@
+import pytest
 from fastapi.testclient import TestClient
 import main
 
@@ -27,9 +28,9 @@ def _valid_request_body() -> dict:
     }
 
 
-def test_summarize_analysis_result() -> None:
+def test_summarize_analysis_result(monkeypatch: pytest.MonkeyPatch) -> None:
     """
-    결과 요약 엔드포인트의 더미 응답 동작을 검증합니다.
+    결과 요약 엔드포인트의 mock 응답 동작을 검증합니다.
 
     검증 항목:
         - 200 응답 반환 여부
@@ -37,6 +38,7 @@ def test_summarize_analysis_result() -> None:
         - description.segments 1개 이상 존재 여부
         - segments[].text 합과 plain_text 일치 여부
     """
+    monkeypatch.setenv("ANAL_LLM_MOCK", "true")
 
     client = TestClient(app)
 

--- a/apps/ai/tests/test_llm_client.py
+++ b/apps/ai/tests/test_llm_client.py
@@ -1,0 +1,176 @@
+"""LLMClient 단위 테스트.
+
+OpenAI SDK 호출을 mock 하여 호출 흐름·재시도·예외 매핑을 검증한다.
+실제 OPENAI_API_KEY 없이 동작.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+from openai import APITimeoutError
+from pydantic import BaseModel
+
+from llm.client import LLMClient, LLMResponseEmptyError
+
+
+class DummyResponse(BaseModel):
+    message: str
+    score: int
+
+
+def _stub_completion(parsed: DummyResponse | None) -> MagicMock:
+    completion = MagicMock()
+    completion.choices = [MagicMock(message=MagicMock(parsed=parsed))]
+    return completion
+
+
+def _timeout_exc() -> APITimeoutError:
+    request = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+    return APITimeoutError(request=request)
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> LLMClient:
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    return LLMClient()
+
+
+def test_complete_structured_returns_parsed_model(client: LLMClient) -> None:
+    expected = DummyResponse(message="hi", score=7)
+    parse_mock = MagicMock(return_value=_stub_completion(expected))
+    client._client.chat.completions.parse = parse_mock  # type: ignore[attr-defined]
+
+    result = client.complete_structured(
+        system_prompt="rules",
+        user_payload={"q": "x"},
+        response_model=DummyResponse,
+        model="gpt-4.1-nano",
+        max_output_tokens=300,
+    )
+
+    assert result == expected
+    call_kwargs = parse_mock.call_args.kwargs
+    assert call_kwargs["model"] == "gpt-4.1-nano"
+    assert call_kwargs["response_format"] is DummyResponse
+    assert call_kwargs["max_tokens"] == 300
+    assert call_kwargs["messages"][0] == {"role": "system", "content": "rules"}
+    assert call_kwargs["messages"][1]["role"] == "user"
+    assert "q" in call_kwargs["messages"][1]["content"]
+
+
+def test_complete_structured_serializes_dict_user_payload_as_utf8_json(
+    client: LLMClient,
+) -> None:
+    expected = DummyResponse(message="ok", score=1)
+    parse_mock = MagicMock(return_value=_stub_completion(expected))
+    client._client.chat.completions.parse = parse_mock  # type: ignore[attr-defined]
+
+    client.complete_structured(
+        system_prompt="x",
+        user_payload={"질문": "이번 주 전환율?"},
+        response_model=DummyResponse,
+        model="gpt-4.1-nano",
+    )
+
+    user_content = parse_mock.call_args.kwargs["messages"][1]["content"]
+    assert "이번 주 전환율?" in user_content
+
+
+def test_complete_structured_passes_string_user_payload_as_is(
+    client: LLMClient,
+) -> None:
+    expected = DummyResponse(message="ok", score=1)
+    parse_mock = MagicMock(return_value=_stub_completion(expected))
+    client._client.chat.completions.parse = parse_mock  # type: ignore[attr-defined]
+
+    client.complete_structured(
+        system_prompt="x",
+        user_payload="raw user text",
+        response_model=DummyResponse,
+        model="gpt-4.1-nano",
+    )
+
+    assert parse_mock.call_args.kwargs["messages"][1]["content"] == "raw user text"
+
+
+def test_complete_structured_raises_on_empty_parsed(client: LLMClient) -> None:
+    parse_mock = MagicMock(return_value=_stub_completion(None))
+    client._client.chat.completions.parse = parse_mock  # type: ignore[attr-defined]
+
+    with pytest.raises(LLMResponseEmptyError):
+        client.complete_structured(
+            system_prompt="x",
+            user_payload="y",
+            response_model=DummyResponse,
+            model="gpt-4.1-nano",
+        )
+
+
+def test_complete_structured_retries_once_on_timeout_then_succeeds(
+    client: LLMClient,
+) -> None:
+    expected = DummyResponse(message="ok", score=1)
+    parse_mock = MagicMock(
+        side_effect=[_timeout_exc(), _stub_completion(expected)]
+    )
+    client._client.chat.completions.parse = parse_mock  # type: ignore[attr-defined]
+
+    result = client.complete_structured(
+        system_prompt="x",
+        user_payload="y",
+        response_model=DummyResponse,
+        model="gpt-4.1-nano",
+    )
+
+    assert result == expected
+    assert parse_mock.call_count == 2
+
+
+def test_complete_structured_reraises_after_second_failure(client: LLMClient) -> None:
+    parse_mock = MagicMock(side_effect=[_timeout_exc(), _timeout_exc()])
+    client._client.chat.completions.parse = parse_mock  # type: ignore[attr-defined]
+
+    with pytest.raises(APITimeoutError):
+        client.complete_structured(
+            system_prompt="x",
+            user_payload="y",
+            response_model=DummyResponse,
+            model="gpt-4.1-nano",
+        )
+
+    assert parse_mock.call_count == 2
+
+
+def test_complete_structured_does_not_retry_on_non_retryable_exception(
+    client: LLMClient,
+) -> None:
+    parse_mock = MagicMock(side_effect=ValueError("not retryable"))
+    client._client.chat.completions.parse = parse_mock  # type: ignore[attr-defined]
+
+    with pytest.raises(ValueError, match="not retryable"):
+        client.complete_structured(
+            system_prompt="x",
+            user_payload="y",
+            response_model=DummyResponse,
+            model="gpt-4.1-nano",
+        )
+
+    assert parse_mock.call_count == 1
+
+
+def test_missing_api_key_raises_at_construction(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    with pytest.raises(RuntimeError, match="OPENAI_API_KEY"):
+        LLMClient()
+
+
+def test_explicit_api_key_overrides_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    client = LLMClient(api_key="explicit-key")
+
+    assert client._client.api_key == "explicit-key"  # type: ignore[attr-defined]

--- a/apps/ai/uv.lock
+++ b/apps/ai/uv.lock
@@ -466,7 +466,7 @@ dev = [
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", specifier = ">=0.28.0" },
-    { name = "openai", specifier = ">=1.0.0" },
+    { name = "openai", specifier = ">=1.50.0" },
     { name = "pandas", marker = "extra == 'ml'", specifier = ">=2.2.0" },
     { name = "pydantic", specifier = ">=2.8.0,<3.0.0" },
     { name = "sentence-transformers", marker = "extra == 'ml'", specifier = ">=3.0.0" },


### PR DESCRIPTION
## 요약
- `apps/ai/llm/` 신설해 OpenAI Structured Outputs 호출과 1회 재시도를 공통화 (#229)

## 변경 사항
- [x] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `cd apps/ai && uv run pytest -q` → **27 passed** (기존 18 + 신규 9)
  - 신규 테스트(`tests/test_llm_client.py`): 호출 흐름 / dict·string payload 직렬화 / empty parsed → `LLMResponseEmptyError` / 1회 retry 후 성공·재실패 raise / 비retryable 즉시 raise / API key 누락·explicit 주입
  - 실제 OpenAI 호출은 없음 (`OPENAI_API_KEY` 불필요, SDK 응답 mock)

## 스크린샷/로그 (선택)
- 해당 없음

## 롤백/리스크
- 리스크 포인트:
  - LLMClient 인스턴스화 호출자가 아직 없어 동작 리스크 0 (#235·#236 에서 처음 사용)
  - `services/analysis_summary.py` mock 토글 변경: `ANAL_LLM_MOCK=true` 미설정 상태로 결과 요약 API 호출 시 `NotImplementedError` (500). 기존 더미 200 동작이 깨지므로 dev/stg 에서 직접 호출하는 컨슈머가 있으면 영향
  - `openai>=1.50.0` 핀 상향: 환경에 1.x 구형이 깔려 있던 경우 `uv sync` 필요
- 롤백 방법:
  - `git revert <merge-commit>` (변경 파일 단순 삭제·복원 만으로 무영향 상태 복귀)

## 관련 이슈
Closes #229

후속 이슈: #230 (폴더 재구조화) → #231 (config) · #232 (prompts) · #233 (observability) · #234 (rules) → #235 (질문분석 연동) · #236 (결과 요약 연동)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 구조화된 LLM 응답 처리 기능 추가
  * 네트워크 오류 및 타임아웃에 대한 자동 재시도 메커니즘 구현
  * 개발 환경용 목 모드 지원

* **Documentation**
  * LLM 클라이언트 사용 가이드 및 환경 변수 설정 방법 문서화

* **Dependencies**
  * OpenAI SDK 최소 버전 상향

* **Tests**
  * LLM 클라이언트 단위 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/26-ewha-capstone-logue/logue/pull/237?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->