### PR TITLE
fix: 데이터 소스 삭제 실패 안내 개선

### DIFF
--- a/apps/fe/src/apis/errors.test.ts
+++ b/apps/fe/src/apis/errors.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getApiErrorCode,
+  getApiErrorStatus,
+  isApiConflictError,
+} from './errors';
+import { ApiResponseError } from './types';
+
+describe('API error helpers', () => {
+  it('reads error codes from ApiResponseError envelopes', () => {
+    const error = new ApiResponseError({
+      success: false,
+      code: 'D007',
+      message: 'Data source is in use.',
+    });
+
+    expect(getApiErrorCode(error)).toBe('D007');
+    expect(getApiErrorStatus(error)).toBeNull();
+    expect(isApiConflictError(error)).toBe(true);
+  });
+
+  it('reads error codes and status from Axios errors', () => {
+    const error = {
+      isAxiosError: true,
+      response: {
+        status: 409,
+        data: {
+          success: false,
+          code: 'D007',
+          message: 'Data source is in use.',
+        },
+      },
+    };
+
+    expect(getApiErrorCode(error)).toBe('D007');
+    expect(getApiErrorStatus(error)).toBe(409);
+    expect(isApiConflictError(error)).toBe(true);
+  });
+
+  it('treats HTTP 409 as a conflict even without an envelope code', () => {
+    const error = {
+      isAxiosError: true,
+      response: {
+        status: 409,
+        data: {},
+      },
+    };
+
+    expect(getApiErrorCode(error)).toBeNull();
+    expect(getApiErrorStatus(error)).toBe(409);
+    expect(isApiConflictError(error)).toBe(true);
+  });
+});

--- a/apps/fe/src/apis/errors.ts
+++ b/apps/fe/src/apis/errors.ts
@@ -7,8 +7,19 @@ type ApiFailurePayload = {
   message?: unknown;
 };
 
+function hasApiCode(value: unknown): value is ApiFailurePayload {
+  return typeof value === 'object' && value !== null && 'code' in value;
+}
+
 function hasApiMessage(value: unknown): value is ApiFailurePayload {
   return typeof value === 'object' && value !== null && 'message' in value;
+}
+
+function pickCode(value: unknown) {
+  if (!hasApiCode(value)) return null;
+  return typeof value.code === 'string' && value.code.trim().length > 0
+    ? value.code
+    : null;
 }
 
 function pickMessage(value: unknown) {
@@ -16,6 +27,28 @@ function pickMessage(value: unknown) {
   return typeof value.message === 'string' && value.message.trim().length > 0
     ? value.message
     : null;
+}
+
+export function getApiErrorCode(error: unknown) {
+  if (error instanceof ApiResponseError) {
+    return error.response.code || null;
+  }
+
+  if (axios.isAxiosError(error)) {
+    return pickCode(error.response?.data);
+  }
+
+  return null;
+}
+
+export function getApiErrorStatus(error: unknown) {
+  if (!axios.isAxiosError(error)) return null;
+
+  return error.response?.status ?? null;
+}
+
+export function isApiConflictError(error: unknown) {
+  return getApiErrorCode(error) === 'D007' || getApiErrorStatus(error) === 409;
 }
 
 export function getApiErrorMessage(error: unknown, fallback: string) {

--- a/apps/fe/src/apis/mockDataSource.test.ts
+++ b/apps/fe/src/apis/mockDataSource.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  MOCK_MARKETING_CVR_DATA_SOURCE_ID,
+  filterVisibleMockDataSources,
+  getDeletedMockDataSourceStorageKey,
+  markMockDataSourcesDeleted,
+  readDeletedMockDataSourceIds,
+} from './mockDataSource';
+
+function createStorage() {
+  const store = new Map<string, string>();
+
+  return {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (key: string) => store.get(key) ?? null,
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+  } satisfies Storage;
+}
+
+function installWindowStorage() {
+  const localStorage = createStorage();
+
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: {
+      localStorage,
+    },
+  });
+
+  return { localStorage };
+}
+
+afterEach(() => {
+  Reflect.deleteProperty(globalThis, 'window');
+});
+
+describe('mock data source deletion storage', () => {
+  it('stores deleted mock data sources per user', () => {
+    const { localStorage } = installWindowStorage();
+
+    expect(
+      markMockDataSourcesDeleted(1, [MOCK_MARKETING_CVR_DATA_SOURCE_ID]),
+    ).toEqual([MOCK_MARKETING_CVR_DATA_SOURCE_ID]);
+
+    expect(
+      readDeletedMockDataSourceIds(1).has(MOCK_MARKETING_CVR_DATA_SOURCE_ID),
+    ).toBe(true);
+    expect(
+      readDeletedMockDataSourceIds(2).has(MOCK_MARKETING_CVR_DATA_SOURCE_ID),
+    ).toBe(false);
+    expect(
+      localStorage.getItem(getDeletedMockDataSourceStorageKey(1)),
+    ).toContain(String(MOCK_MARKETING_CVR_DATA_SOURCE_ID));
+    expect(
+      localStorage.getItem(getDeletedMockDataSourceStorageKey(2)),
+    ).toBeNull();
+  });
+
+  it('ignores non-mock ids and filters hidden mock rows', () => {
+    installWindowStorage();
+
+    expect(
+      markMockDataSourcesDeleted(1, [42, MOCK_MARKETING_CVR_DATA_SOURCE_ID]),
+    ).toEqual([MOCK_MARKETING_CVR_DATA_SOURCE_ID]);
+
+    const visibleDataSources = filterVisibleMockDataSources(
+      [
+        { dataSourceId: MOCK_MARKETING_CVR_DATA_SOURCE_ID, fileName: 'mock' },
+        { dataSourceId: 42, fileName: 'server' },
+      ],
+      readDeletedMockDataSourceIds(1),
+    );
+
+    expect(visibleDataSources).toEqual([
+      { dataSourceId: 42, fileName: 'server' },
+    ]);
+  });
+
+  it('handles malformed localStorage data safely', () => {
+    const { localStorage } = installWindowStorage();
+
+    localStorage.setItem(getDeletedMockDataSourceStorageKey(1), '{');
+
+    expect(readDeletedMockDataSourceIds(1).size).toBe(0);
+  });
+
+  it('does not throw when localStorage is unavailable', () => {
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: Object.defineProperty({}, 'localStorage', {
+        get() {
+          throw new Error('blocked');
+        },
+      }),
+    });
+
+    expect(readDeletedMockDataSourceIds(1).size).toBe(0);
+    expect(() =>
+      markMockDataSourcesDeleted(1, [MOCK_MARKETING_CVR_DATA_SOURCE_ID]),
+    ).not.toThrow();
+  });
+});

