### PR TITLE
feat: AI config/ — env·모델 설정 단일화 (settings + API별 model_config)

### DIFF
--- a/apps/ai/README.md
+++ b/apps/ai/README.md
@@ -31,6 +31,7 @@ apps/ai/
     enums.py · common.py  # 공통 enum / Literal
   services/               # API별 처리 흐름
   llm/                    # OpenAI 호출 공통 모듈 (LLMClient + retry)
+  config/                 # 환경변수 접근 + API별 모델/temperature/token 설정
   core/                   # 에러·예외 핸들러·검증 헬퍼
   tests/
 ```
@@ -50,19 +51,21 @@ apps/ai/
 ### 사용 예 (서비스 레이어)
 
 ```python
+from config.model_config import model_config_for
 from llm import LLMClient
 from schemas.api.result_summary import AnalysisSummaryResponse
 
+cfg = model_config_for("result_summary")  # gpt-4.1-nano · 0.1 · 300
 client = LLMClient()  # OPENAI_API_KEY 자동 로드
 response = client.complete_structured(
     system_prompt=load_system_prompt("result_summary_v1"),
     user_payload={"analysis_criteria": ..., "chart_data": ...},
     response_model=AnalysisSummaryResponse,
-    model="gpt-4.1-nano",
-    temperature=0.1,
-    max_output_tokens=300,
+    **cfg.as_llm_kwargs(),
 )
 ```
+
+API 별 모델·temperature·token 한도는 `config/model_config.py` 에 단일 출처로 관리됨 — 변경 시 호출부 수정 불필요.
 
 ### 동작 규칙
 

--- a/apps/ai/config/__init__.py
+++ b/apps/ai/config/__init__.py
@@ -1,0 +1,5 @@
+"""환경·모델 설정 모듈.
+
+`settings` — env 변수 단일 접근점.
+`model_config` — API 별 OpenAI 모델/temperature/token 한도 (미팅노트 2️⃣ 표).
+"""

--- a/apps/ai/config/model_config.py
+++ b/apps/ai/config/model_config.py
@@ -1,0 +1,69 @@
+"""API 별 OpenAI 모델·파라미터 설정 (미팅노트 2️⃣ API 모델 선정표).
+
+호출부는 `model_config_for(api_name)` 으로 `ModelConfig` 를 받아 `as_llm_kwargs()` 를
+LLMClient 호출에 unpack 한다 — 모델·temperature·token 한도 변경 시 본 모듈만 수정.
+
+```python
+cfg = model_config_for("question_analysis")
+client.complete_structured(
+    system_prompt=...,
+    user_payload=...,
+    response_model=QuestionAnalysisResponse,
+    **cfg.as_llm_kwargs(),
+)
+```
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+ApiName = Literal["file_analysis", "question_analysis", "result_summary"]
+
+
+@dataclass(frozen=True)
+class ModelConfig:
+    """LLMClient.complete_structured 에 전달되는 OpenAI 호출 파라미터 묶음."""
+
+    model: str
+    temperature: float
+    max_output_tokens: int
+
+    def as_llm_kwargs(self) -> dict[str, object]:
+        """LLMClient.complete_structured kwargs 로 unpack 할 수 있는 dict 반환."""
+        return {
+            "model": self.model,
+            "temperature": self.temperature,
+            "max_output_tokens": self.max_output_tokens,
+        }
+
+
+_CONFIGS: dict[ApiName, ModelConfig] = {
+    "file_analysis": ModelConfig(
+        model="gpt-4.1-nano",
+        temperature=0.0,
+        max_output_tokens=1600,
+    ),
+    "question_analysis": ModelConfig(
+        model="gpt-4.1-mini",
+        temperature=0.0,
+        max_output_tokens=1200,
+    ),
+    "result_summary": ModelConfig(
+        model="gpt-4.1-nano",
+        temperature=0.1,
+        max_output_tokens=300,
+    ),
+}
+
+
+def model_config_for(api_name: ApiName) -> ModelConfig:
+    """API 이름으로 ModelConfig 를 조회. 미정의 이름은 KeyError 로 즉시 실패."""
+    if api_name not in _CONFIGS:
+        allowed = " / ".join(_CONFIGS.keys())
+        raise KeyError(
+            f"알 수 없는 API 이름: {api_name!r} — 허용: {allowed}"
+        )
+    return _CONFIGS[api_name]

--- a/apps/ai/config/settings.py
+++ b/apps/ai/config/settings.py
@@ -1,0 +1,32 @@
+"""환경변수 접근 함수.
+
+서비스/LLM 모듈이 직접 `os.getenv()` 를 부르지 않고 본 모듈의 헬퍼만 사용한다.
+함수 형태로 제공해 테스트의 `monkeypatch.setenv()` 와 호환된다 (module-level 상수는
+import 시점에 한 번만 평가되어 monkeypatch 가 안 먹힘).
+"""
+
+from __future__ import annotations
+
+import os
+
+
+_MOCK_ENV = "ANAL_LLM_MOCK"
+
+
+def openai_api_key() -> str | None:
+    """`OPENAI_API_KEY` env 값 (없으면 None). 운영은 SSM 에서 주입."""
+    return os.getenv("OPENAI_API_KEY")
+
+
+def openai_timeout_sec(default: float = 30.0) -> float:
+    """`OPENAI_TIMEOUT_SEC` env 값 (없으면 default)."""
+    raw = os.getenv("OPENAI_TIMEOUT_SEC")
+    return float(raw) if raw else default
+
+
+def is_mock_mode() -> bool:
+    """`ANAL_LLM_MOCK=true` — 모든 LLM 엔드포인트 공통 mock 토글.
+
+    True 일 때 서비스 레이어는 LLM 호출 없이 결정론적 mock 응답을 반환한다 (테스트·통합 검증용).
+    """
+    return os.getenv(_MOCK_ENV, "").lower() == "true"

--- a/apps/ai/config/settings.py
+++ b/apps/ai/config/settings.py
@@ -21,8 +21,14 @@ def openai_api_key() -> str | None:
 def openai_timeout_sec(default: float = 30.0) -> float:
     """`OPENAI_TIMEOUT_SEC` env 값 (없으면 default)."""
     raw = os.getenv("OPENAI_TIMEOUT_SEC")
-    return float(raw) if raw else default
-
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        raise ValueError(
+            f"OPENAI_TIMEOUT_SEC 값이 유효한 숫자가 아닙니다: {raw!r}"
+        )
 
 def is_mock_mode() -> bool:
     """`ANAL_LLM_MOCK=true` — 모든 LLM 엔드포인트 공통 mock 토글.

--- a/apps/ai/llm/client.py
+++ b/apps/ai/llm/client.py
@@ -12,21 +12,18 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 from typing import Any, TypeVar
 
 from openai import OpenAI
 from pydantic import BaseModel
 
+from config.settings import openai_api_key, openai_timeout_sec
 from llm.retry import RETRYABLE_EXCEPTIONS, with_retry
 
 
 logger = logging.getLogger("logue_ai")
 
 T = TypeVar("T", bound=BaseModel)
-
-
-DEFAULT_TIMEOUT_SEC = float(os.getenv("OPENAI_TIMEOUT_SEC", "30"))
 
 
 class LLMResponseEmptyError(Exception):
@@ -40,15 +37,16 @@ class LLMClient:
         self,
         *,
         api_key: str | None = None,
-        timeout_sec: float = DEFAULT_TIMEOUT_SEC,
+        timeout_sec: float | None = None,
     ) -> None:
-        resolved_key = api_key or os.getenv("OPENAI_API_KEY")
+        resolved_key = api_key or openai_api_key()
         if not resolved_key:
             raise RuntimeError(
                 "OPENAI_API_KEY 환경변수가 설정되지 않았습니다. "
                 "SSM/.env 에서 키를 주입하거나 mock 모드(ANAL_LLM_MOCK=true) 로 호출하세요."
             )
-        self._client = OpenAI(api_key=resolved_key, timeout=timeout_sec)
+        resolved_timeout = timeout_sec if timeout_sec is not None else openai_timeout_sec()
+        self._client = OpenAI(api_key=resolved_key, timeout=resolved_timeout)
 
     @with_retry(RETRYABLE_EXCEPTIONS, max_attempts=2)
     def complete_structured(

--- a/apps/ai/services/analysis_criteria_service.py
+++ b/apps/ai/services/analysis_criteria_service.py
@@ -13,8 +13,8 @@ Spring 연동/통합 테스트가 LLM 없이도 가능하다.
 from __future__ import annotations
 
 import logging
-import os
 
+from config.settings import is_mock_mode
 from core.errors import AppError, ErrorDetail, LLMCallFailedError
 from schemas.api.question_analysis import (
     QuestionAnalysisRequest,
@@ -23,8 +23,6 @@ from schemas.api.question_analysis import (
 from schemas.enums import SemanticRoleType
 from services.llm_output_validator import validate_llm_output
 
-
-_MOCK_ENV = "ANAL_LLM_MOCK"
 
 logger = logging.getLogger("logue_ai")
 
@@ -59,11 +57,11 @@ def _call_llm(req: QuestionAnalysisRequest) -> QuestionAnalysisResponse:
 
     `ANAL_LLM_MOCK=true` 가 설정된 경우 결정론적 mock 응답을 반환한다.
     """
-    if os.getenv(_MOCK_ENV, "").lower() == "true":
+    if is_mock_mode():
         return _build_mock_response(req)
     raise NotImplementedError(
         "LLM call to be implemented. "
-        f"개발/통합 테스트는 {_MOCK_ENV}=true 로 mock 응답을 사용할 수 있다."
+        "개발/통합 테스트는 ANAL_LLM_MOCK=true 로 mock 응답을 사용할 수 있다."
     )
 
 

--- a/apps/ai/services/analysis_summary.py
+++ b/apps/ai/services/analysis_summary.py
@@ -1,14 +1,13 @@
 import logging
-import os
 from fastapi import HTTPException
+
+from config.settings import is_mock_mode
 from schemas.api.result_summary import (
     AnalysisSummaryRequest, AnalysisSummaryResponse,
     Description, Segment,
 )
 
 logger = logging.getLogger("logue_ai")
-
-_MOCK_ENV = "ANAL_LLM_MOCK"
 
 
 def _validate_response(request: AnalysisSummaryRequest, response: AnalysisSummaryResponse) -> None:
@@ -62,12 +61,12 @@ async def summarize_analysis_result(request: AnalysisSummaryRequest) -> Analysis
         HTTPException(502): 응답 segments-plain_text 불일치 시 (LLM_OUTPUT_INVALID)
     """
 
-    if os.getenv(_MOCK_ENV, "").lower() == "true":
+    if is_mock_mode():
         response = _build_mock_response(request)
     else:
         raise NotImplementedError(
             "결과 요약 LLM 연동은 아직 구현되지 않았습니다 (#236). "
-            f"개발/통합 테스트는 {_MOCK_ENV}=true 로 mock 응답을 사용할 수 있습니다."
+            "개발/통합 테스트는 ANAL_LLM_MOCK=true 로 mock 응답을 사용할 수 있습니다."
         )
 
     _validate_response(request, response)

--- a/apps/ai/tests/test_config.py
+++ b/apps/ai/tests/test_config.py
@@ -1,0 +1,109 @@
+"""config/ 단위 테스트.
+
+settings 헬퍼 — env 분기.
+model_config — 미팅노트 2️⃣ 표 일치 + lookup 오류 처리.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from config import model_config, settings
+
+
+# ---------- settings ----------
+
+
+def test_openai_api_key_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    assert settings.openai_api_key() == "test-key"
+
+
+def test_openai_api_key_returns_none_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    assert settings.openai_api_key() is None
+
+
+def test_openai_timeout_sec_uses_default_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_TIMEOUT_SEC", raising=False)
+    assert settings.openai_timeout_sec() == 30.0
+
+
+def test_openai_timeout_sec_uses_custom_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_TIMEOUT_SEC", raising=False)
+    assert settings.openai_timeout_sec(default=10.0) == 10.0
+
+
+def test_openai_timeout_sec_parses_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_TIMEOUT_SEC", "5.5")
+    assert settings.openai_timeout_sec() == 5.5
+
+
+def test_is_mock_mode_true_when_env_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ANAL_LLM_MOCK", "true")
+    assert settings.is_mock_mode() is True
+
+
+def test_is_mock_mode_case_insensitive(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ANAL_LLM_MOCK", "TRUE")
+    assert settings.is_mock_mode() is True
+
+
+def test_is_mock_mode_false_when_other_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ANAL_LLM_MOCK", "1")
+    assert settings.is_mock_mode() is False
+
+
+def test_is_mock_mode_false_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ANAL_LLM_MOCK", raising=False)
+    assert settings.is_mock_mode() is False
+
+
+# ---------- model_config ----------
+
+
+def test_model_config_for_question_analysis_matches_meeting_note() -> None:
+    cfg = model_config.model_config_for("question_analysis")
+    assert cfg.model == "gpt-4.1-mini"
+    assert cfg.temperature == 0.0
+    assert cfg.max_output_tokens == 1200
+
+
+def test_model_config_for_result_summary_matches_meeting_note() -> None:
+    cfg = model_config.model_config_for("result_summary")
+    assert cfg.model == "gpt-4.1-nano"
+    assert cfg.temperature == 0.1
+    assert cfg.max_output_tokens == 300
+
+
+def test_model_config_for_file_analysis_matches_meeting_note() -> None:
+    cfg = model_config.model_config_for("file_analysis")
+    assert cfg.model == "gpt-4.1-nano"
+    assert cfg.temperature == 0.0
+    assert cfg.max_output_tokens == 1600
+
+
+def test_model_config_for_unknown_api_raises_keyerror() -> None:
+    with pytest.raises(KeyError, match="허용"):
+        model_config.model_config_for("ghost_api")  # type: ignore[arg-type]
+
+
+def test_as_llm_kwargs_shape() -> None:
+    cfg = model_config.model_config_for("question_analysis")
+    assert cfg.as_llm_kwargs() == {
+        "model": "gpt-4.1-mini",
+        "temperature": 0.0,
+        "max_output_tokens": 1200,
+    }
+
+
+def test_model_config_is_frozen() -> None:
+    cfg = model_config.model_config_for("question_analysis")
+    with pytest.raises(Exception):  # FrozenInstanceError (dataclass)
+        cfg.model = "other"  # type: ignore[misc]


### PR DESCRIPTION
> ⚠️ **stacked PR**: base 가 `feat/ai/#230-schemas-restructure` (#238). #238 머지 시 base 가 자동 retarget 됨.

