### PR TITLE
feat: AI prompts/ + prompt_loader (v1 골격 3종)

### DIFF
--- a/apps/ai/README.md
+++ b/apps/ai/README.md
@@ -30,7 +30,8 @@ apps/ai/
     llm_input/            # LLM 전달용 정규화 DTO (*.from_request() 로 변환)
     enums.py · common.py  # 공통 enum / Literal
   services/               # API별 처리 흐름
-  llm/                    # OpenAI 호출 공통 모듈 (LLMClient + retry)
+  llm/                    # OpenAI 호출 공통 모듈 (LLMClient + retry + prompt_loader)
+  prompts/                # system prompt 저장 (<name>_<version>.system.md)
   config/                 # 환경변수 접근 + API별 모델/temperature/token 설정
   core/                   # 에러·예외 핸들러·검증 헬퍼
   tests/
@@ -52,20 +53,21 @@ apps/ai/
 
 ```python
 from config.model_config import model_config_for
-from llm import LLMClient
+from llm import LLMClient, load_system_prompt
 from schemas.api.result_summary import AnalysisSummaryResponse
 
 cfg = model_config_for("result_summary")  # gpt-4.1-nano · 0.1 · 300
 client = LLMClient()  # OPENAI_API_KEY 자동 로드
 response = client.complete_structured(
-    system_prompt=load_system_prompt("result_summary_v1"),
+    system_prompt=load_system_prompt("result_summary"),  # → prompts/result_summary_v1.system.md
     user_payload={"analysis_criteria": ..., "chart_data": ...},
     response_model=AnalysisSummaryResponse,
     **cfg.as_llm_kwargs(),
 )
 ```
 
-API 별 모델·temperature·token 한도는 `config/model_config.py` 에 단일 출처로 관리됨 — 변경 시 호출부 수정 불필요.
+- API 별 모델·temperature·token 한도는 `config/model_config.py` 단일 출처
+- system prompt 는 `prompts/<name>_<version>.system.md` 파일로 분리 — 버전업 시 `_v2.system.md` 추가 후 `load_system_prompt(name, version="v2")` 호출. `prompt_version_id()` 로 로깅용 식별자 획득
 
 ### 동작 규칙
 

--- a/apps/ai/llm/__init__.py
+++ b/apps/ai/llm/__init__.py
@@ -1,11 +1,14 @@
 """LLM 호출 공통 모듈 (OpenAI Structured Outputs)."""
 
 from llm.client import LLMClient, LLMResponseEmptyError
+from llm.prompt_loader import load_system_prompt, prompt_version_id
 from llm.retry import RETRYABLE_EXCEPTIONS, with_retry
 
 __all__ = [
     "LLMClient",
     "LLMResponseEmptyError",
     "RETRYABLE_EXCEPTIONS",
+    "load_system_prompt",
+    "prompt_version_id",
     "with_retry",
 ]