--- a/apps/fe/src/apis/mockDataSource.ts
+++ b/apps/fe/src/apis/mockDataSource.ts
@@ -8,6 +8,8 @@ import type {
 
 export const MOCK_MARKETING_CVR_DATA_SOURCE_ID = 900001;
 
+const DELETED_MOCK_DATA_SOURCE_STORAGE_PREFIX =
+  'logue:deleted-mock-datasources:';
 const MOCK_MARKETING_CVR_FILE_NAME = 'marketing-cvr-mock-data.csv';
 const MOCK_MARKETING_CVR_FILE_PATH = '/mock-data/marketing-cvr-mock-data.csv';
 const MOCK_MARKETING_CVR_FILE_SIZE_BYTES = 70064;
@@ -21,6 +23,16 @@ const MOCK_MARKETING_CVR_SUMMARY: DataSourceSummary = {
 };
 
 let mockMarketingCvrPreviewPromise: Promise<FilePreview> | null = null;
+
+function getOptionalLocalStorage() {
+  if (typeof window === 'undefined') return null;
+
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
 
 function parseCsvLine(line: string) {
   return line.split(',').map((value) => value.trim());
@@ -66,6 +78,74 @@ async function getMockMarketingCvrPreview() {
 
 export function isMockDataSourceId(dataSourceId: number) {
   return dataSourceId === MOCK_MARKETING_CVR_DATA_SOURCE_ID;
+}
+
+export function getDeletedMockDataSourceStorageKey(userId: number) {
+  return `${DELETED_MOCK_DATA_SOURCE_STORAGE_PREFIX}${userId}`;
+}
+
+export function readDeletedMockDataSourceIds(userId: number) {
+  const storage = getOptionalLocalStorage();
+  if (!storage) return new Set<number>();
+
+  try {
+    const rawValue = storage.getItem(
+      getDeletedMockDataSourceStorageKey(userId),
+    );
+    if (!rawValue) return new Set<number>();
+
+    const parsedValue: unknown = JSON.parse(rawValue);
+    if (!Array.isArray(parsedValue)) return new Set<number>();
+
+    return new Set(
+      parsedValue.filter(
+        (value): value is number =>
+          Number.isSafeInteger(value) && isMockDataSourceId(value),
+      ),
+    );
+  } catch {
+    return new Set<number>();
+  }
+}
+
+export function markMockDataSourcesDeleted(
+  userId: number,
+  dataSourceIds: number[],
+) {
+  const mockDataSourceIds = Array.from(
+    new Set(dataSourceIds.filter(isMockDataSourceId)),
+  );
+
+  if (mockDataSourceIds.length === 0) return [];
+
+  const deletedIds = readDeletedMockDataSourceIds(userId);
+  mockDataSourceIds.forEach((dataSourceId) => deletedIds.add(dataSourceId));
+
+  const storage = getOptionalLocalStorage();
+  if (storage) {
+    try {
+      storage.setItem(
+        getDeletedMockDataSourceStorageKey(userId),
+        JSON.stringify(Array.from(deletedIds)),
+      );
+    } catch {
+      // Keep the in-memory UI state even when localStorage is unavailable.
+    }
+  }
+
+  return mockDataSourceIds;
+}
+
+export function filterVisibleMockDataSources<
+  TDataSource extends Pick<DataSourceSummary, 'dataSourceId'>,
+>(dataSources: TDataSource[], deletedMockDataSourceIds: ReadonlySet<number>) {
+  return dataSources.filter(
+    (dataSource) =>
+      !(
+        isMockDataSourceId(dataSource.dataSourceId) &&
+        deletedMockDataSourceIds.has(dataSource.dataSourceId)
+      ),
+  );
 }
 
 export function withMockDataSource(

--- a/apps/fe/src/app/(main)/data/[id]/page.tsx
+++ b/apps/fe/src/app/(main)/data/[id]/page.tsx
@@ -2,14 +2,24 @@
 
 import { use, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { getApiErrorMessage, isApiConflictError } from '@/apis/errors';
+import { isMockDataSourceId } from '@/apis/mockDataSource';
 import { ToastPortal } from '@/components';
+import { useMyInfo } from '@/hooks/useMyInfo';
 import { useToast } from '@/hooks/useToast';
 import { useAuthSession } from '@/providers/AuthProvider';
 import DataDetailStatus from './_components/DataDetailStatus';
 import DataDetailView from './_components/DataDetailView';
 import { useDataDetail } from './_hooks/useDataDetail';
+import { useDeletedMockDataSources } from '../_hooks/useDeletedMockDataSources';
 
 type PageParams = { id: string };
+
+const DELETE_ERROR_MESSAGE = '파일 삭제에 실패했습니다.';
+const DELETE_CONFLICT_ERROR_MESSAGE =
+  '연결된 분석 채팅이 있어 현재 삭제할 수 없어요. 채팅 삭제 기능이 준비되면 함께 삭제할 수 있습니다.';
+const USER_INFO_REQUIRED_MESSAGE =
+  '사용자 정보를 확인한 뒤 다시 시도해 주세요.';
 
 export default function DataDetailPage({
   params,
@@ -20,25 +30,42 @@ export default function DataDetailPage({
   const router = useRouter();
   const { hasAccessToken, status } = useAuthSession();
   const isAuthenticated = status === 'authenticated';
+  const { data: myInfo } = useMyInfo(isAuthenticated);
+  const { deletedMockDataSourceIds, markDeletedMockDataSources } =
+    useDeletedMockDataSources(myInfo?.id);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const { toast, showToast } = useToast();
 
   const dataSourceId = Number(id);
   const isValidDataSourceId =
     Number.isSafeInteger(dataSourceId) && dataSourceId > 0;
+  const isDeletedMockDataSource =
+    isMockDataSourceId(dataSourceId) &&
+    deletedMockDataSourceIds.has(dataSourceId);
   const dataDetail = useDataDetail({
     dataSourceId: isValidDataSourceId ? dataSourceId : 0,
-    enabled: isAuthenticated && isValidDataSourceId,
+    enabled: isAuthenticated && isValidDataSourceId && !isDeletedMockDataSource,
   });
 
   const handleDeleteConfirm = async () => {
     try {
-      await dataDetail.deleteDataSource();
+      if (isMockDataSourceId(dataSourceId)) {
+        if (!myInfo?.id) throw new Error(USER_INFO_REQUIRED_MESSAGE);
+
+        markDeletedMockDataSources([dataSourceId]);
+      } else {
+        await dataDetail.deleteDataSource();
+      }
+
       setDeleteOpen(false);
       router.push('/data');
-    } catch {
+    } catch (error) {
       setDeleteOpen(false);
-      showToast('파일 삭제에 실패했습니다.');
+      showToast(
+        isApiConflictError(error)
+          ? DELETE_CONFLICT_ERROR_MESSAGE
+          : getApiErrorMessage(error, DELETE_ERROR_MESSAGE),
+      );
     }
   };
 
@@ -60,7 +87,7 @@ export default function DataDetailPage({
     return <DataDetailStatus message="데이터 소스를 불러오는 중입니다." />;
   }
 
-  if (dataDetail.isError || !dataDetail.detail) {
+  if (isDeletedMockDataSource || dataDetail.isError || !dataDetail.detail) {
     return <DataDetailStatus message="데이터 소스를 불러오지 못했습니다." />;
   }
 

--- a/apps/fe/src/app/(main)/data/_hooks/useDataSourceList.ts
+++ b/apps/fe/src/app/(main)/data/_hooks/useDataSourceList.ts
@@ -5,11 +5,15 @@ import { useQuery } from '@tanstack/react-query';
 import { dataSourceKeys, type DataSourceSort } from '@/apis/datasource';
 import { getDataSources } from '@/apis/dataSourceRepository';
 import { getApiErrorMessage } from '@/apis/errors';
-import { getMockDataSourceListResponse } from '@/apis/mockDataSource';
+import {
+  filterVisibleMockDataSources,
+  getMockDataSourceListResponse,
+} from '@/apis/mockDataSource';
 
 const DATA_SOURCE_PAGE_SIZE = 20;
 
 type UseDataSourceListParams = {
+  deletedMockDataSourceIds: ReadonlySet<number>;
   enabled: boolean;
   fallbackErrorMessage: string;
   page: number;
@@ -17,6 +21,7 @@ type UseDataSourceListParams = {
 };
 
 export function useDataSourceList({
+  deletedMockDataSourceIds,
   enabled,
   fallbackErrorMessage,
   page,
@@ -32,9 +37,16 @@ export function useDataSourceList({
     queryFn: () => getDataSources(listParams),
     enabled,
   });
-  const dataSources =
-    query.data?.dataSources ??
-    getMockDataSourceListResponse(listParams).dataSources;
+  const dataSources = useMemo(() => {
+    const rawDataSources =
+      query.data?.dataSources ??
+      getMockDataSourceListResponse(listParams).dataSources;
+
+    return filterVisibleMockDataSources(
+      rawDataSources,
+      deletedMockDataSourceIds,
+    );
+  }, [deletedMockDataSourceIds, listParams, query.data?.dataSources]);
   const hasDataSources = dataSources.length > 0;
 
   return {

--- a/apps/fe/src/app/(main)/data/_hooks/useDeleteDataSources.ts
+++ b/apps/fe/src/app/(main)/data/_hooks/useDeleteDataSources.ts
@@ -4,18 +4,28 @@ import { useCallback } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { deleteDataSources } from '@/apis/dataSourceRepository';
 import { dataSourceKeys } from '@/apis/datasource';
-import { getApiErrorMessage } from '@/apis/errors';
+import { getApiErrorMessage, isApiConflictError } from '@/apis/errors';
+import { isMockDataSourceId } from '@/apis/mockDataSource';
+
+const USER_INFO_REQUIRED_MESSAGE =
+  '사용자 정보를 확인한 뒤 다시 시도해 주세요.';
 
 type UseDeleteDataSourcesOptions = {
+  conflictErrorMessage: string;
   fallbackErrorMessage: string;
+  onDeletedMockDataSources: (dataSourceIds: number[]) => void;
   onError: (message: string) => void;
   onSuccess: () => void;
+  userId?: number | null;
 };
 
 export function useDeleteDataSources({
+  conflictErrorMessage,
   fallbackErrorMessage,
+  onDeletedMockDataSources,
   onError,
   onSuccess,
+  userId,
 }: UseDeleteDataSourcesOptions) {
   const queryClient = useQueryClient();
   const mutation = useMutation({
@@ -26,17 +36,47 @@ export function useDeleteDataSources({
     async (dataSourceIds: number[]) => {
       if (dataSourceIds.length === 0) return;
 
+      const mockDataSourceIds = dataSourceIds.filter(isMockDataSourceId);
+      const serverDataSourceIds = dataSourceIds.filter(
+        (dataSourceId) => !isMockDataSourceId(dataSourceId),
+      );
+
+      if (mockDataSourceIds.length > 0 && !userId) {
+        onError(USER_INFO_REQUIRED_MESSAGE);
+        return;
+      }
+
       try {
-        await mutation.mutateAsync(dataSourceIds);
+        if (serverDataSourceIds.length > 0) {
+          await mutation.mutateAsync(serverDataSourceIds);
+        }
+
+        if (mockDataSourceIds.length > 0 && userId) {
+          onDeletedMockDataSources(mockDataSourceIds);
+        }
+
         await queryClient.invalidateQueries({
           queryKey: dataSourceKeys.lists(),
         });
         onSuccess();
       } catch (error) {
-        onError(getApiErrorMessage(error, fallbackErrorMessage));
+        onError(
+          isApiConflictError(error)
+            ? conflictErrorMessage
+            : getApiErrorMessage(error, fallbackErrorMessage),
+        );
       }
     },
-    [fallbackErrorMessage, mutation, onError, onSuccess, queryClient],
+    [
+      conflictErrorMessage,
+      fallbackErrorMessage,
+      mutation,
+      onDeletedMockDataSources,
+      onError,
+      onSuccess,
+      queryClient,
+      userId,
+    ],
   );
 
   return {

--- a/apps/fe/src/app/(main)/data/_hooks/useDeleteDataSources.ts
+++ b/apps/fe/src/app/(main)/data/_hooks/useDeleteDataSources.ts
@@ -41,7 +41,7 @@ export function useDeleteDataSources({
         (dataSourceId) => !isMockDataSourceId(dataSourceId),
       );
 
-      if (mockDataSourceIds.length > 0 && !userId) {
+      if (mockDataSourceIds.length > 0 && userId == null) {
         onError(USER_INFO_REQUIRED_MESSAGE);
         return;
       }
@@ -51,7 +51,7 @@ export function useDeleteDataSources({
           await mutation.mutateAsync(serverDataSourceIds);
         }
 
-        if (mockDataSourceIds.length > 0 && userId) {
+        if (mockDataSourceIds.length > 0 && userId != null) {
           onDeletedMockDataSources(mockDataSourceIds);
         }
 

--- a/apps/fe/src/app/(main)/data/_hooks/useDeletedMockDataSources.ts
+++ b/apps/fe/src/app/(main)/data/_hooks/useDeletedMockDataSources.ts
@@ -1,0 +1,64 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import {
+  markMockDataSourcesDeleted,
+  readDeletedMockDataSourceIds,
+} from '@/apis/mockDataSource';
+
+const EMPTY_DELETED_IDS = new Set<number>();
+
+export function useDeletedMockDataSources(userId: number | null | undefined) {
+  const [sessionDeletedIdsByUser, setSessionDeletedIdsByUser] = useState(
+    () => new Map<number, Set<number>>(),
+  );
+
+  const storageDeletedIds = useMemo(
+    () => (userId ? readDeletedMockDataSourceIds(userId) : EMPTY_DELETED_IDS),
+    [userId],
+  );
+  const sessionDeletedIds = useMemo(
+    () =>
+      userId
+        ? (sessionDeletedIdsByUser.get(userId) ?? EMPTY_DELETED_IDS)
+        : EMPTY_DELETED_IDS,
+    [sessionDeletedIdsByUser, userId],
+  );
+  const deletedMockDataSourceIds = useMemo(() => {
+    const deletedIds = new Set(storageDeletedIds);
+    sessionDeletedIds.forEach((dataSourceId) => {
+      deletedIds.add(dataSourceId);
+    });
+
+    return deletedIds;
+  }, [sessionDeletedIds, storageDeletedIds]);
+
+  const markDeletedMockDataSources = useCallback(
+    (dataSourceIds: number[]) => {
+      if (!userId) return [];
+
+      const deletedIds = markMockDataSourcesDeleted(userId, dataSourceIds);
+      if (deletedIds.length === 0) return deletedIds;
+
+      setSessionDeletedIdsByUser((prev) => {
+        const next = new Map(prev);
+        const nextDeletedIds = new Set(next.get(userId));
+
+        deletedIds.forEach((dataSourceId) => {
+          nextDeletedIds.add(dataSourceId);
+        });
+        next.set(userId, nextDeletedIds);
+
+        return next;
+      });
+
+      return deletedIds;
+    },
+    [userId],
+  );
+
+  return {
+    deletedMockDataSourceIds,
+    markDeletedMockDataSources,
+  };
+}

--- a/apps/fe/src/app/(main)/data/_hooks/useDeletedMockDataSources.ts
+++ b/apps/fe/src/app/(main)/data/_hooks/useDeletedMockDataSources.ts
@@ -14,12 +14,13 @@ export function useDeletedMockDataSources(userId: number | null | undefined) {
   );
 
   const storageDeletedIds = useMemo(
-    () => (userId ? readDeletedMockDataSourceIds(userId) : EMPTY_DELETED_IDS),
+    () =>
+      userId != null ? readDeletedMockDataSourceIds(userId) : EMPTY_DELETED_IDS,
     [userId],
   );
   const sessionDeletedIds = useMemo(
     () =>
-      userId
+      userId != null
         ? (sessionDeletedIdsByUser.get(userId) ?? EMPTY_DELETED_IDS)
         : EMPTY_DELETED_IDS,
     [sessionDeletedIdsByUser, userId],
@@ -35,7 +36,7 @@ export function useDeletedMockDataSources(userId: number | null | undefined) {
 
   const markDeletedMockDataSources = useCallback(
     (dataSourceIds: number[]) => {
-      if (!userId) return [];
+      if (userId == null) return [];
 
       const deletedIds = markMockDataSourcesDeleted(userId, dataSourceIds);
       if (deletedIds.length === 0) return deletedIds;

--- a/apps/fe/src/app/(main)/data/page.tsx
+++ b/apps/fe/src/app/(main)/data/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { type DataSourceSummary, type DataSourceSort } from '@/apis/datasource';
 import {
@@ -10,11 +10,13 @@ import {
   ToastPortal,
 } from '@/components';
 import { useStartAnalysis } from '@/hooks/useStartAnalysis';
+import { useMyInfo } from '@/hooks/useMyInfo';
 import { useToast } from '@/hooks/useToast';
 import { validateCsvFile } from '@/lib/fileValidation';
 import { useAuthSession } from '@/providers/AuthProvider';
 import DataSourceRow from './_components/DataSourceRow';
 import SortDropdown from './_components/SortDropdown';
+import { useDeletedMockDataSources } from './_hooks/useDeletedMockDataSources';
 import { useDataSourceList } from './_hooks/useDataSourceList';
 import { useDeleteDataSources } from './_hooks/useDeleteDataSources';
 import { useUploadDataSource } from './_hooks/useUploadDataSource';
@@ -26,6 +28,8 @@ const UPLOAD_ERROR_MESSAGE =
   '파일 업로드에 실패했어요. 잠시 후 다시 시도해 주세요.';
 const DELETE_ERROR_MESSAGE =
   '파일 삭제에 실패했어요. 잠시 후 다시 시도해 주세요.';
+const DELETE_CONFLICT_ERROR_MESSAGE =
+  '연결된 분석 채팅이 있어 현재 삭제할 수 없어요. 채팅 삭제 기능이 준비되면 함께 삭제할 수 있습니다.';
 const START_CHAT_ERROR_MESSAGE =
   '분석 채팅을 시작하지 못했어요. 잠시 후 다시 시도해 주세요.';
 
@@ -44,6 +48,9 @@ export default function DataPage() {
   const router = useRouter();
   const { hasAccessToken, status } = useAuthSession();
   const isAuthenticated = status === 'authenticated';
+  const { data: myInfo } = useMyInfo(isAuthenticated);
+  const { deletedMockDataSourceIds, markDeletedMockDataSources } =
+    useDeletedMockDataSources(myInfo?.id);
   const { toast, showToast } = useToast();
   const [sortKey, setSortKey] = useState<DataSourceSort>('LATEST');
   const [page, setPage] = useState(0);
@@ -57,6 +64,7 @@ export default function DataPage() {
   });
 
   const dataSourcesQuery = useDataSourceList({
+    deletedMockDataSourceIds,
     enabled: isAuthenticated,
     fallbackErrorMessage: LIST_ERROR_MESSAGE,
     page,
@@ -73,7 +81,9 @@ export default function DataPage() {
     },
   });
   const deleteDataSourcesMutation = useDeleteDataSources({
+    conflictErrorMessage: DELETE_CONFLICT_ERROR_MESSAGE,
     fallbackErrorMessage: DELETE_ERROR_MESSAGE,
+    onDeletedMockDataSources: markDeletedMockDataSources,
     onError: (message) => {
       setDeleteOpen(false);
       showToast(message, 'error');
@@ -83,15 +93,31 @@ export default function DataPage() {
       setDeleteOpen(false);
       showToast('파일을 삭제했습니다.', 'success');
     },
+    userId: myInfo?.id,
   });
 
   const dataSources = dataSourcesQuery.dataSources;
+  const visibleDataSourceIds = useMemo(
+    () => new Set(dataSources.map((dataSource) => dataSource.dataSourceId)),
+    [dataSources],
+  );
+  const selectedVisibleIds = useMemo(
+    () =>
+      new Set(
+        Array.from(selectedIds).filter((dataSourceId) =>
+          visibleDataSourceIds.has(dataSourceId),
+        ),
+      ),
+    [selectedIds, visibleDataSourceIds],
+  );
   const chatPendingDataSourceId = startAnalysis.pendingDataSourceId;
   const allSelected =
     dataSources.length > 0 &&
-    dataSources.every((dataSource) => selectedIds.has(dataSource.dataSourceId));
-  const partiallySelected = !allSelected && selectedIds.size > 0;
-  const hasSelection = selectedIds.size > 0;
+    dataSources.every((dataSource) =>
+      selectedVisibleIds.has(dataSource.dataSourceId),
+    );
+  const partiallySelected = !allSelected && selectedVisibleIds.size > 0;
+  const hasSelection = selectedVisibleIds.size > 0;
   const tableMessage =
     !hasAccessToken && status !== 'initializing'
       ? LOGIN_REQUIRED_MESSAGE
@@ -143,7 +169,7 @@ export default function DataPage() {
   };
 
   const handleDeleteConfirm = async () => {
-    await deleteDataSourcesMutation.remove(Array.from(selectedIds));
+    await deleteDataSourcesMutation.remove(Array.from(selectedVisibleIds));
   };
 
   const handleChat = (dataSource: DataSourceSummary) => {
@@ -236,7 +262,7 @@ export default function DataPage() {
               dataSources.map((dataSource) => (
                 <DataSourceRow
                   key={dataSource.dataSourceId}
-                  checked={selectedIds.has(dataSource.dataSourceId)}
+                  checked={selectedVisibleIds.has(dataSource.dataSourceId)}
                   chatDisabled={startAnalysis.isPending}
                   chatPending={
                     chatPendingDataSourceId === dataSource.dataSourceId


### PR DESCRIPTION
﻿## 요약
- 데이터 소스 삭제 실패 시 409/D007 응답을 분석 채팅 연결 안내로 분기했습니다.
- FE 내장 mock 데이터 삭제 상태를 사용자별 localStorage에 저장하고 목록/상세에서 숨기도록 했습니다.
- mock 삭제 저장소와 API 에러 코드/status 추출 유틸 테스트를 추가했습니다.

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩터링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `yarn lint`
  - `yarn test`

## 스크린샷/로그 (선택)
- 별도 첨부 없음

## 롤백/리스크
- 리스크: 관련 채팅까지 실제 삭제하는 동작은 아직 BE API/DB 정책이 없어 포함하지 않았습니다.
- 롤백 방법: 이 PR을 revert하면 기존 삭제 실패 안내와 mock 주입 동작으로 돌아갑니다.

## 관련 이슈
Closes #255


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 삭제된 모의 데이터 소스가 목록에서 자동으로 숨겨집니다.
  * 데이터 소스 삭제 시 충돌 상황에 대한 명확한 오류 메시지를 제공합니다.

* **버그 수정**
  * 사용자별 삭제된 모의 데이터 소스 상태를 안정적으로 추적합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/26-ewha-capstone-logue/logue/pull/256?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->