### PR TITLE
fix: 로그인 세션 복원 401 오류 수정

### DIFF
--- a/apps/fe/src/hooks/useAuthLifecycle.ts
+++ b/apps/fe/src/hooks/useAuthLifecycle.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect } from 'react';
 import type { QueryClient } from '@tanstack/react-query';
+import { reissueAuthTokens } from '@/apis/auth';
 import {
   ACCESS_TOKEN_STORAGE_KEY,
   AUTH_TOKENS_CHANGED_EVENT,
@@ -9,7 +10,6 @@ import {
   REFRESH_TOKEN_STORAGE_KEY,
   consumeAuthEntryRedirectBypass,
   consumePrivatePathRedirectBypass,
-  getAccessToken,
   readAuthTokensFromSearchParams,
   setAuthTokens,
 } from '@/lib/auth';
@@ -27,6 +27,7 @@ import {
   shouldRedirectPrivatePath,
   type AuthStatus,
 } from '@/lib/authSession';
+import { restoreAuthSession } from '@/lib/authSessionRestore';
 
 type SetAuthStatus = (status: AuthStatus) => void;
 
@@ -47,37 +48,6 @@ function removeTokenParamsFromCurrentUrl(url: URL) {
 
 function replaceLocation(pathname: string) {
   window.location.replace(pathname);
-}
-
-function useAuthTokenSync({
-  pathname,
-  queryClient,
-  setStatus,
-}: {
-  pathname: string;
-  queryClient: QueryClient;
-  setStatus: SetAuthStatus;
-}) {
-  return useCallback(() => {
-    const nextStatus: AuthStatus = getAccessToken()
-      ? 'authenticated'
-      : 'anonymous';
-
-    setStatus(nextStatus);
-
-    if (nextStatus === 'anonymous') {
-      queryClient.clear();
-
-      if (
-        shouldRedirectPrivatePath(nextStatus, pathname) &&
-        !consumePrivatePathRedirectBypass()
-      ) {
-        replaceLocation(getLoginRedirectPath(new URL(window.location.href)));
-      }
-    }
-
-    return nextStatus;
-  }, [pathname, queryClient, setStatus]);
 }
 
 function useOAuthCallbackHandler({
@@ -145,11 +115,6 @@ export function useAuthLifecycle({
   queryClient: QueryClient;
   setStatus: SetAuthStatus;
 }) {
-  const syncAccessToken = useAuthTokenSync({
-    pathname,
-    queryClient,
-    setStatus,
-  });
   const handleOAuthCallback = useOAuthCallbackHandler({
     pathname,
     queryClient,
@@ -162,19 +127,59 @@ export function useAuthLifecycle({
   useEffect(() => {
     if (handleOAuthCallback()) return;
 
-    const nextStatus = syncAccessToken();
-    const shouldBypassAuthEntryRedirect =
-      shouldRedirectAuthenticatedUser(pathname) &&
-      consumeAuthEntryRedirectBypass();
+    let isActive = true;
+    let isRestoring = false;
 
-    if (
-      nextStatus === 'authenticated' &&
-      shouldRedirectAuthenticatedUser(pathname) &&
-      !shouldBypassAuthEntryRedirect
-    ) {
-      replaceLocation(AUTH_REDIRECT_PATH);
-      return;
-    }
+    const applyStatus = (
+      nextStatus: AuthStatus,
+      shouldCheckAuthEntryRedirect: boolean,
+    ) => {
+      setStatus(nextStatus);
+
+      if (nextStatus === 'anonymous') {
+        queryClient.clear();
+
+        if (
+          shouldRedirectPrivatePath(nextStatus, pathname) &&
+          !consumePrivatePathRedirectBypass()
+        ) {
+          replaceLocation(getLoginRedirectPath(new URL(window.location.href)));
+        }
+
+        return;
+      }
+
+      const shouldBypassAuthEntryRedirect =
+        shouldCheckAuthEntryRedirect &&
+        shouldRedirectAuthenticatedUser(pathname) &&
+        consumeAuthEntryRedirectBypass();
+
+      if (
+        shouldCheckAuthEntryRedirect &&
+        shouldRedirectAuthenticatedUser(pathname) &&
+        !shouldBypassAuthEntryRedirect
+      ) {
+        replaceLocation(AUTH_REDIRECT_PATH);
+      }
+    };
+
+    const restoreAndApply = async (shouldCheckAuthEntryRedirect: boolean) => {
+      if (isRestoring) return;
+
+      isRestoring = true;
+
+      try {
+        const nextStatus = await restoreAuthSession(reissueAuthTokens);
+
+        if (!isActive) return;
+
+        applyStatus(nextStatus, shouldCheckAuthEntryRedirect);
+      } finally {
+        isRestoring = false;
+      }
+    };
+
+    void restoreAndApply(true);
 
     const handleStorage = (event: StorageEvent) => {
       if (
@@ -182,18 +187,26 @@ export function useAuthLifecycle({
         event.key === REFRESH_TOKEN_STORAGE_KEY ||
         event.key === LEGACY_ACCESS_TOKEN_STORAGE_KEY
       ) {
-        syncAccessToken();
+        void restoreAndApply(false);
       }
     };
 
-    window.addEventListener(AUTH_TOKENS_CHANGED_EVENT, syncAccessToken);
+    const handleAuthTokensChanged = () => {
+      void restoreAndApply(false);
+    };
+
+    window.addEventListener(AUTH_TOKENS_CHANGED_EVENT, handleAuthTokensChanged);
     window.addEventListener('message', handleMessage);
     window.addEventListener('storage', handleStorage);
 
     return () => {
-      window.removeEventListener(AUTH_TOKENS_CHANGED_EVENT, syncAccessToken);
+      isActive = false;
+      window.removeEventListener(
+        AUTH_TOKENS_CHANGED_EVENT,
+        handleAuthTokensChanged,
+      );
       window.removeEventListener('message', handleMessage);
       window.removeEventListener('storage', handleStorage);
     };
-  }, [handleMessage, handleOAuthCallback, pathname, syncAccessToken]);
+  }, [handleMessage, handleOAuthCallback, pathname, queryClient, setStatus]);
 }

--- a/apps/fe/src/hooks/useMyInfo.ts
+++ b/apps/fe/src/hooks/useMyInfo.ts
@@ -10,6 +10,7 @@ export function useMyInfo(enabled: boolean) {
     queryKey: userKeys.me(),
     queryFn: getMyInfo,
     enabled,
+    retry: false,
     staleTime: USER_INFO_STALE_TIME,
   });
 }

--- a/apps/fe/src/lib/auth.test.ts
+++ b/apps/fe/src/lib/auth.test.ts
@@ -7,8 +7,10 @@ import {
   consumePrivatePathRedirectBypass,
   getAccessToken,
   getRefreshToken,
+  readJwtExpiresAt,
   readAuthTokensFromSearchParams,
   setAuthTokens,
+  shouldRefreshAccessToken,
   skipNextPrivatePathRedirect,
 } from './auth';
 
@@ -46,6 +48,20 @@ function installWindowStorage() {
   });
 
   return { dispatchEvent, localStorage, sessionStorage };
+}
+
+function encodeBase64Url(value: unknown) {
+  return Buffer.from(JSON.stringify(value))
+    .toString('base64')
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
+    .replaceAll('=', '');
+}
+
+function createJwt(payload: Record<string, unknown>) {
+  return `${encodeBase64Url({ alg: 'none' })}.${encodeBase64Url(
+    payload,
+  )}.signature`;
 }
 
 afterEach(() => {
@@ -102,6 +118,31 @@ describe('auth token storage', () => {
     expect(localStorage.getItem(ACCESS_TOKEN_STORAGE_KEY)).toBeNull();
     expect(localStorage.getItem(LEGACY_ACCESS_TOKEN_STORAGE_KEY)).toBeNull();
     expect(localStorage.getItem(REFRESH_TOKEN_STORAGE_KEY)).toBeNull();
+  });
+});
+
+describe('JWT token expiry helpers', () => {
+  it('reads the exp claim as milliseconds', () => {
+    const token = createJwt({ exp: 1_800_000_000 });
+
+    expect(readJwtExpiresAt(token)).toBe(1_800_000_000_000);
+  });
+
+  it('treats expired or nearly expired tokens as refresh candidates', () => {
+    const now = 1_800_000_000_000;
+    const expiredToken = createJwt({ exp: 1_799_999_999 });
+    const nearlyExpiredToken = createJwt({ exp: 1_800_000_030 });
+    const validToken = createJwt({ exp: 1_800_000_120 });
+
+    expect(shouldRefreshAccessToken(expiredToken, now)).toBe(true);
+    expect(shouldRefreshAccessToken(nearlyExpiredToken, now)).toBe(true);
+    expect(shouldRefreshAccessToken(validToken, now)).toBe(false);
+  });
+
+  it('treats malformed tokens as refresh candidates', () => {
+    expect(readJwtExpiresAt('not-a-jwt')).toBeNull();
+    expect(readJwtExpiresAt(createJwt({ sub: 'user-1' }))).toBeNull();
+    expect(shouldRefreshAccessToken('not-a-jwt')).toBe(true);
   });
 });
 

--- a/apps/fe/src/lib/auth.ts
+++ b/apps/fe/src/lib/auth.ts
@@ -13,6 +13,7 @@ const PRIVATE_PATH_REDIRECT_BYPASS_STORAGE_KEY =
   'logue:private-path-redirect-bypass';
 
 const MAX_AUTH_TOKEN_LENGTH = 8192;
+const AUTH_TOKEN_REFRESH_BUFFER_MS = 60 * 1000;
 
 function getOptionalLocalStorage() {
   if (typeof window === 'undefined') return null;
@@ -80,6 +81,49 @@ function normalizeToken(token: string | null | undefined) {
   if (!normalized || normalized.length > MAX_AUTH_TOKEN_LENGTH) return null;
 
   return normalized;
+}
+
+function decodeBase64Url(value: string) {
+  const base64 = value.replace(/-/g, '+').replace(/_/g, '/');
+  const paddedBase64 = base64.padEnd(Math.ceil(base64.length / 4) * 4, '=');
+
+  return globalThis.atob(paddedBase64);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+export function readJwtExpiresAt(token: string | null | undefined) {
+  const normalizedToken = normalizeToken(token);
+  const payload = normalizedToken?.split('.')[1];
+
+  if (!payload) return null;
+
+  try {
+    const parsedPayload: unknown = JSON.parse(decodeBase64Url(payload));
+
+    if (!isRecord(parsedPayload) || typeof parsedPayload.exp !== 'number') {
+      return null;
+    }
+
+    const expiresAt = parsedPayload.exp * 1000;
+
+    return Number.isFinite(expiresAt) ? expiresAt : null;
+  } catch {
+    return null;
+  }
+}
+
+export function shouldRefreshAccessToken(
+  token: string | null | undefined,
+  now = Date.now(),
+) {
+  const expiresAt = readJwtExpiresAt(token);
+
+  if (!expiresAt) return true;
+
+  return expiresAt - now <= AUTH_TOKEN_REFRESH_BUFFER_MS;
 }
 
 export function getAccessToken() {

--- a/apps/fe/src/lib/authSessionRestore.test.ts
+++ b/apps/fe/src/lib/authSessionRestore.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  ACCESS_TOKEN_STORAGE_KEY,
+  LEGACY_ACCESS_TOKEN_STORAGE_KEY,
+  REFRESH_TOKEN_STORAGE_KEY,
+  getAccessToken,
+  getRefreshToken,
+  setAuthTokens,
+} from './auth';
+import {
+  restoreAuthSession,
+  type ReissueAuthTokens,
+} from './authSessionRestore';
+
+function createStorage() {
+  const store = new Map<string, string>();
+
+  return {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (key: string) => store.get(key) ?? null,
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+  } satisfies Storage;
+}
+
+function installWindowStorage() {
+  const localStorage = createStorage();
+  const sessionStorage = createStorage();
+
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: {
+      localStorage,
+      sessionStorage,
+      dispatchEvent: vi.fn(),
+    },
+  });
+
+  return { localStorage };
+}
+
+function encodeBase64Url(value: unknown) {
+  return Buffer.from(JSON.stringify(value))
+    .toString('base64')
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
+    .replaceAll('=', '');
+}
+
+function createJwt(expiresAtMs: number) {
+  return `${encodeBase64Url({ alg: 'none' })}.${encodeBase64Url({
+    exp: Math.floor(expiresAtMs / 1000),
+  })}.signature`;
+}
+
+afterEach(() => {
+  Reflect.deleteProperty(globalThis, 'window');
+  vi.restoreAllMocks();
+});
+
+describe('restoreAuthSession', () => {
+  it('keeps authenticated status without reissuing when access token is still valid', async () => {
+    installWindowStorage();
+    const accessToken = createJwt(Date.now() + 120_000);
+    const reissueAuthTokens = vi.fn<ReissueAuthTokens>();
+
+    setAuthTokens({
+      accessToken,
+      refreshToken: 'refresh-token',
+    });
+
+    await expect(restoreAuthSession(reissueAuthTokens)).resolves.toBe(
+      'authenticated',
+    );
+
+    expect(reissueAuthTokens).not.toHaveBeenCalled();
+    expect(getAccessToken()).toBe(accessToken);
+    expect(getRefreshToken()).toBe('refresh-token');
+  });
+
+  it('reissues tokens before authenticating when access token is expired', async () => {
+    const { localStorage } = installWindowStorage();
+    const nextAccessToken = createJwt(Date.now() + 120_000);
+    const reissueAuthTokens = vi.fn<ReissueAuthTokens>().mockResolvedValue({
+      accessToken: nextAccessToken,
+      refreshToken: 'next-refresh-token',
+    });
+
+    setAuthTokens({
+      accessToken: createJwt(Date.now() - 1_000),
+      refreshToken: 'refresh-token',
+    });
+
+    await expect(restoreAuthSession(reissueAuthTokens)).resolves.toBe(
+      'authenticated',
+    );
+
+    expect(reissueAuthTokens).toHaveBeenCalledWith('refresh-token');
+    expect(localStorage.getItem(ACCESS_TOKEN_STORAGE_KEY)).toBe(
+      nextAccessToken,
+    );
+    expect(localStorage.getItem(LEGACY_ACCESS_TOKEN_STORAGE_KEY)).toBe(
+      nextAccessToken,
+    );
+    expect(localStorage.getItem(REFRESH_TOKEN_STORAGE_KEY)).toBe(
+      'next-refresh-token',
+    );
+  });
+
+  it('clears tokens and returns anonymous when reissue fails', async () => {
+    installWindowStorage();
+    const reissueAuthTokens = vi
+      .fn<ReissueAuthTokens>()
+      .mockRejectedValue(new Error('invalid refresh token'));
+
+    setAuthTokens({
+      accessToken: createJwt(Date.now() - 1_000),
+      refreshToken: 'refresh-token',
+    });
+
+    await expect(restoreAuthSession(reissueAuthTokens)).resolves.toBe(
+      'anonymous',
+    );
+
+    expect(getAccessToken()).toBeNull();
+    expect(getRefreshToken()).toBeNull();
+  });
+
+  it('keeps authenticated status when another tab already rotated tokens', async () => {
+    installWindowStorage();
+    const nextAccessToken = createJwt(Date.now() + 120_000);
+    const reissueAuthTokens = vi
+      .fn<ReissueAuthTokens>()
+      .mockImplementation(async () => {
+        setAuthTokens({
+          accessToken: nextAccessToken,
+          refreshToken: 'rotated-refresh-token',
+        });
+        throw new Error('old refresh token was already rotated');
+      });
+
+    setAuthTokens({
+      accessToken: createJwt(Date.now() - 1_000),
+      refreshToken: 'refresh-token',
+    });
+
+    await expect(restoreAuthSession(reissueAuthTokens)).resolves.toBe(
+      'authenticated',
+    );
+
+    expect(getAccessToken()).toBe(nextAccessToken);
+    expect(getRefreshToken()).toBe('rotated-refresh-token');
+  });
+});

--- a/apps/fe/src/lib/authSessionRestore.ts
+++ b/apps/fe/src/lib/authSessionRestore.ts
@@ -1,0 +1,56 @@
+import {
+  clearAuthTokens,
+  getAccessToken,
+  getRefreshToken,
+  setAuthTokens,
+  shouldRefreshAccessToken,
+  type AuthTokens,
+} from './auth';
+import type { AuthStatus } from './authSession';
+
+export type ReissueAuthTokens = (refreshToken: string) => Promise<AuthTokens>;
+
+function hasUsableRotatedTokens(previousRefreshToken: string) {
+  const latestAccessToken = getAccessToken();
+  const latestRefreshToken = getRefreshToken();
+
+  return (
+    !!latestAccessToken &&
+    !!latestRefreshToken &&
+    latestRefreshToken !== previousRefreshToken &&
+    !shouldRefreshAccessToken(latestAccessToken)
+  );
+}
+
+export async function restoreAuthSession(
+  reissueAuthTokens: ReissueAuthTokens,
+): Promise<AuthStatus> {
+  const accessToken = getAccessToken();
+
+  if (accessToken && !shouldRefreshAccessToken(accessToken)) {
+    return 'authenticated';
+  }
+
+  const refreshToken = getRefreshToken();
+
+  if (!refreshToken) {
+    if (accessToken) {
+      clearAuthTokens();
+    }
+
+    return 'anonymous';
+  }
+
+  try {
+    const nextTokens = await reissueAuthTokens(refreshToken);
+    setAuthTokens(nextTokens);
+    return 'authenticated';
+  } catch {
+    if (hasUsableRotatedTokens(refreshToken)) {
+      return 'authenticated';
+    }
+
+    clearAuthTokens();
+    return 'anonymous';
+  }
+}

--- a/apps/fe/src/lib/axios.test.ts
+++ b/apps/fe/src/lib/axios.test.ts
@@ -4,6 +4,7 @@ import type {
   InternalAxiosRequestConfig,
 } from 'axios';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { reissueAuthTokens } from '../apis/auth';
 import {
   ACCESS_TOKEN_STORAGE_KEY,
   LEGACY_ACCESS_TOKEN_STORAGE_KEY,
@@ -13,6 +14,10 @@ import {
   setAuthTokens,
 } from './auth';
 import instance from './axios';
+
+vi.mock('../apis/auth', () => ({
+  reissueAuthTokens: vi.fn(),
+}));
 
 function createStorage() {
   const store = new Map<string, string>();
@@ -62,7 +67,35 @@ function createRejectedResponse(
   };
 }
 
+function createSuccessResponse(
+  config: InternalAxiosRequestConfig,
+  data: unknown = { ok: true },
+): AxiosResponse {
+  return {
+    config,
+    data,
+    headers: {},
+    status: 200,
+    statusText: 'OK',
+  };
+}
+
+function encodeBase64Url(value: unknown) {
+  return Buffer.from(JSON.stringify(value))
+    .toString('base64')
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
+    .replaceAll('=', '');
+}
+
+function createJwt(expiresAtMs: number) {
+  return `${encodeBase64Url({ alg: 'none' })}.${encodeBase64Url({
+    exp: Math.floor(expiresAtMs / 1000),
+  })}.signature`;
+}
+
 const originalAdapter = instance.defaults.adapter;
+const mockReissueAuthTokens = vi.mocked(reissueAuthTokens);
 
 afterEach(() => {
   instance.defaults.adapter = originalAdapter;
@@ -154,5 +187,134 @@ describe('axios auth interceptor', () => {
 
     expect(getAccessToken()).toBeNull();
     expect(getRefreshToken()).toBeNull();
+  });
+
+  it('reissues tokens and retries the original request after a 401', async () => {
+    const { localStorage } = installWindowStorage();
+    const nextAccessToken = createJwt(Date.now() + 120_000);
+    const requests: InternalAxiosRequestConfig[] = [];
+    const authorizations: unknown[] = [];
+    mockReissueAuthTokens.mockResolvedValue({
+      accessToken: nextAccessToken,
+      refreshToken: 'next-refresh-token',
+    });
+    setAuthTokens({
+      accessToken: 'expired-access-token',
+      refreshToken: 'refresh-token',
+    });
+
+    const adapter: AxiosAdapter = async (config) => {
+      requests.push(config);
+      authorizations.push(config.headers.Authorization);
+
+      if (requests.length === 1) {
+        return Promise.reject({
+          config,
+          isAxiosError: true,
+          response: createRejectedResponse(config, 401),
+          toJSON: () => ({}),
+        });
+      }
+
+      return createSuccessResponse(config);
+    };
+
+    instance.defaults.adapter = adapter;
+
+    await expect(instance.get('/api/datasources')).resolves.toMatchObject({
+      status: 200,
+    });
+
+    expect(mockReissueAuthTokens).toHaveBeenCalledWith('refresh-token');
+    expect(requests).toHaveLength(2);
+    expect(authorizations).toEqual([
+      'Bearer expired-access-token',
+      `Bearer ${nextAccessToken}`,
+    ]);
+    expect(localStorage.getItem(ACCESS_TOKEN_STORAGE_KEY)).toBe(
+      nextAccessToken,
+    );
+    expect(localStorage.getItem(LEGACY_ACCESS_TOKEN_STORAGE_KEY)).toBe(
+      nextAccessToken,
+    );
+    expect(localStorage.getItem(REFRESH_TOKEN_STORAGE_KEY)).toBe(
+      'next-refresh-token',
+    );
+  });
+
+  it('clears tokens when reissue fails without a rotated refresh token', async () => {
+    installWindowStorage();
+    mockReissueAuthTokens.mockRejectedValue(new Error('invalid refresh token'));
+    setAuthTokens({
+      accessToken: 'expired-access-token',
+      refreshToken: 'refresh-token',
+    });
+
+    const adapter: AxiosAdapter = async (config) => {
+      return Promise.reject({
+        config,
+        isAxiosError: true,
+        response: createRejectedResponse(config, 401),
+        toJSON: () => ({}),
+      });
+    };
+
+    instance.defaults.adapter = adapter;
+
+    await expect(instance.get('/api/datasources')).rejects.toThrow(
+      'invalid refresh token',
+    );
+
+    expect(mockReissueAuthTokens).toHaveBeenCalledWith('refresh-token');
+    expect(getAccessToken()).toBeNull();
+    expect(getRefreshToken()).toBeNull();
+  });
+
+  it('retries with rotated tokens when another tab already refreshed the session', async () => {
+    installWindowStorage();
+    const nextAccessToken = createJwt(Date.now() + 120_000);
+    const requests: InternalAxiosRequestConfig[] = [];
+    const authorizations: unknown[] = [];
+    mockReissueAuthTokens.mockImplementation(async () => {
+      setAuthTokens({
+        accessToken: nextAccessToken,
+        refreshToken: 'rotated-refresh-token',
+      });
+      throw new Error('old refresh token was already rotated');
+    });
+    setAuthTokens({
+      accessToken: 'expired-access-token',
+      refreshToken: 'refresh-token',
+    });
+
+    const adapter: AxiosAdapter = async (config) => {
+      requests.push(config);
+      authorizations.push(config.headers.Authorization);
+
+      if (requests.length === 1) {
+        return Promise.reject({
+          config,
+          isAxiosError: true,
+          response: createRejectedResponse(config, 401),
+          toJSON: () => ({}),
+        });
+      }
+
+      return createSuccessResponse(config);
+    };
+
+    instance.defaults.adapter = adapter;
+
+    await expect(instance.get('/api/datasources')).resolves.toMatchObject({
+      status: 200,
+    });
+
+    expect(requests).toHaveLength(2);
+    expect(authorizations).toEqual([
+      'Bearer expired-access-token',
+      `Bearer ${nextAccessToken}`,
+    ]);
+    expect(getAccessToken()).toBe(nextAccessToken);
+    expect(getRefreshToken()).toBe('rotated-refresh-token');
   });
 });

--- a/apps/fe/src/lib/axios.ts
+++ b/apps/fe/src/lib/axios.ts
@@ -5,6 +5,7 @@ import {
   getAccessToken,
   getRefreshToken,
   setAuthTokens,
+  shouldRefreshAccessToken,
   type AuthTokens,
 } from './auth';
 import { getApiBaseUrl } from './apiBaseUrl';
@@ -43,6 +44,22 @@ function getReissuedAuthTokens(refreshToken: string) {
   return reissueTokensRequest;
 }
 
+function getUsableRotatedAccessToken(previousRefreshToken: string) {
+  const latestAccessToken = getAccessToken();
+  const latestRefreshToken = getRefreshToken();
+
+  if (
+    latestAccessToken &&
+    latestRefreshToken &&
+    latestRefreshToken !== previousRefreshToken &&
+    !shouldRefreshAccessToken(latestAccessToken)
+  ) {
+    return latestAccessToken;
+  }
+
+  return null;
+}
+
 instance.interceptors.response.use(
   (response) => response,
   async (error: AxiosError) => {
@@ -71,6 +88,13 @@ instance.interceptors.response.use(
       originalRequest.headers.Authorization = `Bearer ${nextTokens.accessToken}`;
       return instance(originalRequest);
     } catch (refreshError) {
+      const rotatedAccessToken = getUsableRotatedAccessToken(refreshToken);
+
+      if (rotatedAccessToken) {
+        originalRequest.headers.Authorization = `Bearer ${rotatedAccessToken}`;
+        return instance(originalRequest);
+      }
+
       clearAuthTokens();
       return Promise.reject(refreshError);
     }


### PR DESCRIPTION
﻿## 요약
- 앱 진입 시 저장된 refresh token으로 인증 세션을 먼저 복원하도록 변경했습니다.
- access token 만료/만료 임박 상태에서 `/api/user/me`가 먼저 401을 내지 않도록 profile query 실행 시점을 인증 복원 이후로 늦췄습니다.
- refresh token rotation 경합 시 최신 저장 토큰이 있으면 무조건 로그아웃하지 않고 원 요청을 재시도하도록 보완했습니다.

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `yarn test -- src/lib/auth.test.ts src/lib/authSessionRestore.test.ts src/lib/axios.test.ts`
  - `yarn lint`

## 스크린샷/로그 (선택)
- 인증 흐름 단위 테스트와 lint로 검증했습니다.

## 롤백/리스크
- 리스크 사인: refresh token 재발급 API 장애 시 기존 계획대로 저장 토큰을 정리하고 익명 상태로 전환합니다.
- 롤백 방법: 이 PR을 revert하면 기존 access token 존재 기반 인증 판정으로 되돌아갑니다.

## 관련 이슈
Closes #248


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * JWT 토큰 만료 시점을 읽고 갱신 필요 여부를 판단하는 기능 추가
  * 세션 복원 프로세스를 비동기 방식으로 개선
  * 다중 탭 환경에서 회전된 토큰 재사용 기능 추가

* **Tests**
  * JWT 토큰 만료/리프레시 로직 검증 테스트 추가
  * 세션 복원 흐름 검증 테스트 추가
  * 토큰 재발급 및 회전 시나리오 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/26-ewha-capstone-logue/logue/pull/249?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->