--- a/apps/ai/llm/prompt_loader.py
+++ b/apps/ai/llm/prompt_loader.py
@@ -1,0 +1,46 @@
+"""System prompt 파일 로더.
+
+`apps/ai/prompts/<name>_<version>.system.md` 파일을 읽어 LLMClient 호출 시 system
+message 로 전달한다. LRU 캐시로 동일 (name, version) 재요청 시 디스크 I/O 를 피한다.
+
+```python
+from llm.prompt_loader import load_system_prompt, prompt_version_id
+
+system_message = load_system_prompt("question_analysis")  # v1 default
+log_field = prompt_version_id("question_analysis")  # "question_analysis_v1"
+```
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+
+
+PROMPTS_DIR: Path = Path(__file__).resolve().parent.parent / "prompts"
+
+
+@lru_cache(maxsize=64)
+def load_system_prompt(name: str, version: str = "v1") -> str:
+    """`prompts/<name>_<version>.system.md` 본문을 UTF-8 문자열로 반환.
+
+    파일이 없으면 FileNotFoundError 를 raise — 호출부는 별도 fallback 없이
+    버전 typo / 미작성 prompt 를 즉시 인지하도록 한다.
+    """
+    path = PROMPTS_DIR / f"{name}_{version}.system.md"
+    if not path.is_file():
+        raise FileNotFoundError(
+            f"system prompt 파일이 없습니다: {path} "
+            f"(name={name!r}, version={version!r})"
+        )
+    return path.read_text(encoding="utf-8")
+
+
+def prompt_version_id(name: str, version: str = "v1") -> str:
+    """observability 로깅용 prompt 버전 식별자 (`question_analysis_v1`)."""
+    return f"{name}_{version}"
+
+
+def clear_cache() -> None:
+    """LRU 캐시 초기화 — 테스트에서 prompts/ 디렉토리 monkeypatch 시 사용."""
+    load_system_prompt.cache_clear()

--- a/apps/ai/llm/prompt_loader.py
+++ b/apps/ai/llm/prompt_loader.py
@@ -41,6 +41,9 @@ def prompt_version_id(name: str, version: str = "v1") -> str:
     return f"{name}_{version}"
 
 
-def clear_cache() -> None:
-    """LRU 캐시 초기화 — 테스트에서 prompts/ 디렉토리 monkeypatch 시 사용."""
+def clear_cache() -> None:  # noqa: D401
+    """[테스트 전용] LRU 캐시 초기화 — 운영 코드에서 직접 호출 금지.
+
+    prompts/ monkeypatch 시 캐시 무효화 용도.
+    """
     load_system_prompt.cache_clear()

--- a/apps/ai/prompts/file_analysis_v1.system.md
+++ b/apps/ai/prompts/file_analysis_v1.system.md
@@ -4,7 +4,7 @@
 > response schema: `schemas.api.file_analysis.FileAnalysisResponse` (Structured Outputs 로 강제됨)
 > model: `gpt-4.1-nano` (`config.model_config.model_config_for("file_analysis")`)
 
-<!-- TODO: 본문은 F8 (01 파일 분석 LLM 연동) 에서 작성. 본 파일은 골격 + prompt_loader 동작 검증용 placeholder. -->
+<!-- TODO: 본문은 실제 LLM 연동 구현 시 작성. 본 파일은 골격 + prompt_loader 동작 검증용 placeholder. -->
 
 You are a column profiler. You receive CSV column metadata and assign one semantic role per column.
 

--- a/apps/ai/prompts/file_analysis_v1.system.md
+++ b/apps/ai/prompts/file_analysis_v1.system.md
@@ -1,0 +1,16 @@
+# File Analysis — System Prompt v1
+
+> 01 파일 분석 API (`POST /v1/llm/data-sources/analyze`) 의 system message.
+> response schema: `schemas.api.file_analysis.FileAnalysisResponse` (Structured Outputs 로 강제됨)
+> model: `gpt-4.1-nano` (`config.model_config.model_config_for("file_analysis")`)
+
+<!-- TODO: 본문은 F8 (01 파일 분석 LLM 연동) 에서 작성. 본 파일은 골격 + prompt_loader 동작 검증용 placeholder. -->
+
+You are a column profiler. You receive CSV column metadata and assign one semantic role per column.
+
+(실제 규칙·few-shot 예시는 미정 — 작성 시 다음을 포함할 것)
+
+- 각 컬럼에 단일 `semantic_role` (DATE_CRITERIA / MEASURE / DIMENSION / STATUS_CONDITION / FLAG / ID_CRITERIA) 할당
+- `data_status_summary.primary_candidates` 분류 규칙
+- `source_warning_keys[].code` 매핑 — 날짜 컬럼 2개 이상 → `DATE_FIELD_CONFLICT` 등
+- 자유 텍스트·markdown·코드 펜스 금지 — 응답은 schema 에 맞는 JSON 만

--- a/apps/ai/prompts/question_analysis_v1.system.md
+++ b/apps/ai/prompts/question_analysis_v1.system.md
@@ -1,0 +1,19 @@
+# Question Analysis — System Prompt v1
+
+> 02 질문 분석 API (`POST /v1/llm/analysis-criteria/resolve`) 의 system message.
+> response schema: `schemas.api.question_analysis.QuestionAnalysisResponse` (Structured Outputs 로 강제됨)
+> model: `gpt-4.1-mini` (`config.model_config.model_config_for("question_analysis")`)
+
+<!-- TODO: 본문은 F6 (#235) 질문분석 LLM 연동 에서 작성. 본 파일은 골격 + prompt_loader 동작 검증용 placeholder. -->
+
+You convert a user's natural-language question into a structured `analysis_criteria` (COMPARISON / RANKING).
+
+(실제 규칙·few-shot 예시는 미정 — 작성 시 다음을 포함할 것)
+
+- `analysis_type`: COMPARISON / RANKING 만 허용 — 그 외 의도는 `unsupported_question` 으로 반환
+- `metric_name`: 반드시 `catalog.predefined_metrics[].metric_name` 안에서 선택 (catalog 외 metric → `unsupported_question`)
+- `metric_type` · `formula_*`: catalog 기준으로 매핑 (LLM 임의 생성 금지)
+- `base_date_column` · `group_by` · `filters[].field`: 반드시 `data_source.columns[].column_name` 안에서 선택
+- `standard_period` · `compare_period`: 반드시 `catalog.supported_periods` 안에서 선택
+- warning 처리: `catalog.flow_warning_keys[].code` 안의 코드만 사용
+- 자유 텍스트·markdown·코드 펜스 금지 — 응답은 schema 에 맞는 JSON 만

--- a/apps/ai/prompts/question_analysis_v1.system.md
+++ b/apps/ai/prompts/question_analysis_v1.system.md
@@ -4,7 +4,7 @@
 > response schema: `schemas.api.question_analysis.QuestionAnalysisResponse` (Structured Outputs 로 강제됨)
 > model: `gpt-4.1-mini` (`config.model_config.model_config_for("question_analysis")`)
 
-<!-- TODO: 본문은 F6 (#235) 질문분석 LLM 연동 에서 작성. 본 파일은 골격 + prompt_loader 동작 검증용 placeholder. -->
+<!-- TODO: 본문은 실제 LLM 연동 구현 시 작성. 본 파일은 골격 + prompt_loader 동작 검증용 placeholder. -->
 
 You convert a user's natural-language question into a structured `analysis_criteria` (COMPARISON / RANKING).
 

--- a/apps/ai/prompts/result_summary_v1.system.md
+++ b/apps/ai/prompts/result_summary_v1.system.md
@@ -4,7 +4,7 @@
 > response schema: `schemas.api.result_summary.AnalysisSummaryResponse` (Structured Outputs 로 강제됨)
 > model: `gpt-4.1-nano` (`config.model_config.model_config_for("result_summary")`)
 
-<!-- TODO: 본문은 F7 (#236) 결과 요약 LLM 연동 에서 작성. 본 파일은 골격 + prompt_loader 동작 검증용 placeholder. -->
+<!-- TODO: 본문은 실제 LLM 연동 구현 시 작성. 본 파일은 골격 + prompt_loader 동작 검증용 placeholder. -->
 
 You summarize an analysis result (`analysis_criteria` + `chart_data`) into a single natural-language sentence with emphasis segments.
 

--- a/apps/ai/prompts/result_summary_v1.system.md
+++ b/apps/ai/prompts/result_summary_v1.system.md
@@ -1,0 +1,16 @@
+# Result Summary — System Prompt v1
+
+> 03 결과 요약 API (`POST /v1/llm/analysis-results/describe`) 의 system message.
+> response schema: `schemas.api.result_summary.AnalysisSummaryResponse` (Structured Outputs 로 강제됨)
+> model: `gpt-4.1-nano` (`config.model_config.model_config_for("result_summary")`)
+
+<!-- TODO: 본문은 F7 (#236) 결과 요약 LLM 연동 에서 작성. 본 파일은 골격 + prompt_loader 동작 검증용 placeholder. -->
+
+You summarize an analysis result (`analysis_criteria` + `chart_data`) into a single natural-language sentence with emphasis segments.
+
+(실제 규칙·few-shot 예시는 미정 — 작성 시 다음을 포함할 것)
+
+- `description.segments[].text` 를 순서대로 이어붙인 결과는 **반드시** `description.plain_text` 와 완전히 일치 (공백·구두점 포함). 불일치 시 셀프 검증이 502 `LLM_OUTPUT_INVALID` 로 차단
+- `emphasis: true` 는 의미 강조 구간 (와이어프레임 주황색 처리) — 핵심 수치·비교 표현 위주
+- `locale` 에 맞춘 자연어 (기본 `ko-KR`)
+- 자유 텍스트·markdown·코드 펜스 금지 — 응답은 schema 에 맞는 JSON 만

--- a/apps/ai/tests/test_prompt_loader.py
+++ b/apps/ai/tests/test_prompt_loader.py
@@ -1,0 +1,93 @@
+"""prompt_loader 단위 테스트.
+
+실제 prompts/ 디렉토리의 v1 골격 파일 3종 로딩 + 미존재 분기 + LRU 캐시 동작 검증.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from llm import prompt_loader
+
+
+@pytest.fixture(autouse=True)
+def _clear_prompt_cache() -> None:
+    prompt_loader.clear_cache()
+
+
+# ---------- 정상 로딩 ----------
+
+
+def test_load_system_prompt_returns_file_analysis_v1() -> None:
+    content = prompt_loader.load_system_prompt("file_analysis")
+    assert "# File Analysis" in content
+    assert "Structured Outputs" in content
+
+
+def test_load_system_prompt_returns_question_analysis_v1() -> None:
+    content = prompt_loader.load_system_prompt("question_analysis")
+    assert "# Question Analysis" in content
+    assert "analysis_criteria" in content
+
+
+def test_load_system_prompt_returns_result_summary_v1() -> None:
+    content = prompt_loader.load_system_prompt("result_summary")
+    assert "# Result Summary" in content
+    assert "plain_text" in content
+
+
+def test_load_system_prompt_default_version_is_v1() -> None:
+    assert prompt_loader.load_system_prompt(
+        "question_analysis"
+    ) == prompt_loader.load_system_prompt("question_analysis", version="v1")
+
+
+# ---------- 미존재 분기 ----------
+
+
+def test_load_system_prompt_unknown_name_raises() -> None:
+    with pytest.raises(FileNotFoundError, match="system prompt 파일이 없습니다"):
+        prompt_loader.load_system_prompt("ghost_api")
+
+
+def test_load_system_prompt_unknown_version_raises() -> None:
+    with pytest.raises(FileNotFoundError, match="v999"):
+        prompt_loader.load_system_prompt("question_analysis", version="v999")
+
+
+# ---------- LRU 캐시 ----------
+
+
+def test_load_system_prompt_returns_same_string_instance_on_cache_hit() -> None:
+    first = prompt_loader.load_system_prompt("question_analysis")
+    second = prompt_loader.load_system_prompt("question_analysis")
+    assert first is second  # LRU 캐시 → identity 보존
+
+
+def test_clear_cache_forces_disk_reread() -> None:
+    first = prompt_loader.load_system_prompt("question_analysis")
+    prompt_loader.clear_cache()
+    second = prompt_loader.load_system_prompt("question_analysis")
+    assert first == second  # 내용은 동일
+    # identity 는 보장 안 됨 (cache_clear 후 새 read)
+
+
+# ---------- prompt_version_id ----------
+
+
+def test_prompt_version_id_default_v1() -> None:
+    assert prompt_loader.prompt_version_id("question_analysis") == "question_analysis_v1"
+
+
+def test_prompt_version_id_explicit_version() -> None:
+    assert prompt_loader.prompt_version_id("file_analysis", version="v3") == "file_analysis_v3"
+
+
+# ---------- 패키지 re-export ----------
+
+
+def test_prompt_loader_exposed_via_llm_package() -> None:
+    from llm import load_system_prompt, prompt_version_id
+
+    assert callable(load_system_prompt)
+    assert prompt_version_id("result_summary") == "result_summary_v1"