## 요약
- `config/settings.py` 로 env 접근 일원화, `config/model_config.py` 로 미팅노트 2️⃣ API 모델 선정표를 코드화 (#231)

## 변경 사항
- [x] 기능
- [ ] 버그 수정
- [x] 리팩토링
- [x] 문서
- [x] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `cd apps/ai && uv run pytest -q` → **48 passed** (기존 33 + 신규 15)
  - 신규 테스트(`tests/test_config.py`): env 접근(`OPENAI_API_KEY` / `OPENAI_TIMEOUT_SEC` / `ANAL_LLM_MOCK`) 분기, ModelConfig 표 일치(`gpt-4.1-nano` · `gpt-4.1-mini`), 미정의 API → KeyError, frozen 검증

## 스크린샷/로그 (선택)
- 해당 없음

## 롤백/리스크
- 리스크 포인트:
  - LLMClient 생성자 시그니처에서 `timeout_sec` 기본값이 `DEFAULT_TIMEOUT_SEC` 상수 → `settings.openai_timeout_sec()` 호출로 바뀜 (monkeypatch 호환). 호출자가 명시적으로 `timeout_sec=...` 전달하는 경우엔 영향 없음
  - `services/analysis_summary.py` / `services/analysis_criteria_service.py` 의 `os.getenv(_MOCK_ENV, ...)` 직접 호출 → `settings.is_mock_mode()` 호출로 교체. 의미 동등
  - env 변수명·기본값 자체는 변경 없음 (`OPENAI_API_KEY`, `OPENAI_TIMEOUT_SEC=30`, `ANAL_LLM_MOCK=true`)
- 롤백 방법:
  - `git revert <merge-commit>` (config/ 디렉토리 삭제 + 3개 파일의 env 접근 원복 만으로 무영향 상태 복귀)

## 관련 이슈
Closes #231

스택 순서: #237(#229) → #238(#230) → 본 PR(#231) → #232·#233·#234 병렬 → #235·#236