### PR TITLE
fix: 분석 화면 데이터셋과 질문 영역 분리

### DIFF
--- a/apps/fe/src/app/(main)/analysis/[id]/_components/AnalysisChatMessageList.tsx
+++ b/apps/fe/src/app/(main)/analysis/[id]/_components/AnalysisChatMessageList.tsx
@@ -5,6 +5,7 @@ import { ChatBubble } from '@/components';
 import AnalysisResult from './AnalysisResult';
 import AnalyzingIndicator from './AnalyzingIndicator';
 import QuestionAnalysisResult from './QuestionAnalysisResult';
+import UploadedFileBadge from './UploadedFileBadge';
 import VerificationResult from './VerificationResult';
 import type {
   ChatMessage,
@@ -75,16 +76,20 @@ export default function AnalysisChatMessageList({
 
   const renderMessage = (message: ChatMessage) => {
     if (message.role === 'user') {
+      if (message.fileName) {
+        return (
+          <div
+            key={message.id}
+            className="flex w-full flex-col items-end gap-8"
+          >
+            <UploadedFileBadge fileName={message.fileName} />
+            <ChatBubble role="user">{message.content}</ChatBubble>
+          </div>
+        );
+      }
+
       return (
-        <ChatBubble
-          key={message.id}
-          role="user"
-          file={
-            message.fileName
-              ? { name: message.fileName, status: 'uploaded' }
-              : undefined
-          }
-        >
+        <ChatBubble key={message.id} role="user">
           {message.content}
         </ChatBubble>
       );

--- a/apps/fe/src/components/ChatBubble/ChatBubble.stories.tsx
+++ b/apps/fe/src/components/ChatBubble/ChatBubble.stories.tsx
@@ -32,11 +32,3 @@ export const Bot: Story = {
 export const BotLoading: Story = {
   args: { role: 'bot', loading: true },
 };
-
-export const UserWithFile: Story = {
-  args: {
-    role: 'user',
-    children: '데이터분석 결과 알려줘',
-    file: { name: '업로드된 CSV 파일명.csv', status: 'uploaded' },
-  },
-};

--- a/apps/fe/src/components/ChatBubble/ChatBubble.tsx
+++ b/apps/fe/src/components/ChatBubble/ChatBubble.tsx
@@ -6,7 +6,6 @@ export type ChatBubbleProps = {
   role: ChatBubbleRole;
   children: ReactNode;
   loading?: boolean;
-  file?: { name: string; status?: string };
 } & Omit<HTMLAttributes<HTMLDivElement>, 'role' | 'children'>;
 
 function LoadingDots() {
@@ -36,7 +35,6 @@ export default function ChatBubble({
   role,
   children,
   loading = false,
-  file,
   className = '',
   ...rest
 }: ChatBubbleProps) {
@@ -48,15 +46,6 @@ export default function ChatBubble({
       {...rest}
     >
       <div className={isUser ? USER_BUBBLE_CLASS : BOT_BUBBLE_CLASS}>
-        {file && (
-          <div className="mb-8 inline-flex items-center gap-8 rounded-12 border border-gray-300 px-12 py-8">
-            <span className="inline-block h-20 w-20 rounded-4 bg-orange-400" />
-            <span className="text-body4 text-gray-800">{file.name}</span>
-            {file.status && (
-              <span className="text-body4 text-gray-500">{file.status}</span>
-            )}
-          </div>
-        )}
         {loading ? (
           <div className="flex items-center gap-8">
             <LoadingDots />

--- a/apps/fe/src/components/TextField/TextField.tsx
+++ b/apps/fe/src/components/TextField/TextField.tsx
@@ -141,7 +141,7 @@ const TextField = forwardRef<HTMLTextAreaElement, TextFieldProps>(
           onKeyDown={handleKeyDown}
           onChange={handleChange}
           className={`scrollbar-hide min-w-0 w-full flex-1 resize-none bg-transparent outline-none ${
-            isCompact ? 'text-body2' : 'text-head3'
+            isCompact ? 'text-body2' : 'text-body1'
           } ${toneClass}`}
           {...textareaProps}
         />


### PR DESCRIPTION
﻿## 요약
- 분석 채팅에서 업로드된 CSV 데이터셋 표시와 질문 메시지를 분리했습니다.
- 질문 입력 TextField의 large variant 텍스트 크기를 낮춰 헤딩처럼 보이지 않게 조정했습니다.

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `yarn lint`

## 스크린샷/로그 (선택)
- 사용자 제공 Figma 캡처를 기준으로 수정했습니다.
- Figma 파일/노드 링크가 없어 캔버스 직접 수정은 아직 반영하지 못했습니다.

## 롤백/리스크
- 리스크: `TextField` large variant의 입력 텍스트 토큰이 `text-head3`에서 `text-body1`로 변경되어 해당 variant를 사용하는 화면의 입력 텍스트 크기가 함께 낮아집니다. 현재 앱 사용처는 분석 질문 입력 영역입니다.
- 롤백 방법: `TextField` large textarea 토큰을 `text-head3`로 되돌리고, 사용자 메시지의 `UploadedFileBadge` 분리 변경을 revert합니다.

## 관련 이슈
Closes #251