### PR DESCRIPTION
> ⚠️ **stacked PR**: base 가 `feat/ai/#231-model-config` (#239). 위 PR 머지 시 base 가 자동 retarget 됨.

## 요약
- `prompts/` 디렉토리에 system prompt v1 골격 3종을 두고, `llm/prompt_loader.py` 로 로드·캐시·로깅 식별자 노출 (#232)

## 변경 사항
- [x] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 문서
- [x] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `cd apps/ai && uv run pytest -q` → **59 passed** (기존 48 + 신규 11)
  - 신규 테스트(`tests/test_prompt_loader.py`): v1 골격 3종 로딩 / default version=v1 / 미존재 name·version → FileNotFoundError / LRU 캐시 identity / clear_cache 동작 / prompt_version_id 포맷 / 패키지 re-export

## 스크린샷/로그 (선택)
- 해당 없음

## 롤백/리스크
- 리스크 포인트:
  - prompts/*.system.md 3종은 **골격 placeholder** — 실제 prompt 본문은 각 API 의 LLM 연동 구현 시 작성. 본 PR 머지만으로는 LLM 호출 동작 변화 없음 (호출자가 아직 없음)
  - `load_system_prompt` 는 LRU 캐시 (maxsize=64). 운영 중 파일 변경은 reflect 되지 않음 — 배포 단위로 갱신 가정
- 롤백 방법:
  - `git revert <merge-commit>` (prompts/ 디렉토리 + prompt_loader.py + 테스트 삭제, 호출자 없으므로 무영향)

## 관련 이슈
Closes #232

스택 순서: #237(#229) → #238(#230) → #239(#231) → 본 PR(#232) → #233·#234 병렬 → #235·#236

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 시스템 프롬프트 관리 기능 추가로 AI 기능별 프롬프트를 통합 관리
  * 파일 분석, 질문 분석, 결과 요약 등 주요 AI 기능의 프롬프트 템플릿 제공
  * 프롬프트 버전 관리 지원으로 향후 업데이트 용이

* **Tests**
  * 시스템 프롬프트 로더 기능의 단위 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/26-ewha-capstone-logue/logue/pull/242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->