### PR TITLE
test: AI 02 질문분석 평가 케이스 43개 적재 + composer/fixtures

### DIFF
--- a/apps/ai/eval/cases/question_analysis/amb/AMB-01.json
+++ b/apps/ai/eval/cases/question_analysis/amb/AMB-01.json
@@ -1,0 +1,20 @@
+{
+  "id": "AMB-01",
+  "layer": "모호성·경고",
+  "category": "amb",
+  "description": "DIMENSION 모호 - channel/source 둘 다, channel 우선",
+  "spec": {
+    "id": "AMB-01",
+    "dataset": "dataset-c",
+    "question": "이번 주 채널별 가입 전환율 top 5"
+  },
+  "expected": {
+    "analysis_criteria": {
+      "analysis_type": "RANKING",
+      "metric_name": "signup_conversion_rate",
+      "group_by": ["channel"],
+      "limit_num": 5
+    },
+    "warnings": {"QUESTION_DATA_MISMATCH": true}
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/amb/AMB-02.json
+++ b/apps/ai/eval/cases/question_analysis/amb/AMB-02.json
@@ -1,0 +1,20 @@
+{
+  "id": "AMB-02",
+  "layer": "모호성·경고",
+  "category": "amb",
+  "description": "MEASURE 모호 - signup_complete/signups 둘 다, predefined formula 기준 signup_complete 우선",
+  "spec": {
+    "id": "AMB-02",
+    "dataset": "dataset-c",
+    "question": "이번 주 채널·디바이스별 가입 전환율 top 5"
+  },
+  "expected": {
+    "analysis_criteria": {
+      "analysis_type": "RANKING",
+      "metric_name": "signup_conversion_rate",
+      "group_by": ["channel", "device"],
+      "limit_num": 5
+    },
+    "warnings": {"QUESTION_DATA_MISMATCH": true}
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/amb/AMB-03.json
+++ b/apps/ai/eval/cases/question_analysis/amb/AMB-03.json
@@ -1,0 +1,26 @@
+{
+  "id": "AMB-03",
+  "layer": "모호성·경고",
+  "category": "amb",
+  "description": "STATUS_CONDITION 모호 - payment_status/order_status 둘 다, 질문 키워드 기준 payment_status 선택",
+  "spec": {
+    "id": "AMB-03",
+    "dataset": "dataset-a",
+    "add_columns": [
+      {"name": "payment_status", "data_type": "string", "role": "STATUS_CONDITION", "sample_values": ["paid", "pending"]},
+      {"name": "order_status", "data_type": "string", "role": "STATUS_CONDITION", "sample_values": ["fulfilled", "cancelled"]}
+    ],
+    "question": "이번 주 결제 완료 채널별 가입 전환율 top 5"
+  },
+  "expected": {
+    "analysis_criteria": {
+      "analysis_type": "RANKING",
+      "metric_name": "signup_conversion_rate",
+      "base_date_column": "event_date",
+      "standard_period": "1W",
+      "group_by": ["channel"],
+      "limit_num": 5
+    },
+    "warnings": {"QUESTION_DATA_MISMATCH": true}
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/amb/AMB-04.json
+++ b/apps/ai/eval/cases/question_analysis/amb/AMB-04.json
@@ -1,0 +1,25 @@
+{
+  "id": "AMB-04",
+  "layer": "모호성·경고",
+  "category": "amb",
+  "description": "FLAG 모호 - account_flag(string)/is_test_account(boolean), boolean 우선",
+  "spec": {
+    "id": "AMB-04",
+    "dataset": "dataset-a",
+    "add_columns": [
+      {"name": "is_test_account", "data_type": "boolean", "role": "FLAG", "sample_values": [true, false]}
+    ],
+    "question": "테스트 계정 제외하고 이번 주 가입 전환율 하위 5개 채널·디바이스"
+  },
+  "expected": {
+    "analysis_criteria": {
+      "analysis_type": "RANKING",
+      "metric_name": "signup_conversion_rate",
+      "base_date_column": "event_date",
+      "standard_period": "1W",
+      "group_by": ["channel", "device"],
+      "limit_num": 5
+    },
+    "warnings": {"QUESTION_DATA_MISMATCH": true}
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/amb/AMB-05.json
+++ b/apps/ai/eval/cases/question_analysis/amb/AMB-05.json
@@ -1,0 +1,20 @@
+{
+  "id": "AMB-05",
+  "layer": "모호성·경고",
+  "category": "amb",
+  "description": "DATE_CRITERIA 충돌 - event_date/created_at 둘 다",
+  "spec": {
+    "id": "AMB-05",
+    "dataset": "dataset-c",
+    "question": "이번 주 채널별 가입 전환율 top 5"
+  },
+  "expected": {
+    "analysis_criteria": {
+      "analysis_type": "RANKING",
+      "metric_name": "signup_conversion_rate",
+      "group_by": ["channel"],
+      "limit_num": 5
+    },
+    "warnings": {"QUESTION_DATA_MISMATCH": true}
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/amb/AMB-06.json
+++ b/apps/ai/eval/cases/question_analysis/amb/AMB-06.json
@@ -1,0 +1,22 @@
+{
+  "id": "AMB-06",
+  "layer": "스키마 변화+모호성",
+  "category": "amb",
+  "description": "질문이 '채널'인데 데이터셋엔 source 만 - source 자동 매핑",
+  "spec": {
+    "id": "AMB-06",
+    "dataset": "dataset-b",
+    "question": "이번 주 채널별 가입 전환율 top 5"
+  },
+  "expected": {
+    "analysis_criteria": {
+      "analysis_type": "RANKING",
+      "metric_name": "signup_conversion_rate",
+      "base_date_column": "created_at",
+      "standard_period": "1W",
+      "group_by": ["source"],
+      "limit_num": 5
+    },
+    "warnings": {"QUESTION_DATA_MISMATCH": true}
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/amb/AMB-07.json
+++ b/apps/ai/eval/cases/question_analysis/amb/AMB-07.json
@@ -1,0 +1,26 @@
+{
+  "id": "AMB-07",
+  "layer": "모호성·경고",
+  "category": "amb",
+  "description": "3-way DIMENSION 모호 - device/device_type/device_kind",
+  "spec": {
+    "id": "AMB-07",
+    "dataset": "dataset-a",
+    "add_columns": [
+      {"name": "device_type", "data_type": "string", "role": "DIMENSION", "sample_values": ["smartphone"]},
+      {"name": "device_kind", "data_type": "string", "role": "DIMENSION", "sample_values": ["touch"]}
+    ],
+    "question": "이번 주 디바이스별 가입 전환율 top 5"
+  },
+  "expected": {
+    "analysis_criteria": {
+      "analysis_type": "RANKING",
+      "metric_name": "signup_conversion_rate",
+      "base_date_column": "event_date",
+      "standard_period": "1W",
+      "group_by": ["device"],
+      "limit_num": 5
+    },
+    "warnings": {"QUESTION_DATA_MISMATCH": true}
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/amb/AMB-08.json
+++ b/apps/ai/eval/cases/question_analysis/amb/AMB-08.json
@@ -1,0 +1,21 @@
+{
+  "id": "AMB-08",
+  "layer": "모호성·경고",
+  "category": "amb",
+  "description": "metric 모호 - '전환율' 이 signup/trial_start/paid 중 어디?",
+  "spec": {
+    "id": "AMB-08",
+    "dataset": "dataset-a",
+    "question": "이번 주 채널별 전환율 top 5"
+  },
+  "expected": {
+    "analysis_criteria": {
+      "analysis_type": "RANKING",
+      "base_date_column": "event_date",
+      "standard_period": "1W",
+      "group_by": ["channel"],
+      "limit_num": 5
+    },
+    "warnings": {"QUESTION_DATA_MISMATCH": true}
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/amb/AMB-09.json
+++ b/apps/ai/eval/cases/question_analysis/amb/AMB-09.json
@@ -1,0 +1,21 @@
+{
+  "id": "AMB-09",
+  "layer": "표현 다양화",
+  "category": "amb",
+  "description": "period 모호 - '최근'만 (1W/1M/3M 다 가능), LLM 기본값 적용",
+  "spec": {
+    "id": "AMB-09",
+    "dataset": "dataset-a",
+    "question": "최근 채널별 가입 전환율 top 5"
+  },
+  "expected": {
+    "analysis_criteria": {
+      "analysis_type": "RANKING",
+      "metric_name": "signup_conversion_rate",
+      "base_date_column": "event_date",
+      "group_by": ["channel"],
+      "limit_num": 5
+    },
+    "warnings": {"QUESTION_DATA_MISMATCH": true}
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/cmp/CMP-01.json
+++ b/apps/ai/eval/cases/question_analysis/cmp/CMP-01.json
@@ -1,0 +1,21 @@
+{
+  "id": "CMP-01",
+  "layer": "정상 케이스",
+  "category": "cmp",
+  "spec": {
+    "id": "CMP-01",
+    "dataset": "dataset-a",
+    "question": "이번 주 가입 전환율이 지난주 대비 가장 많이 떨어진 채널·디바이스를 알려줘"
+  },
+  "expected": {
+    "analysis_criteria": {
+      "analysis_type": "COMPARISON",
+      "metric_name": "signup_conversion_rate",
+      "base_date_column": "event_date",
+      "standard_period": "1W",
+      "compare_period": "1W",
+      "group_by": ["channel", "device"],
+      "sort_direction": "asc"
+    }
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/cmp/CMP-02.json
+++ b/apps/ai/eval/cases/question_analysis/cmp/CMP-02.json
@@ -1,0 +1,21 @@
+{
+  "id": "CMP-02",
+  "layer": "정상 케이스",
+  "category": "cmp",
+  "spec": {
+    "id": "CMP-02",
+    "dataset": "dataset-a",
+    "question": "이번 달 채널별 액티베이션율이 지난달 대비 가장 떨어진 곳은?"
+  },
+  "expected": {
+    "analysis_criteria": {
+      "analysis_type": "COMPARISON",
+      "metric_name": "activation_rate",
+      "base_date_column": "event_date",
+      "standard_period": "1M",
+      "compare_period": "1M",
+      "group_by": ["channel"],
+      "sort_direction": "asc"
+    }
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/cmp/CMP-03.json
+++ b/apps/ai/eval/cases/question_analysis/cmp/CMP-03.json
@@ -1,0 +1,21 @@
+{
+  "id": "CMP-03",
+  "layer": "정상 케이스",
+  "category": "cmp",
+  "spec": {
+    "id": "CMP-03",
+    "dataset": "dataset-a",
+    "question": "지난주 대비 이번 주 트라이얼 시작율이 가장 많이 떨어진 디바이스를 보여줘"
+  },
+  "expected": {
+    "analysis_criteria": {
+      "analysis_type": "COMPARISON",
+      "metric_name": "trial_start_rate",
+      "base_date_column": "event_date",
+      "standard_period": "1W",
+      "compare_period": "1W",
+      "group_by": ["device"],
+      "sort_direction": "asc"
+    }
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/cmp/CMP-04.json
+++ b/apps/ai/eval/cases/question_analysis/cmp/CMP-04.json
@@ -1,0 +1,21 @@
+{
+  "id": "CMP-04",
+  "layer": "정상 케이스",
+  "category": "cmp",
+  "spec": {
+    "id": "CMP-04",
+    "dataset": "dataset-a",
+    "question": "이번 분기 유료 전환율이 직전 분기 대비 가장 많이 하락한 채널·디바이스 조합은?"
+  },
+  "expected": {
+    "analysis_criteria": {
+      "analysis_type": "COMPARISON",
+      "metric_name": "paid_conversion_rate",
+      "base_date_column": "event_date",
+      "standard_period": "3M",
+      "compare_period": "3M",
+      "group_by": ["channel", "device"],
+      "sort_direction": "asc"
+    }
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/cmp/CMP-05.json
+++ b/apps/ai/eval/cases/question_analysis/cmp/CMP-05.json
@@ -1,0 +1,21 @@
+{
+  "id": "CMP-05",
+  "layer": "표현 다양화",
+  "category": "cmp",
+  "spec": {
+    "id": "CMP-05",
+    "dataset": "dataset-a",
+    "question": "이번 주 가입 전환율이 전주 대비 어디서 제일 빠졌어?"
+  },
+  "expected": {
+    "analysis_criteria": {
+      "analysis_type": "COMPARISON",
+      "metric_name": "signup_conversion_rate",
+      "base_date_column": "event_date",
+      "standard_period": "1W",
+      "compare_period": "1W",
+      "group_by": ["channel", "device"],
+      "sort_direction": "asc"
+    }
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/cmp/CMP-06.json
+++ b/apps/ai/eval/cases/question_analysis/cmp/CMP-06.json
@@ -1,0 +1,21 @@
+{
+  "id": "CMP-06",
+  "layer": "표현 다양화",
+  "category": "cmp",
+  "spec": {
+    "id": "CMP-06",
+    "dataset": "dataset-a",
+    "question": "전주 대비 크게 떨어진 구간 보여줘"
+  },
+  "expected": {
+    "analysis_criteria": {
+      "analysis_type": "COMPARISON",
+      "metric_name": "signup_conversion_rate",
+      "base_date_column": "event_date",
+      "standard_period": "1W",
+      "compare_period": "1W",
+      "group_by": ["channel", "device"],
+      "sort_direction": "asc"
+    }
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/cmp/CMP-07.json
+++ b/apps/ai/eval/cases/question_analysis/cmp/CMP-07.json
@@ -1,0 +1,21 @@
+{
+  "id": "CMP-07",
+  "layer": "표현 다양화",
+  "category": "cmp",
+  "spec": {
+    "id": "CMP-07",
+    "dataset": "dataset-a",
+    "question": "이번 주 전환율 하락폭이 가장 큰 채널·디바이스"
+  },
+  "expected": {
+    "analysis_criteria": {
+      "analysis_type": "COMPARISON",
+      "metric_name": "signup_conversion_rate",
+      "base_date_column": "event_date",
+      "standard_period": "1W",
+      "compare_period": "1W",
+      "group_by": ["channel", "device"],
+      "sort_direction": "asc"
+    }
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/cmp/CMP-08.json
+++ b/apps/ai/eval/cases/question_analysis/cmp/CMP-08.json
@@ -1,0 +1,21 @@
+{
+  "id": "CMP-08",
+  "layer": "스키마 변화",
+  "category": "cmp",
+  "spec": {
+    "id": "CMP-08",
+    "dataset": "dataset-b",
+    "question": "이번 주 가입 전환율이 지난주 대비 가장 많이 떨어진 소스·디바이스를 알려줘"
+  },
+  "expected": {
+    "analysis_criteria": {
+      "analysis_type": "COMPARISON",
+      "metric_name": "signup_conversion_rate",
+      "base_date_column": "created_at",
+      "standard_period": "1W",
+      "compare_period": "1W",
+      "group_by": ["source", "device_type"],
+      "sort_direction": "asc"
+    }
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/cmp/CMP-09.json
+++ b/apps/ai/eval/cases/question_analysis/cmp/CMP-09.json
@@ -1,0 +1,21 @@
+{
+  "id": "CMP-09",
+  "layer": "모호성·경고",
+  "category": "cmp",
+  "description": "dataset-c (날짜 컬럼 2개) - DATE_FIELD_CONFLICT warning, base_date_column 비결정",
+  "spec": {
+    "id": "CMP-09",
+    "dataset": "dataset-c",
+    "question": "이번 주 가입 전환율이 지난주 대비 가장 많이 떨어진 채널·디바이스를 알려줘"
+  },
+  "expected": {
+    "analysis_criteria": {
+      "analysis_type": "COMPARISON",
+      "metric_name": "signup_conversion_rate",
+      "standard_period": "1W",
+      "compare_period": "1W",
+      "group_by": ["channel", "device"],
+      "sort_direction": "asc"
+    }
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/cmp/CMP-10.json
+++ b/apps/ai/eval/cases/question_analysis/cmp/CMP-10.json
@@ -1,0 +1,21 @@
+{
+  "id": "CMP-10",
+  "layer": "필터 추가",
+  "category": "cmp",
+  "spec": {
+    "id": "CMP-10",
+    "dataset": "dataset-a",
+    "question": "internal_test 제외하고 이번 주 가입 전환율이 지난주 대비 가장 많이 떨어진 채널·디바이스"
+  },
+  "expected": {
+    "analysis_criteria": {
+      "analysis_type": "COMPARISON",
+      "metric_name": "signup_conversion_rate",
+      "base_date_column": "event_date",
+      "standard_period": "1W",
+      "compare_period": "1W",
+      "group_by": ["channel", "device"],
+      "sort_direction": "asc"
+    }
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/flt/FLT-01.json
+++ b/apps/ai/eval/cases/question_analysis/flt/FLT-01.json
@@ -1,0 +1,21 @@
+{
+  "id": "FLT-01",
+  "layer": "필터 + RANKING",
+  "category": "flt",
+  "spec": {
+    "id": "FLT-01",
+    "dataset": "dataset-a",
+    "question": "internal_test 계정을 제외하고, 이번 주 가입 전환율 하위 5개 채널·디바이스"
+  },
+  "expected": {
+    "analysis_criteria": {
+      "analysis_type": "RANKING",
+      "metric_name": "signup_conversion_rate",
+      "base_date_column": "event_date",
+      "standard_period": "1W",
+      "group_by": ["channel", "device"],
+      "sort_direction": "asc",
+      "limit_num": 5
+    }
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/flt/FLT-02.json
+++ b/apps/ai/eval/cases/question_analysis/flt/FLT-02.json
@@ -1,0 +1,21 @@
+{
+  "id": "FLT-02",
+  "layer": "필터 + COMPARISON",
+  "category": "flt",
+  "spec": {
+    "id": "FLT-02",
+    "dataset": "dataset-a",
+    "question": "internal_test 계정을 제외하고, 이번 주 가입 전환율이 지난주 대비 가장 많이 떨어진 채널·디바이스"
+  },
+  "expected": {
+    "analysis_criteria": {
+      "analysis_type": "COMPARISON",
+      "metric_name": "signup_conversion_rate",
+      "base_date_column": "event_date",
+      "standard_period": "1W",
+      "compare_period": "1W",
+      "group_by": ["channel", "device"],
+      "sort_direction": "asc"
+    }
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/flt/FLT-03.json
+++ b/apps/ai/eval/cases/question_analysis/flt/FLT-03.json
@@ -1,0 +1,21 @@
+{
+  "id": "FLT-03",
+  "layer": "필터 + 스키마 변화",
+  "category": "flt",
+  "spec": {
+    "id": "FLT-03",
+    "dataset": "dataset-b",
+    "question": "is_test 제외하고 이번 주 소스별 가입 전환율 하위 5개"
+  },
+  "expected": {
+    "analysis_criteria": {
+      "analysis_type": "RANKING",
+      "metric_name": "signup_conversion_rate",
+      "base_date_column": "created_at",
+      "standard_period": "1W",
+      "group_by": ["source"],
+      "sort_direction": "asc",
+      "limit_num": 5
+    }
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/rnk/RNK-01.json
+++ b/apps/ai/eval/cases/question_analysis/rnk/RNK-01.json
@@ -1,0 +1,21 @@
+{
+  "id": "RNK-01",
+  "layer": "정상 케이스",
+  "category": "rnk",
+  "spec": {
+    "id": "RNK-01",
+    "dataset": "dataset-a",
+    "question": "이번 주 가입 전환율이 가장 낮은 채널·디바이스 top 5"
+  },
+  "expected": {
+    "analysis_criteria": {
+      "analysis_type": "RANKING",
+      "metric_name": "signup_conversion_rate",
+      "base_date_column": "event_date",
+      "standard_period": "1W",
+      "group_by": ["channel", "device"],
+      "sort_direction": "asc",
+      "limit_num": 5
+    }
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/rnk/RNK-02.json
+++ b/apps/ai/eval/cases/question_analysis/rnk/RNK-02.json
@@ -1,0 +1,21 @@
+{
+  "id": "RNK-02",
+  "layer": "정상 케이스",
+  "category": "rnk",
+  "spec": {
+    "id": "RNK-02",
+    "dataset": "dataset-a",
+    "question": "이번 주 가입 전환율 높은 순으로 채널·디바이스 top 5"
+  },
+  "expected": {
+    "analysis_criteria": {
+      "analysis_type": "RANKING",
+      "metric_name": "signup_conversion_rate",
+      "base_date_column": "event_date",
+      "standard_period": "1W",
+      "group_by": ["channel", "device"],
+      "sort_direction": "desc",
+      "limit_num": 5
+    }
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/rnk/RNK-03.json
+++ b/apps/ai/eval/cases/question_analysis/rnk/RNK-03.json
@@ -1,0 +1,21 @@
+{
+  "id": "RNK-03",
+  "layer": "표현 다양화",
+  "category": "rnk",
+  "spec": {
+    "id": "RNK-03",
+    "dataset": "dataset-a",
+    "question": "이번 주 채널·디바이스별 가입 전환율 낮은 순 5개 보여줘"
+  },
+  "expected": {
+    "analysis_criteria": {
+      "analysis_type": "RANKING",
+      "metric_name": "signup_conversion_rate",
+      "base_date_column": "event_date",
+      "standard_period": "1W",
+      "group_by": ["channel", "device"],
+      "sort_direction": "asc",
+      "limit_num": 5
+    }
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/rnk/RNK-04.json
+++ b/apps/ai/eval/cases/question_analysis/rnk/RNK-04.json
@@ -1,0 +1,21 @@
+{
+  "id": "RNK-04",
+  "layer": "표현 다양화",
+  "category": "rnk",
+  "spec": {
+    "id": "RNK-04",
+    "dataset": "dataset-a",
+    "question": "이번 주 채널·디바이스별 가입 전환율 하위 5개 조합"
+  },
+  "expected": {
+    "analysis_criteria": {
+      "analysis_type": "RANKING",
+      "metric_name": "signup_conversion_rate",
+      "base_date_column": "event_date",
+      "standard_period": "1W",
+      "group_by": ["channel", "device"],
+      "sort_direction": "asc",
+      "limit_num": 5
+    }
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/rnk/RNK-05.json
+++ b/apps/ai/eval/cases/question_analysis/rnk/RNK-05.json
@@ -1,0 +1,21 @@
+{
+  "id": "RNK-05",
+  "layer": "정상 케이스",
+  "category": "rnk",
+  "spec": {
+    "id": "RNK-05",
+    "dataset": "dataset-a",
+    "question": "이번 달 채널별 액티베이션율 낮은 순으로 5개"
+  },
+  "expected": {
+    "analysis_criteria": {
+      "analysis_type": "RANKING",
+      "metric_name": "activation_rate",
+      "base_date_column": "event_date",
+      "standard_period": "1M",
+      "group_by": ["channel"],
+      "sort_direction": "asc",
+      "limit_num": 5
+    }
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/rnk/RNK-06.json
+++ b/apps/ai/eval/cases/question_analysis/rnk/RNK-06.json
@@ -1,0 +1,21 @@
+{
+  "id": "RNK-06",
+  "layer": "표현 다양화",
+  "category": "rnk",
+  "spec": {
+    "id": "RNK-06",
+    "dataset": "dataset-a",
+    "question": "지난 한 달 디바이스별 유료 전환율 하위 3개"
+  },
+  "expected": {
+    "analysis_criteria": {
+      "analysis_type": "RANKING",
+      "metric_name": "paid_conversion_rate",
+      "base_date_column": "event_date",
+      "standard_period": "1M",
+      "group_by": ["device"],
+      "sort_direction": "asc",
+      "limit_num": 3
+    }
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/rnk/RNK-07.json
+++ b/apps/ai/eval/cases/question_analysis/rnk/RNK-07.json
@@ -1,0 +1,21 @@
+{
+  "id": "RNK-07",
+  "layer": "정상 케이스",
+  "category": "rnk",
+  "spec": {
+    "id": "RNK-07",
+    "dataset": "dataset-a",
+    "question": "이번 주 디바이스별 트라이얼 시작율 top 5"
+  },
+  "expected": {
+    "analysis_criteria": {
+      "analysis_type": "RANKING",
+      "metric_name": "trial_start_rate",
+      "base_date_column": "event_date",
+      "standard_period": "1W",
+      "group_by": ["device"],
+      "sort_direction": "desc",
+      "limit_num": 5
+    }
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/rnk/RNK-08.json
+++ b/apps/ai/eval/cases/question_analysis/rnk/RNK-08.json
@@ -1,0 +1,21 @@
+{
+  "id": "RNK-08",
+  "layer": "스키마 변화",
+  "category": "rnk",
+  "spec": {
+    "id": "RNK-08",
+    "dataset": "dataset-b",
+    "question": "이번 주 소스·디바이스별 가입 전환율 하위 5개"
+  },
+  "expected": {
+    "analysis_criteria": {
+      "analysis_type": "RANKING",
+      "metric_name": "signup_conversion_rate",
+      "base_date_column": "created_at",
+      "standard_period": "1W",
+      "group_by": ["source", "device_type"],
+      "sort_direction": "asc",
+      "limit_num": 5
+    }
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/rnk/RNK-09.json
+++ b/apps/ai/eval/cases/question_analysis/rnk/RNK-09.json
@@ -1,0 +1,21 @@
+{
+  "id": "RNK-09",
+  "layer": "모호성·경고",
+  "category": "rnk",
+  "description": "dataset-c (날짜 컬럼 2개) - DATE_FIELD_CONFLICT warning",
+  "spec": {
+    "id": "RNK-09",
+    "dataset": "dataset-c",
+    "question": "이번 주 채널별 가입 전환율 top 5"
+  },
+  "expected": {
+    "analysis_criteria": {
+      "analysis_type": "RANKING",
+      "metric_name": "signup_conversion_rate",
+      "standard_period": "1W",
+      "group_by": ["channel"],
+      "sort_direction": "desc",
+      "limit_num": 5
+    }
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/rnk/RNK-10.json
+++ b/apps/ai/eval/cases/question_analysis/rnk/RNK-10.json
@@ -1,0 +1,21 @@
+{
+  "id": "RNK-10",
+  "layer": "필터 추가",
+  "category": "rnk",
+  "spec": {
+    "id": "RNK-10",
+    "dataset": "dataset-a",
+    "question": "internal_test 제외하고 이번 주 가입 전환율 하위 5개 채널·디바이스"
+  },
+  "expected": {
+    "analysis_criteria": {
+      "analysis_type": "RANKING",
+      "metric_name": "signup_conversion_rate",
+      "base_date_column": "event_date",
+      "standard_period": "1W",
+      "group_by": ["channel", "device"],
+      "sort_direction": "asc",
+      "limit_num": 5
+    }
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/uns/UNS-01.json
+++ b/apps/ai/eval/cases/question_analysis/uns/UNS-01.json
@@ -1,0 +1,15 @@
+{
+  "id": "UNS-01",
+  "layer": "모호성·경고",
+  "category": "uns",
+  "description": "catalog 외 metric (avg_session_duration)",
+  "spec": {
+    "id": "UNS-01",
+    "dataset": "dataset-a",
+    "question": "이번 주 채널별 평균 세션 시간 top 5"
+  },
+  "expected": {
+    "analysis_criteria": null,
+    "unsupported_question": {"detected_intent": "unknown_metric"}
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/uns/UNS-02.json
+++ b/apps/ai/eval/cases/question_analysis/uns/UNS-02.json
@@ -1,0 +1,15 @@
+{
+  "id": "UNS-02",
+  "layer": "모호성·경고",
+  "category": "uns",
+  "description": "TREND 시계열 미지원 (COMPARISON/RANKING만)",
+  "spec": {
+    "id": "UNS-02",
+    "dataset": "dataset-a",
+    "question": "지난 3개월간 일별 가입 전환율 추이를 그려줘"
+  },
+  "expected": {
+    "analysis_criteria": null,
+    "unsupported_question": {"detected_intent": "trend_request"}
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/uns/UNS-03.json
+++ b/apps/ai/eval/cases/question_analysis/uns/UNS-03.json
@@ -1,0 +1,15 @@
+{
+  "id": "UNS-03",
+  "layer": "모호성·경고",
+  "category": "uns",
+  "description": "supported_periods 밖 (6M 미지원)",
+  "spec": {
+    "id": "UNS-03",
+    "dataset": "dataset-a",
+    "question": "최근 6개월 채널별 가입 전환율 top 5"
+  },
+  "expected": {
+    "analysis_criteria": null,
+    "unsupported_question": {"detected_intent": "unsupported_period"}
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/uns/UNS-04.json
+++ b/apps/ai/eval/cases/question_analysis/uns/UNS-04.json
@@ -1,0 +1,16 @@
+{
+  "id": "UNS-04",
+  "layer": "모호성·경고",
+  "category": "uns",
+  "description": "metric formula 컬럼(signup_complete) 데이터셋에 없음",
+  "spec": {
+    "id": "UNS-04",
+    "dataset": "dataset-a",
+    "override_columns": {"signup_complete": {"remove": true}},
+    "question": "이번 주 채널별 가입 전환율 top 5"
+  },
+  "expected": {
+    "analysis_criteria": null,
+    "unsupported_question": {"detected_intent": "missing_formula_column"}
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/uns/UNS-05.json
+++ b/apps/ai/eval/cases/question_analysis/uns/UNS-05.json
@@ -1,0 +1,16 @@
+{
+  "id": "UNS-05",
+  "layer": "모호성·경고",
+  "category": "uns",
+  "description": "DATE_CRITERIA role 컬럼 자체가 데이터셋에 없음",
+  "spec": {
+    "id": "UNS-05",
+    "dataset": "dataset-a",
+    "override_columns": {"event_date": {"remove": true}},
+    "question": "이번 주 가입 전환율 top 5 채널"
+  },
+  "expected": {
+    "analysis_criteria": null,
+    "unsupported_question": {"detected_intent": "missing_date_criteria"}
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/uns/UNS-06.json
+++ b/apps/ai/eval/cases/question_analysis/uns/UNS-06.json
@@ -1,0 +1,15 @@
+{
+  "id": "UNS-06",
+  "layer": "표현 다양화",
+  "category": "uns",
+  "description": "COMPARISON+RANKING 복합 의도, 단일 analysis_type 매핑 불가",
+  "spec": {
+    "id": "UNS-06",
+    "dataset": "dataset-a",
+    "question": "이번 주 가입 전환율 top 5 중에서 지난주 대비 가장 많이 떨어진 채널"
+  },
+  "expected": {
+    "analysis_criteria": null,
+    "unsupported_question": {"detected_intent": "mixed_intent"}
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/uns/UNS-07.json
+++ b/apps/ai/eval/cases/question_analysis/uns/UNS-07.json
@@ -1,0 +1,16 @@
+{
+  "id": "UNS-07",
+  "layer": "표현 다양화",
+  "category": "uns",
+  "description": "후속 질문 - previous_messages 없이 단독 해석 불가",
+  "spec": {
+    "id": "UNS-07",
+    "dataset": "dataset-a",
+    "question": "그러면 디바이스별로는 어때?",
+    "previous_messages": []
+  },
+  "expected": {
+    "analysis_criteria": null,
+    "unsupported_question": {"detected_intent": "context_dependent"}
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/uns/UNS-08.json
+++ b/apps/ai/eval/cases/question_analysis/uns/UNS-08.json
@@ -1,0 +1,15 @@
+{
+  "id": "UNS-08",
+  "layer": "표현 다양화",
+  "category": "uns",
+  "description": "catalog가 RATIO만 포함 - COUNT 지표 요청 불가",
+  "spec": {
+    "id": "UNS-08",
+    "dataset": "dataset-a",
+    "question": "이번 주 채널별 가입한 사용자 수 top 5"
+  },
+  "expected": {
+    "analysis_criteria": null,
+    "unsupported_question": {"detected_intent": "missing_metric_type"}
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/wrn/WRN-01.json
+++ b/apps/ai/eval/cases/question_analysis/wrn/WRN-01.json
@@ -1,0 +1,23 @@
+{
+  "id": "WRN-01",
+  "layer": "데이터 품질 경고",
+  "category": "wrn",
+  "description": "landing_sessions null_ratio=0.42 override - critical_null_detected",
+  "spec": {
+    "id": "WRN-01",
+    "dataset": "dataset-a",
+    "override_columns": {"landing_sessions": {"null_ratio": 0.42}},
+    "question": "이번 주 채널·디바이스별 가입 전환율 하위 5개"
+  },
+  "expected": {
+    "analysis_criteria": {
+      "analysis_type": "RANKING",
+      "metric_name": "signup_conversion_rate",
+      "base_date_column": "event_date",
+      "standard_period": "1W",
+      "group_by": ["channel", "device"],
+      "limit_num": 5
+    },
+    "warnings": {"CRITICAL_NULL_DETECTED": true}
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/wrn/WRN-02.json
+++ b/apps/ai/eval/cases/question_analysis/wrn/WRN-02.json
@@ -1,0 +1,20 @@
+{
+  "id": "WRN-02",
+  "layer": "질문-데이터 불일치",
+  "category": "wrn",
+  "description": "질문에 '지역별' 포함 - region 컬럼 없음",
+  "spec": {
+    "id": "WRN-02",
+    "dataset": "dataset-a",
+    "question": "이번 주 지역별 가입 전환율 하위 5개"
+  },
+  "expected": {
+    "analysis_criteria": {
+      "analysis_type": "RANKING",
+      "metric_name": "signup_conversion_rate",
+      "base_date_column": "event_date",
+      "standard_period": "1W"
+    },
+    "warnings": {"QUESTION_DATA_MISMATCH": true}
+  }
+}

--- a/apps/ai/eval/cases/question_analysis/wrn/WRN-03.json
+++ b/apps/ai/eval/cases/question_analysis/wrn/WRN-03.json
@@ -1,0 +1,23 @@
+{
+  "id": "WRN-03",
+  "layer": "질문-데이터 불일치",
+  "category": "wrn",
+  "description": "질문에 'internal_test 제외' 포함 - account_flag 컬럼 없는 변형",
+  "spec": {
+    "id": "WRN-03",
+    "dataset": "dataset-a",
+    "override_columns": {"account_flag": {"remove": true}},
+    "question": "internal_test 제외하고 이번 주 가입 전환율 하위 5개 채널·디바이스"
+  },
+  "expected": {
+    "analysis_criteria": {
+      "analysis_type": "RANKING",
+      "metric_name": "signup_conversion_rate",
+      "base_date_column": "event_date",
+      "standard_period": "1W",
+      "group_by": ["channel", "device"],
+      "limit_num": 5
+    },
+    "warnings": {"QUESTION_DATA_MISMATCH": true}
+  }
+}

--- a/apps/ai/eval/composers/__init__.py
+++ b/apps/ai/eval/composers/__init__.py
@@ -1,0 +1,10 @@
+"""Case spec → 서비스 layer 호출용 request payload composer.
+
+각 suite (특히 02 question_analysis) 의 평가 케이스는 dataset 참조 + question 같은 high-level
+spec 형태이므로, 실제 호출 전에 full request payload 로 변환하는 단계가 필요하다.
+"""
+
+from eval.composers.question_analysis import compose_request as compose_question_analysis_request
+
+
+__all__ = ["compose_question_analysis_request"]

--- a/apps/ai/eval/composers/question_analysis.py
+++ b/apps/ai/eval/composers/question_analysis.py
@@ -1,0 +1,64 @@
+"""02 question_analysis 평가 케이스 spec → QuestionAnalysisRequest payload 변환.
+
+case JSON 의 `spec` 필드는 다음 형식:
+
+```json
+{
+  "id": "CMP-01",
+  "dataset": "dataset-a",
+  "override_columns": {"col": {...}},
+  "add_columns": [...],
+  "question": "이번 주 가입 전환율 ...",
+  "catalog_overrides": {"metric_types": ["RATIO", "COUNT"]}
+}
+```
+
+composer 가 fixture 를 로드 → 변형 적용 → catalog 와 합쳐 full payload 반환.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+from eval.loader import apply_dataset_overrides, load_fixture
+
+
+def compose_request(spec: dict[str, Any]) -> dict[str, Any]:
+    """case spec 을 QuestionAnalysisRequest 페이로드로 변환."""
+    dataset_id = spec["dataset"]
+    fixture = load_fixture(dataset_id)
+
+    dataset = apply_dataset_overrides(
+        fixture,
+        override_columns=spec.get("override_columns"),
+        add_columns=spec.get("add_columns"),
+    )
+
+    columns = [_field_to_column(f) for f in dataset.get("fields", [])]
+
+    catalog = copy.deepcopy(load_fixture("catalog"))
+    for key, value in (spec.get("catalog_overrides") or {}).items():
+        catalog[key] = value
+
+    return {
+        "request_id": spec["id"].lower().replace("-", "_"),
+        "conversation_id": 1,
+        "question": {
+            "content": spec["question"],
+            "previous_messages": spec.get("previous_messages", []),
+        },
+        "data_source": {"id": 1, "columns": columns},
+        "catalog": catalog,
+    }
+
+
+def _field_to_column(field: dict[str, Any]) -> dict[str, Any]:
+    """fixture 의 field 표기 → QuestionAnalysisRequest.data_source.columns[] 형식."""
+    return {
+        "column_name": field["name"],
+        "data_type": field["data_type"],
+        "semantic_role": field["role"],
+        "null_ratio": field.get("null_ratio", 0.0),
+        "sample_values": field.get("sample_values", []),
+    }

--- a/apps/ai/eval/fixtures/catalog.json
+++ b/apps/ai/eval/fixtures/catalog.json
@@ -1,0 +1,15 @@
+{
+  "analysis_types": ["COMPARISON", "RANKING"],
+  "metric_types": ["RATIO"],
+  "predefined_metrics": [
+    {"metric_name": "signup_conversion_rate", "display_name": "가입 전환율", "metric_type": "RATIO", "formula_numerator": "signup_complete", "formula_denominator": "landing_sessions"},
+    {"metric_name": "activation_rate", "display_name": "액티베이션율", "metric_type": "RATIO", "formula_numerator": "activated_users", "formula_denominator": "signup_complete"},
+    {"metric_name": "trial_start_rate", "display_name": "트라이얼 시작율", "metric_type": "RATIO", "formula_numerator": "trial_start", "formula_denominator": "activated_users"},
+    {"metric_name": "paid_conversion_rate", "display_name": "유료 전환율", "metric_type": "RATIO", "formula_numerator": "paid_users", "formula_denominator": "trial_start"}
+  ],
+  "supported_periods": ["1W", "1M", "3M"],
+  "flow_warning_keys": [
+    {"code": "QUESTION_DATA_MISMATCH", "name": "질문/데이터 불일치", "comment": "질문에서 요구한 컬럼이 데이터에 없습니다."},
+    {"code": "CRITICAL_NULL_DETECTED", "name": "critical null", "comment": "분석 필요 컬럼의 null 비율이 임계값을 초과합니다."}
+  ]
+}

--- a/apps/ai/eval/fixtures/dataset-a.json
+++ b/apps/ai/eval/fixtures/dataset-a.json
@@ -1,0 +1,15 @@
+{
+  "id": "dataset-a",
+  "table": "marketing_funnel_daily",
+  "fields": [
+    {"name": "event_date", "data_type": "date", "role": "DATE_CRITERIA"},
+    {"name": "channel", "data_type": "string", "role": "DIMENSION", "sample_values": ["paid_search", "organic", "referral", "direct"]},
+    {"name": "device", "data_type": "string", "role": "DIMENSION", "sample_values": ["mobile", "desktop", "tablet"]},
+    {"name": "landing_sessions", "data_type": "integer", "role": "MEASURE"},
+    {"name": "signup_complete", "data_type": "integer", "role": "MEASURE"},
+    {"name": "activated_users", "data_type": "integer", "role": "MEASURE"},
+    {"name": "trial_start", "data_type": "integer", "role": "MEASURE"},
+    {"name": "paid_users", "data_type": "integer", "role": "MEASURE"},
+    {"name": "account_flag", "data_type": "string", "role": "FLAG", "sample_values": ["normal", "internal_test"]}
+  ]
+}

--- a/apps/ai/eval/fixtures/dataset-b.json
+++ b/apps/ai/eval/fixtures/dataset-b.json
@@ -1,0 +1,15 @@
+{
+  "id": "dataset-b",
+  "table": "acquisition_daily",
+  "fields": [
+    {"name": "created_at", "data_type": "date", "role": "DATE_CRITERIA"},
+    {"name": "source", "data_type": "string", "role": "DIMENSION", "sample_values": ["paid_search", "organic", "referral", "direct"]},
+    {"name": "device_type", "data_type": "string", "role": "DIMENSION", "sample_values": ["mobile", "desktop", "tablet"]},
+    {"name": "visits", "data_type": "integer", "role": "MEASURE"},
+    {"name": "signups", "data_type": "integer", "role": "MEASURE"},
+    {"name": "activated", "data_type": "integer", "role": "MEASURE"},
+    {"name": "trial_starts", "data_type": "integer", "role": "MEASURE"},
+    {"name": "paid", "data_type": "integer", "role": "MEASURE"},
+    {"name": "is_test", "data_type": "boolean", "role": "FLAG", "sample_values": [true, false]}
+  ]
+}

--- a/apps/ai/eval/fixtures/dataset-c.json
+++ b/apps/ai/eval/fixtures/dataset-c.json
@@ -1,0 +1,15 @@
+{
+  "id": "dataset-c",
+  "table": "mixed_funnel_daily",
+  "fields": [
+    {"name": "event_date", "data_type": "date", "role": "DATE_CRITERIA"},
+    {"name": "created_at", "data_type": "datetime", "role": "DATE_CRITERIA"},
+    {"name": "channel", "data_type": "string", "role": "DIMENSION", "sample_values": ["paid_search", "organic"]},
+    {"name": "source", "data_type": "string", "role": "DIMENSION", "sample_values": ["paid_search", "organic"]},
+    {"name": "device", "data_type": "string", "role": "DIMENSION", "sample_values": ["mobile", "desktop"]},
+    {"name": "landing_sessions", "data_type": "integer", "role": "MEASURE"},
+    {"name": "signup_complete", "data_type": "integer", "role": "MEASURE"},
+    {"name": "signups", "data_type": "integer", "role": "MEASURE"},
+    {"name": "account_flag", "data_type": "string", "role": "FLAG", "sample_values": ["normal", "internal_test"]}
+  ]
+}

--- a/apps/ai/eval/runner.py
+++ b/apps/ai/eval/runner.py
@@ -25,11 +25,15 @@ class RunResult:
 
 
 def run_case(suite: SuiteName, case: dict[str, Any]) -> RunResult:
-    """case["input"] 을 suite 별 schema 로 검증한 뒤 service 호출. 결과 dict 또는 error 반환."""
+    """case 의 `input` (raw) 또는 `spec` (composer 필요) 를 받아 service 호출.
+
+    `spec` 이 있으면 suite 별 composer 로 변환 후 service 호출. 둘 다 없으면 ValueError.
+    """
     case_id = case.get("id", "<unknown>")
     start = time.monotonic()
     try:
-        response = _dispatch(suite, case["input"])
+        payload = _resolve_payload(suite, case)
+        response = _dispatch(suite, payload)
     except Exception as exc:
         return RunResult(
             case_id=case_id,
@@ -45,6 +49,18 @@ def run_case(suite: SuiteName, case: dict[str, Any]) -> RunResult:
         error=None,
         latency_ms=int((time.monotonic() - start) * 1000),
     )
+
+
+def _resolve_payload(suite: SuiteName, case: dict[str, Any]) -> dict[str, Any]:
+    """case 가 raw input 을 가지면 그대로, spec 만 있으면 suite composer 로 변환."""
+    if "input" in case:
+        return case["input"]
+    if "spec" in case:
+        if suite == "question_analysis":
+            from eval.composers import compose_question_analysis_request
+            return compose_question_analysis_request(case["spec"])
+        raise ValueError(f"composer 미구현 suite: {suite!r}")
+    raise ValueError(f"case 에 'input' 또는 'spec' 필드가 필요합니다: id={case.get('id')!r}")
 
 
 def _dispatch(suite: SuiteName, input_payload: dict[str, Any]) -> dict[str, Any]:

--- a/apps/ai/eval/scoring.py
+++ b/apps/ai/eval/scoring.py
@@ -151,25 +151,26 @@ def summarize_suite(suite: str, scores: list[CaseScore]) -> SuiteReport:
 def _normalize_actual(suite: str, actual: dict[str, Any]) -> dict[str, Any]:
     """suite 별 응답 형태 정규화 — list of dicts 를 dot-notation 비교 가능한 dict 로 변환.
 
-    file_analysis: `column_roles[{column_name, semantic_role, ...}]` → `{column_name: semantic_role}`.
-    `warnings[{code, ...}]` → `{code1: True, code2: True}` (셋 비교용).
+    file_analysis: `column_roles[{column_name, semantic_role, ...}]` → `{column_name: semantic_role}`,
+    `warnings[{code, ...}]` → `{code1: True}`.
+    question_analysis: `warnings[{code, ...}]` → `{code1: True}` (셋 비교용).
     """
-    if suite != "file_analysis":
-        return actual
-
     normalized = {**actual}
-    if isinstance(actual.get("column_roles"), list):
+
+    if suite == "file_analysis" and isinstance(actual.get("column_roles"), list):
         normalized["column_roles"] = {
             cr["column_name"]: cr["semantic_role"]
             for cr in actual["column_roles"]
             if "column_name" in cr and "semantic_role" in cr
         }
-    if isinstance(actual.get("warnings"), list):
+
+    if suite in ("file_analysis", "question_analysis") and isinstance(actual.get("warnings"), list):
         normalized["warnings"] = {
             w["code"]: True
             for w in actual["warnings"]
             if "code" in w
         }
+
     return normalized
 
 

--- a/apps/ai/tests/test_eval_harness.py
+++ b/apps/ai/tests/test_eval_harness.py
@@ -176,6 +176,21 @@ def test_score_file_analysis_normalizes_column_roles_list_to_dict() -> None:
     assert score.passed is True
 
 
+def test_score_question_analysis_normalizes_warnings_list_to_dict() -> None:
+    """question_analysis 의 warnings list 도 code key 기반 dict 로 정규화."""
+    score = score_case(
+        case_id="WRN-X", suite="question_analysis",
+        expected={"warnings": {"CRITICAL_NULL_DETECTED": True}},
+        actual={
+            "warnings": [
+                {"code": "CRITICAL_NULL_DETECTED", "related_fields": ["x"], "detail": "..."},
+            ],
+        },
+        error=None, latency_ms=100,
+    )
+    assert score.passed is True
+
+
 def test_score_file_analysis_normalizes_warnings_list_to_dict() -> None:
     """warnings list 도 code key 기반 dict 로 정규화."""
     score = score_case(
@@ -255,6 +270,76 @@ def test_runner_question_analysis_mock_path(monkeypatch: pytest.MonkeyPatch) -> 
     assert result.error is None
     assert result.response is not None
     assert result.response["request_id"] == "req_smoke"
+
+
+def test_composer_question_analysis_builds_valid_request() -> None:
+    """spec → composer → Pydantic 검증 통과."""
+    from eval.composers import compose_question_analysis_request
+    from schemas.api.question_analysis import QuestionAnalysisRequest
+
+    payload = compose_question_analysis_request({
+        "id": "CMP-X",
+        "dataset": "dataset-a",
+        "question": "이번 주 가입 전환율 top 5",
+    })
+    req = QuestionAnalysisRequest.model_validate(payload)
+    assert req.request_id == "cmp_x"
+    assert any(c.column_name == "event_date" for c in req.data_source.columns)
+    assert {m.metric_name for m in req.catalog.predefined_metrics} == {
+        "signup_conversion_rate", "activation_rate", "trial_start_rate", "paid_conversion_rate",
+    }
+
+
+def test_composer_applies_override_columns_remove() -> None:
+    from eval.composers import compose_question_analysis_request
+
+    payload = compose_question_analysis_request({
+        "id": "UNS-X",
+        "dataset": "dataset-a",
+        "override_columns": {"signup_complete": {"remove": True}},
+        "question": "이번 주 채널별 가입 전환율 top 5",
+    })
+    column_names = [c["column_name"] for c in payload["data_source"]["columns"]]
+    assert "signup_complete" not in column_names
+
+
+def test_composer_applies_add_columns() -> None:
+    from eval.composers import compose_question_analysis_request
+
+    payload = compose_question_analysis_request({
+        "id": "AMB-X",
+        "dataset": "dataset-a",
+        "add_columns": [
+            {"name": "new_col", "data_type": "string", "role": "DIMENSION"},
+        ],
+        "question": "x",
+    })
+    column_names = [c["column_name"] for c in payload["data_source"]["columns"]]
+    assert "new_col" in column_names
+
+
+def test_all_question_analysis_case_files_load_and_compose() -> None:
+    """43개 02 케이스가 모두 Pydantic 검증을 통과하는지 (단순 로드 + composer + validate)."""
+    from eval.composers import compose_question_analysis_request
+    from schemas.api.question_analysis import QuestionAnalysisRequest
+
+    expected_count = {"cmp": 10, "rnk": 10, "flt": 3, "wrn": 3, "uns": 8, "amb": 9}
+    for category, count in expected_count.items():
+        cases = load_cases("question_analysis", category)
+        assert len(cases) == count, f"{category} count mismatch: got {len(cases)}, expected {count}"
+        for case in cases:
+            payload = compose_question_analysis_request(case["spec"])
+            QuestionAnalysisRequest.model_validate(payload)
+
+
+def test_all_file_analysis_case_files_load_and_validate() -> None:
+    """기존 14개 01 케이스가 Pydantic 검증 통과 (regression guard)."""
+    from schemas.api.file_analysis import FileAnalysisRequest
+
+    cases = load_cases("file_analysis")
+    assert len(cases) == 14
+    for case in cases:
+        FileAnalysisRequest.model_validate(case["input"])
 
 
 def test_runner_unknown_suite_returns_error() -> None:


### PR DESCRIPTION
> ⚠️ **stacked PR**: base 가 `feat/ai/#261-fa-eval-cases` (#264). #263·#264 머지 시 base 자동 retarget.

## 요약
- `.claude/ai_test_cast_plan.md` §3 ~ §9 의 02 질문분석 평가 케이스 43개 적재 + dataset fixtures (a/b/c) + canonical catalog + spec → request composer (#241)

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 문서
- [x] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `cd apps/ai && uv run pytest -q` → **101 passed** (기존 95 + 신규 6)
  - 신규 테스트: composer (build + override remove + add_columns) + 43개 case files 모두 Pydantic 검증 + warnings list→dict normalizer (question_analysis)
  - case 카테고리: CMP 10 + RNK 10 + FLT 3 + WRN 3 + UNS 8 + AMB 9 = 43개
  - baseline 측정은 OPENAI_API_KEY 가 주입된 환경에서 별도 수행 예정 (mock 모드로는 의미 측정 불가)

## 스크린샷/로그 (선택)
- 해당 없음

## 롤백/리스크
- 리스크 포인트:
  - `eval/composers/question_analysis.py` 신설. case spec(고수준) → QuestionAnalysisRequest payload 변환. runner 가 `input` 또는 `spec` 둘 다 처리하도록 분기
  - `eval/scoring.py` 의 `_normalize_actual` 가 question_analysis 응답의 `warnings` list 도 code key dict 로 정규화. 기존 file_analysis 동작 변화 없음
  - ERR-07/08/09/11 (셀프 검증 502) 케이스는 LLM 응답 위조가 필요해 eval 하네스 패턴에 맞지 않음 → 단위 테스트(`tests/test_business_validation.py`)로 이미 커버됨, 본 PR 에서 제외
  - 일부 case 의 expected 는 hard-fail 필드(analysis_type · metric_name · base_date_column · compare_period) + group_by + limit_num 만 검증. sort_by 의 정확한 값 (delta · metric_value 등) 은 scoring hard-fail 대상 외라 변동 허용
- 롤백 방법:
  - `git revert <merge-commit>` (eval/cases/question_analysis/ + composers/ + fixtures/{a,b,c,catalog}.json 삭제, scoring normalizer 원복)

## 관련 이슈
Closes #241

후속: OPENAI_API_KEY 준비 후 baseline 측정 → `eval/baselines/question_analysis_v1.jsonl` commit