### PR TITLE
refactor: 프론트 리팩토링 백로그 정리

### DIFF
--- a/apps/fe/src/apis/mockDataSource.test.ts
+++ b/apps/fe/src/apis/mockDataSource.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
+import { installWindowStorage } from '../test-utils/storage';
 import {
   MOCK_MARKETING_CVR_DATA_SOURCE_ID,
   filterVisibleMockDataSources,
@@ -6,38 +7,6 @@ import {
   markMockDataSourcesDeleted,
   readDeletedMockDataSourceIds,
 } from './mockDataSource';
-
-function createStorage() {
-  const store = new Map<string, string>();
-
-  return {
-    get length() {
-      return store.size;
-    },
-    clear: () => store.clear(),
-    getItem: (key: string) => store.get(key) ?? null,
-    key: (index: number) => Array.from(store.keys())[index] ?? null,
-    removeItem: (key: string) => {
-      store.delete(key);
-    },
-    setItem: (key: string, value: string) => {
-      store.set(key, value);
-    },
-  } satisfies Storage;
-}
-
-function installWindowStorage() {
-  const localStorage = createStorage();
-
-  Object.defineProperty(globalThis, 'window', {
-    configurable: true,
-    value: {
-      localStorage,
-    },
-  });
-
-  return { localStorage };
-}
 
 afterEach(() => {
   Reflect.deleteProperty(globalThis, 'window');

--- a/apps/fe/src/app/(main)/analysis/[id]/_components/CriterionSelect.tsx
+++ b/apps/fe/src/app/(main)/analysis/[id]/_components/CriterionSelect.tsx
@@ -2,6 +2,8 @@
 
 import ArrowDownIcon from '@/assets/icons/arrow-down.svg';
 import {
+  ListboxCheckboxOptionList,
+  ListboxOptionList,
   ListboxDropdownShell,
   LISTBOX_DROPDOWN_PANEL_BASE_CLASS,
   LISTBOX_DROPDOWN_TRIGGER_BASE_CLASS,
@@ -70,78 +72,24 @@ export default function CriterionSelect(props: CriterionSelectProps) {
             </div>
           )}
 
-          {props.options.map((opt) => {
-            if (props.multi) {
-              const checked = props.values.includes(opt);
-              const disabled =
-                !checked &&
-                props.maxSelect !== undefined &&
-                props.values.length >= props.maxSelect;
-              const handleToggle = () => {
-                if (disabled) return;
-
-                const next = checked
-                  ? props.values.filter((v) => v !== opt)
-                  : [...props.values, opt];
-                props.onChange(next);
-              };
-
-              return (
-                <label
-                  key={opt}
-                  role="option"
-                  aria-selected={checked}
-                  aria-disabled={disabled}
-                  tabIndex={disabled ? -1 : 0}
-                  onClick={(event) => {
-                    event.preventDefault();
-                    handleToggle();
-                  }}
-                  onKeyDown={(event) => {
-                    if (event.key !== 'Enter' && event.key !== ' ') return;
-
-                    event.preventDefault();
-                    handleToggle();
-                  }}
-                  className={`flex cursor-pointer items-center gap-8 px-12 py-8 text-body2 transition-colors hover:bg-gray-100 ${
-                    disabled
-                      ? 'cursor-not-allowed text-gray-500'
-                      : 'text-gray-900'
-                  }`}
-                >
-                  <input
-                    type="checkbox"
-                    aria-hidden
-                    tabIndex={-1}
-                    checked={checked}
-                    disabled={disabled}
-                    readOnly
-                    className="h-16 w-16 accent-orange-500"
-                  />
-                  <span>{opt}</span>
-                </label>
-              );
-            }
-
-            const selected = props.value === opt;
-            return (
-              <button
-                key={opt}
-                type="button"
-                role="option"
-                aria-selected={selected}
-                onClick={() => {
-                  props.onChange(opt);
-                  closeAndFocusButton();
-                }}
-                className={`block w-full px-12 py-8 text-left text-body2 transition-colors hover:bg-gray-100 ${
-                  selected ? 'text-orange-500' : 'text-gray-900'
-                }`}
-              >
-                {opt}
-              </button>
-            );
-          })}
+          {props.multi ? (
+            <ListboxCheckboxOptionList
+              maxSelect={props.maxSelect}
+              options={props.options}
+              values={props.values}
+              onChange={props.onChange}
+            />
+          ) : (
+            <ListboxOptionList
+              closeAndFocusButton={closeAndFocusButton}
+              options={props.options.map((opt) => ({
+                value: opt,
+                label: opt,
+              }))}
+              value={props.value}
+              onChange={props.onChange}
+            />
+          )}
         </div>
       )}
     />

--- a/apps/fe/src/app/(main)/analysis/[id]/page.tsx
+++ b/apps/fe/src/app/(main)/analysis/[id]/page.tsx
@@ -18,8 +18,7 @@ export default function AnalysisChatPage({
   params: Promise<PageParams>;
 }) {
   const { id } = use(params);
-  const { status } = useAuthSession();
-  const isAuthenticated = status === 'authenticated';
+  const { isAuthenticated } = useAuthSession();
   const [isChatCollapsed, setIsChatCollapsed] = useState(false);
   const chat = useAnalysisChat({
     hasAccessToken: isAuthenticated,

--- a/apps/fe/src/app/(main)/analysis/page.tsx
+++ b/apps/fe/src/app/(main)/analysis/page.tsx
@@ -23,8 +23,7 @@ const ANALYSIS_FILE_MESSAGES = {
 };
 
 export default function AnalysisPage() {
-  const { status } = useAuthSession();
-  const isAuthenticated = status === 'authenticated';
+  const { isAuthenticated } = useAuthSession();
   const { toast, showToast } = useToast();
   const {
     data: myInfo,

--- a/apps/fe/src/app/(main)/data/[id]/page.tsx
+++ b/apps/fe/src/app/(main)/data/[id]/page.tsx
@@ -28,8 +28,7 @@ export default function DataDetailPage({
 }) {
   const { id } = use(params);
   const router = useRouter();
-  const { hasAccessToken, status } = useAuthSession();
-  const isAuthenticated = status === 'authenticated';
+  const { hasAccessToken, isAuthenticated, status } = useAuthSession();
   const { data: myInfo } = useMyInfo(isAuthenticated);
   const { deletedMockDataSourceIds, markDeletedMockDataSources } =
     useDeletedMockDataSources(myInfo?.id);

--- a/apps/fe/src/app/(main)/data/_components/DataSourceToolbar.tsx
+++ b/apps/fe/src/app/(main)/data/_components/DataSourceToolbar.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import type { DataSourceSort } from '@/apis/datasource';
+import SortDropdown, { type SortOption } from './SortDropdown';
+
+type DataSourceToolbarProps = {
+  deletePending: boolean;
+  hasSelection: boolean;
+  onDeleteClick: () => void;
+  onSortChange: (next: DataSourceSort) => void;
+  onUploadClick: () => void;
+  sortKey: DataSourceSort;
+  sortOptions: SortOption<DataSourceSort>[];
+  uploadPending: boolean;
+};
+
+export default function DataSourceToolbar({
+  deletePending,
+  hasSelection,
+  onDeleteClick,
+  onSortChange,
+  onUploadClick,
+  sortKey,
+  sortOptions,
+  uploadPending,
+}: DataSourceToolbarProps) {
+  return (
+    <div className="mb-16 flex items-center justify-between">
+      <SortDropdown
+        options={sortOptions}
+        value={sortKey}
+        onChange={onSortChange}
+      />
+      <div className="flex items-center gap-16">
+        {hasSelection && (
+          <button
+            type="button"
+            onClick={onDeleteClick}
+            disabled={deletePending}
+            className="text-body4 text-gray-700 underline underline-offset-2 hover:text-gray-900 disabled:cursor-not-allowed disabled:text-gray-400"
+          >
+            삭제하기
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={onUploadClick}
+          disabled={uploadPending}
+          className="rounded-full bg-orange-500 px-16 py-8 text-body4 font-medium text-white transition-colors hover:bg-orange-600 disabled:cursor-not-allowed disabled:bg-gray-400"
+        >
+          CSV 파일 업로드
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/fe/src/app/(main)/data/_components/SortDropdown.tsx
+++ b/apps/fe/src/app/(main)/data/_components/SortDropdown.tsx
@@ -2,6 +2,7 @@
 
 import DownIcon from '@/assets/icons/down.svg';
 import {
+  ListboxOptionList,
   ListboxDropdownShell,
   LISTBOX_DROPDOWN_PANEL_BASE_CLASS,
   LISTBOX_DROPDOWN_TRIGGER_BASE_CLASS,
@@ -44,35 +45,13 @@ export default function SortDropdown<T extends string>({
           {...panelProps}
           className={`${LISTBOX_DROPDOWN_PANEL_BASE_CLASS} min-w-[14rem] py-8`}
         >
-          {options.map((opt) => {
-            const selected = opt.value === value;
-            return (
-              <button
-                key={opt.value}
-                type="button"
-                role="option"
-                aria-selected={selected}
-                onClick={() => {
-                  onChange(opt.value);
-                  closeAndFocusButton();
-                }}
-                className={`flex w-full items-center gap-12 px-16 py-12 text-left text-body4 transition-colors hover:bg-gray-100 ${
-                  selected ? 'text-orange-500' : 'text-gray-500'
-                }`}
-              >
-                <span
-                  className={`flex h-16 w-16 shrink-0 items-center justify-center rounded-full border-2 ${
-                    selected ? 'border-orange-500' : 'border-gray-400'
-                  }`}
-                >
-                  {selected && (
-                    <span className="h-8 w-8 rounded-full bg-orange-500" />
-                  )}
-                </span>
-                <span>{opt.label}</span>
-              </button>
-            );
-          })}
+          <ListboxOptionList
+            closeAndFocusButton={closeAndFocusButton}
+            options={options}
+            value={value}
+            variant="radio"
+            onChange={onChange}
+          />
         </div>
       )}
     />

--- a/apps/fe/src/app/(main)/data/_hooks/useDataSourceSelection.ts
+++ b/apps/fe/src/app/(main)/data/_hooks/useDataSourceSelection.ts
@@ -1,0 +1,63 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import type { DataSourceSummary } from '@/apis/datasource';
+
+export function useDataSourceSelection(
+  dataSources: readonly DataSourceSummary[],
+) {
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const visibleDataSourceIds = useMemo(
+    () => new Set(dataSources.map((dataSource) => dataSource.dataSourceId)),
+    [dataSources],
+  );
+  const selectedVisibleIds = useMemo(
+    () =>
+      new Set(
+        Array.from(selectedIds).filter((dataSourceId) =>
+          visibleDataSourceIds.has(dataSourceId),
+        ),
+      ),
+    [selectedIds, visibleDataSourceIds],
+  );
+  const allSelected =
+    dataSources.length > 0 &&
+    dataSources.every((dataSource) =>
+      selectedVisibleIds.has(dataSource.dataSourceId),
+    );
+  const partiallySelected = !allSelected && selectedVisibleIds.size > 0;
+  const hasSelection = selectedVisibleIds.size > 0;
+
+  const clearSelection = useCallback(() => {
+    setSelectedIds(new Set());
+  }, []);
+
+  const toggleAll = useCallback(() => {
+    if (allSelected) {
+      clearSelection();
+    } else {
+      setSelectedIds(
+        new Set(dataSources.map((dataSource) => dataSource.dataSourceId)),
+      );
+    }
+  }, [allSelected, clearSelection, dataSources]);
+
+  const toggleOne = useCallback((id: number) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  return {
+    allSelected,
+    clearSelection,
+    hasSelection,
+    partiallySelected,
+    selectedVisibleIds,
+    toggleAll,
+    toggleOne,
+  };
+}

--- a/apps/fe/src/app/(main)/data/_tests/tableMessage.test.ts
+++ b/apps/fe/src/app/(main)/data/_tests/tableMessage.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { getTableMessage } from '../_utils/tableMessage';
+
+const BASE_PARAMS = {
+  dataSourceCount: 1,
+  emptyMessage: 'empty',
+  errorMessage: 'error',
+  hasAccessToken: true,
+  isError: false,
+  isLoading: false,
+  loadingMessage: 'loading',
+  loginRequiredMessage: 'login required',
+  status: 'authenticated' as const,
+};
+
+describe('getTableMessage', () => {
+  it('asks anonymous users to log in after auth initialization', () => {
+    expect(
+      getTableMessage({
+        ...BASE_PARAMS,
+        hasAccessToken: false,
+        status: 'anonymous',
+      }),
+    ).toBe('login required');
+  });
+
+  it('prefers loading while auth or data sources are loading', () => {
+    expect(
+      getTableMessage({
+        ...BASE_PARAMS,
+        status: 'initializing',
+      }),
+    ).toBe('loading');
+    expect(
+      getTableMessage({
+        ...BASE_PARAMS,
+        isLoading: true,
+      }),
+    ).toBe('loading');
+  });
+
+  it('shows errors before the empty state', () => {
+    expect(
+      getTableMessage({
+        ...BASE_PARAMS,
+        dataSourceCount: 0,
+        isError: true,
+      }),
+    ).toBe('error');
+  });
+
+  it('shows the empty message only when no higher priority state applies', () => {
+    expect(
+      getTableMessage({
+        ...BASE_PARAMS,
+        dataSourceCount: 0,
+      }),
+    ).toBe('empty');
+  });
+
+  it('returns null when rows can be rendered', () => {
+    expect(getTableMessage(BASE_PARAMS)).toBeNull();
+  });
+});

--- a/apps/fe/src/app/(main)/data/_utils/tableMessage.ts
+++ b/apps/fe/src/app/(main)/data/_utils/tableMessage.ts
@@ -1,0 +1,43 @@
+import type { AuthStatus } from '@/lib/authSession';
+
+export type GetTableMessageParams = {
+  dataSourceCount: number;
+  emptyMessage: string;
+  errorMessage: string | null;
+  hasAccessToken: boolean;
+  isError: boolean;
+  isLoading: boolean;
+  loadingMessage: string;
+  loginRequiredMessage: string;
+  status: AuthStatus;
+};
+
+export function getTableMessage({
+  dataSourceCount,
+  emptyMessage,
+  errorMessage,
+  hasAccessToken,
+  isError,
+  isLoading,
+  loadingMessage,
+  loginRequiredMessage,
+  status,
+}: GetTableMessageParams) {
+  if (!hasAccessToken && status !== 'initializing') {
+    return loginRequiredMessage;
+  }
+
+  if (status === 'initializing' || isLoading) {
+    return loadingMessage;
+  }
+
+  if (isError) {
+    return errorMessage;
+  }
+
+  if (dataSourceCount === 0) {
+    return emptyMessage;
+  }
+
+  return null;
+}

--- a/apps/fe/src/app/(main)/data/page.tsx
+++ b/apps/fe/src/app/(main)/data/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { type DataSourceSummary, type DataSourceSort } from '@/apis/datasource';
 import {
@@ -14,12 +14,14 @@ import { useMyInfo } from '@/hooks/useMyInfo';
 import { useToast } from '@/hooks/useToast';
 import { validateCsvFile } from '@/lib/fileValidation';
 import { useAuthSession } from '@/providers/AuthProvider';
+import DataSourceToolbar from './_components/DataSourceToolbar';
 import DataSourceRow from './_components/DataSourceRow';
-import SortDropdown from './_components/SortDropdown';
 import { useDeletedMockDataSources } from './_hooks/useDeletedMockDataSources';
 import { useDataSourceList } from './_hooks/useDataSourceList';
+import { useDataSourceSelection } from './_hooks/useDataSourceSelection';
 import { useDeleteDataSources } from './_hooks/useDeleteDataSources';
 import { useUploadDataSource } from './_hooks/useUploadDataSource';
+import { getTableMessage } from './_utils/tableMessage';
 
 const DELETE_ILLUST_SRC = '/illusts/delete.svg';
 const LOGIN_REQUIRED_MESSAGE = '로그인이 필요해요. 다시 로그인해 주세요.';
@@ -46,15 +48,13 @@ const DATA_FILE_MESSAGES = {
 
 export default function DataPage() {
   const router = useRouter();
-  const { hasAccessToken, status } = useAuthSession();
-  const isAuthenticated = status === 'authenticated';
+  const { hasAccessToken, isAuthenticated, status } = useAuthSession();
   const { data: myInfo } = useMyInfo(isAuthenticated);
   const { deletedMockDataSourceIds, markDeletedMockDataSources } =
     useDeletedMockDataSources(myInfo?.id);
   const { toast, showToast } = useToast();
   const [sortKey, setSortKey] = useState<DataSourceSort>('LATEST');
   const [page, setPage] = useState(0);
-  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [uploadOpen, setUploadOpen] = useState(false);
   const startAnalysis = useStartAnalysis({
@@ -70,12 +70,22 @@ export default function DataPage() {
     page,
     sort: sortKey,
   });
+  const dataSources = dataSourcesQuery.dataSources;
+  const {
+    allSelected,
+    clearSelection,
+    hasSelection,
+    partiallySelected,
+    selectedVisibleIds,
+    toggleAll,
+    toggleOne,
+  } = useDataSourceSelection(dataSources);
   const uploadDataSourceMutation = useUploadDataSource({
     fallbackErrorMessage: UPLOAD_ERROR_MESSAGE,
     hasAccessToken,
     loginRequiredMessage: LOGIN_REQUIRED_MESSAGE,
     onSuccess: () => {
-      setSelectedIds(new Set());
+      clearSelection();
       setUploadOpen(false);
       showToast('파일을 업로드했습니다.', 'success');
     },
@@ -89,69 +99,30 @@ export default function DataPage() {
       showToast(message, 'error');
     },
     onSuccess: () => {
-      setSelectedIds(new Set());
+      clearSelection();
       setDeleteOpen(false);
       showToast('파일을 삭제했습니다.', 'success');
     },
     userId: myInfo?.id,
   });
 
-  const dataSources = dataSourcesQuery.dataSources;
-  const visibleDataSourceIds = useMemo(
-    () => new Set(dataSources.map((dataSource) => dataSource.dataSourceId)),
-    [dataSources],
-  );
-  const selectedVisibleIds = useMemo(
-    () =>
-      new Set(
-        Array.from(selectedIds).filter((dataSourceId) =>
-          visibleDataSourceIds.has(dataSourceId),
-        ),
-      ),
-    [selectedIds, visibleDataSourceIds],
-  );
   const chatPendingDataSourceId = startAnalysis.pendingDataSourceId;
-  const allSelected =
-    dataSources.length > 0 &&
-    dataSources.every((dataSource) =>
-      selectedVisibleIds.has(dataSource.dataSourceId),
-    );
-  const partiallySelected = !allSelected && selectedVisibleIds.size > 0;
-  const hasSelection = selectedVisibleIds.size > 0;
-  const tableMessage =
-    !hasAccessToken && status !== 'initializing'
-      ? LOGIN_REQUIRED_MESSAGE
-      : status === 'initializing' || dataSourcesQuery.isLoading
-        ? '데이터 소스 목록을 불러오는 중이에요.'
-        : dataSourcesQuery.isError
-          ? dataSourcesQuery.errorMessage
-          : dataSources.length === 0
-            ? '업로드된 데이터 소스가 없습니다.'
-            : null;
-
-  const toggleAll = () => {
-    if (allSelected) {
-      setSelectedIds(new Set());
-    } else {
-      setSelectedIds(
-        new Set(dataSources.map((dataSource) => dataSource.dataSourceId)),
-      );
-    }
-  };
-
-  const toggleOne = (id: number) => {
-    setSelectedIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
-  };
+  const tableMessage = getTableMessage({
+    dataSourceCount: dataSources.length,
+    emptyMessage: '업로드된 데이터 소스가 없습니다.',
+    errorMessage: dataSourcesQuery.errorMessage,
+    hasAccessToken,
+    isError: dataSourcesQuery.isError,
+    isLoading: dataSourcesQuery.isLoading,
+    loadingMessage: '데이터 소스 목록을 불러오는 중이에요.',
+    loginRequiredMessage: LOGIN_REQUIRED_MESSAGE,
+    status,
+  });
 
   const handleSortChange = (next: DataSourceSort) => {
     setSortKey(next);
     setPage(0);
-    setSelectedIds(new Set());
+    clearSelection();
   };
 
   const handleUploadClick = () => {
@@ -164,7 +135,7 @@ export default function DataPage() {
   };
 
   const handleDeleteClick = () => {
-    if (selectedIds.size === 0) return;
+    if (!hasSelection) return;
     setDeleteOpen(true);
   };
 
@@ -195,33 +166,16 @@ export default function DataPage() {
         데이터 소스
       </h1>
 
-      <div className="mb-16 flex items-center justify-between">
-        <SortDropdown
-          options={SORT_OPTIONS}
-          value={sortKey}
-          onChange={handleSortChange}
-        />
-        <div className="flex items-center gap-16">
-          {hasSelection && (
-            <button
-              type="button"
-              onClick={handleDeleteClick}
-              disabled={deleteDataSourcesMutation.isPending}
-              className="text-body4 text-gray-700 underline underline-offset-2 hover:text-gray-900 disabled:cursor-not-allowed disabled:text-gray-400"
-            >
-              삭제하기
-            </button>
-          )}
-          <button
-            type="button"
-            onClick={handleUploadClick}
-            disabled={uploadDataSourceMutation.isPending}
-            className="rounded-full bg-orange-500 px-16 py-8 text-body4 font-medium text-white transition-colors hover:bg-orange-600 disabled:cursor-not-allowed disabled:bg-gray-400"
-          >
-            CSV 파일 업로드
-          </button>
-        </div>
-      </div>
+      <DataSourceToolbar
+        deletePending={deleteDataSourcesMutation.isPending}
+        hasSelection={hasSelection}
+        sortKey={sortKey}
+        sortOptions={SORT_OPTIONS}
+        uploadPending={uploadDataSourceMutation.isPending}
+        onDeleteClick={handleDeleteClick}
+        onSortChange={handleSortChange}
+        onUploadClick={handleUploadClick}
+      />
 
       <div className="overflow-hidden rounded-12 border border-gray-300 bg-white">
         <table className="w-full border-collapse text-body4">

--- a/apps/fe/src/app/(main)/layout.tsx
+++ b/apps/fe/src/app/(main)/layout.tsx
@@ -34,8 +34,7 @@ export default function MainLayout({ children }: { children: ReactNode }) {
   const router = useRouter();
   const pathname = usePathname();
   const queryClient = useQueryClient();
-  const { status } = useAuthSession();
-  const isAuthenticated = status === 'authenticated';
+  const { isAuthenticated } = useAuthSession();
   const {
     data: myInfo,
     isError: isUserInfoError,

--- a/apps/fe/src/components/ListboxDropdownShell/ListboxOptionList.tsx
+++ b/apps/fe/src/components/ListboxDropdownShell/ListboxOptionList.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import type { KeyboardEvent } from 'react';
+
+export type ListboxOption<T extends string = string> = {
+  value: T;
+  label: string;
+};
+
+export type ListboxOptionListProps<T extends string = string> = {
+  closeAndFocusButton: () => void;
+  onChange: (next: T) => void;
+  options: readonly ListboxOption<T>[];
+  value: T;
+  variant?: 'plain' | 'radio';
+};
+
+export type ListboxCheckboxOptionListProps<T extends string = string> = {
+  maxSelect?: number;
+  onChange: (next: T[]) => void;
+  options: readonly T[];
+  values: readonly T[];
+};
+
+export function ListboxOptionList<T extends string>({
+  closeAndFocusButton,
+  onChange,
+  options,
+  value,
+  variant = 'plain',
+}: ListboxOptionListProps<T>) {
+  return (
+    <>
+      {options.map((opt) => {
+        const selected = opt.value === value;
+
+        if (variant === 'radio') {
+          return (
+            <button
+              key={opt.value}
+              type="button"
+              role="option"
+              aria-selected={selected}
+              onClick={() => {
+                onChange(opt.value);
+                closeAndFocusButton();
+              }}
+              className={`flex w-full items-center gap-12 px-16 py-12 text-left text-body4 transition-colors hover:bg-gray-100 ${
+                selected ? 'text-orange-500' : 'text-gray-500'
+              }`}
+            >
+              <span
+                className={`flex h-16 w-16 shrink-0 items-center justify-center rounded-full border-2 ${
+                  selected ? 'border-orange-500' : 'border-gray-400'
+                }`}
+              >
+                {selected && (
+                  <span className="h-8 w-8 rounded-full bg-orange-500" />
+                )}
+              </span>
+              <span>{opt.label}</span>
+            </button>
+          );
+        }
+
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            role="option"
+            aria-selected={selected}
+            onClick={() => {
+              onChange(opt.value);
+              closeAndFocusButton();
+            }}
+            className={`block w-full px-12 py-8 text-left text-body2 transition-colors hover:bg-gray-100 ${
+              selected ? 'text-orange-500' : 'text-gray-900'
+            }`}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </>
+  );
+}
+
+export function ListboxCheckboxOptionList<T extends string>({
+  maxSelect,
+  onChange,
+  options,
+  values,
+}: ListboxCheckboxOptionListProps<T>) {
+  const handleToggle = (opt: T) => {
+    const checked = values.includes(opt);
+    const disabled =
+      !checked && maxSelect !== undefined && values.length >= maxSelect;
+
+    if (disabled) return;
+
+    const next = checked
+      ? values.filter((value) => value !== opt)
+      : [...values, opt];
+    onChange(next);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLLabelElement>, opt: T) => {
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+
+    event.preventDefault();
+    handleToggle(opt);
+  };
+
+  return (
+    <>
+      {options.map((opt) => {
+        const checked = values.includes(opt);
+        const disabled =
+          !checked && maxSelect !== undefined && values.length >= maxSelect;
+
+        return (
+          <label
+            key={opt}
+            role="option"
+            aria-selected={checked}
+            aria-disabled={disabled}
+            tabIndex={disabled ? -1 : 0}
+            onClick={(event) => {
+              event.preventDefault();
+              handleToggle(opt);
+            }}
+            onKeyDown={(event) => handleKeyDown(event, opt)}
+            className={`flex cursor-pointer items-center gap-8 px-12 py-8 text-body2 transition-colors hover:bg-gray-100 ${
+              disabled ? 'cursor-not-allowed text-gray-500' : 'text-gray-900'
+            }`}
+          >
+            <input
+              type="checkbox"
+              aria-hidden
+              tabIndex={-1}
+              checked={checked}
+              disabled={disabled}
+              readOnly
+              className="h-16 w-16 accent-orange-500"
+            />
+            <span>{opt}</span>
+          </label>
+        );
+      })}
+    </>
+  );
+}

--- a/apps/fe/src/components/index.ts
+++ b/apps/fe/src/components/index.ts
@@ -86,6 +86,15 @@ export type {
   ListboxDropdownShellPanelProps,
   ListboxDropdownShellProps,
 } from './ListboxDropdownShell/ListboxDropdownShell';
+export {
+  ListboxCheckboxOptionList,
+  ListboxOptionList,
+} from './ListboxDropdownShell/ListboxOptionList';
+export type {
+  ListboxCheckboxOptionListProps,
+  ListboxOption,
+  ListboxOptionListProps,
+} from './ListboxDropdownShell/ListboxOptionList';
 
 export { default as MenuTab } from './MenuTab/MenuTab';
 export type { MenuTabProps } from './MenuTab/MenuTab';

--- a/apps/fe/src/lib/auth.test.ts
+++ b/apps/fe/src/lib/auth.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createJwt } from '../test-utils/jwt';
+import { installWindowStorage } from '../test-utils/storage';
 import {
   ACCESS_TOKEN_STORAGE_KEY,
   LEGACY_ACCESS_TOKEN_STORAGE_KEY,
@@ -13,56 +15,6 @@ import {
   shouldRefreshAccessToken,
   skipNextPrivatePathRedirect,
 } from './auth';
-
-function createStorage() {
-  const store = new Map<string, string>();
-
-  return {
-    get length() {
-      return store.size;
-    },
-    clear: () => store.clear(),
-    getItem: (key: string) => store.get(key) ?? null,
-    key: (index: number) => Array.from(store.keys())[index] ?? null,
-    removeItem: (key: string) => {
-      store.delete(key);
-    },
-    setItem: (key: string, value: string) => {
-      store.set(key, value);
-    },
-  } satisfies Storage;
-}
-
-function installWindowStorage() {
-  const localStorage = createStorage();
-  const sessionStorage = createStorage();
-  const dispatchEvent = vi.fn();
-
-  Object.defineProperty(globalThis, 'window', {
-    configurable: true,
-    value: {
-      localStorage,
-      sessionStorage,
-      dispatchEvent,
-    },
-  });
-
-  return { dispatchEvent, localStorage, sessionStorage };
-}
-
-function encodeBase64Url(value: unknown) {
-  return Buffer.from(JSON.stringify(value))
-    .toString('base64')
-    .replaceAll('+', '-')
-    .replaceAll('/', '_')
-    .replaceAll('=', '');
-}
-
-function createJwt(payload: Record<string, unknown>) {
-  return `${encodeBase64Url({ alg: 'none' })}.${encodeBase64Url(
-    payload,
-  )}.signature`;
-}
 
 afterEach(() => {
   Reflect.deleteProperty(globalThis, 'window');

--- a/apps/fe/src/lib/authRedirect.test.ts
+++ b/apps/fe/src/lib/authRedirect.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createStorage } from '../test-utils/storage';
 import {
   OAUTH_LOGIN_POPUP_BLOCKED_MESSAGE,
   OAUTH_POPUP_CALLBACK_MESSAGE_TYPE,
@@ -10,25 +11,6 @@ import {
   readOAuthPopupCallbackMessage,
   startOAuthLogin,
 } from './authRedirect';
-
-function createStorage() {
-  const store = new Map<string, string>();
-
-  return {
-    get length() {
-      return store.size;
-    },
-    clear: () => store.clear(),
-    getItem: (key: string) => store.get(key) ?? null,
-    key: (index: number) => Array.from(store.keys())[index] ?? null,
-    removeItem: (key: string) => {
-      store.delete(key);
-    },
-    setItem: (key: string, value: string) => {
-      store.set(key, value);
-    },
-  } satisfies Storage;
-}
 
 function installWindow(openResult: Window | null) {
   const sessionStorage = createStorage();

--- a/apps/fe/src/lib/authSessionRestore.test.ts
+++ b/apps/fe/src/lib/authSessionRestore.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createJwt } from '../test-utils/jwt';
+import { installWindowStorage } from '../test-utils/storage';
 import {
   ACCESS_TOKEN_STORAGE_KEY,
   LEGACY_ACCESS_TOKEN_STORAGE_KEY,
@@ -11,55 +13,6 @@ import {
   restoreAuthSession,
   type ReissueAuthTokens,
 } from './authSessionRestore';
-
-function createStorage() {
-  const store = new Map<string, string>();
-
-  return {
-    get length() {
-      return store.size;
-    },
-    clear: () => store.clear(),
-    getItem: (key: string) => store.get(key) ?? null,
-    key: (index: number) => Array.from(store.keys())[index] ?? null,
-    removeItem: (key: string) => {
-      store.delete(key);
-    },
-    setItem: (key: string, value: string) => {
-      store.set(key, value);
-    },
-  } satisfies Storage;
-}
-
-function installWindowStorage() {
-  const localStorage = createStorage();
-  const sessionStorage = createStorage();
-
-  Object.defineProperty(globalThis, 'window', {
-    configurable: true,
-    value: {
-      localStorage,
-      sessionStorage,
-      dispatchEvent: vi.fn(),
-    },
-  });
-
-  return { localStorage };
-}
-
-function encodeBase64Url(value: unknown) {
-  return Buffer.from(JSON.stringify(value))
-    .toString('base64')
-    .replaceAll('+', '-')
-    .replaceAll('/', '_')
-    .replaceAll('=', '');
-}
-
-function createJwt(expiresAtMs: number) {
-  return `${encodeBase64Url({ alg: 'none' })}.${encodeBase64Url({
-    exp: Math.floor(expiresAtMs / 1000),
-  })}.signature`;
-}
 
 afterEach(() => {
   Reflect.deleteProperty(globalThis, 'window');

--- a/apps/fe/src/lib/axios.test.ts
+++ b/apps/fe/src/lib/axios.test.ts
@@ -5,6 +5,8 @@ import type {
 } from 'axios';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { reissueAuthTokens } from '../apis/auth';
+import { createJwt } from '../test-utils/jwt';
+import { installWindowStorage } from '../test-utils/storage';
 import {
   ACCESS_TOKEN_STORAGE_KEY,
   LEGACY_ACCESS_TOKEN_STORAGE_KEY,
@@ -18,41 +20,6 @@ import instance from './axios';
 vi.mock('../apis/auth', () => ({
   reissueAuthTokens: vi.fn(),
 }));
-
-function createStorage() {
-  const store = new Map<string, string>();
-
-  return {
-    get length() {
-      return store.size;
-    },
-    clear: () => store.clear(),
-    getItem: (key: string) => store.get(key) ?? null,
-    key: (index: number) => Array.from(store.keys())[index] ?? null,
-    removeItem: (key: string) => {
-      store.delete(key);
-    },
-    setItem: (key: string, value: string) => {
-      store.set(key, value);
-    },
-  } satisfies Storage;
-}
-
-function installWindowStorage() {
-  const localStorage = createStorage();
-  const sessionStorage = createStorage();
-
-  Object.defineProperty(globalThis, 'window', {
-    configurable: true,
-    value: {
-      localStorage,
-      sessionStorage,
-      dispatchEvent: vi.fn(),
-    },
-  });
-
-  return { localStorage };
-}
 
 function createRejectedResponse(
   config: InternalAxiosRequestConfig,
@@ -78,20 +45,6 @@ function createSuccessResponse(
     status: 200,
     statusText: 'OK',
   };
-}
-
-function encodeBase64Url(value: unknown) {
-  return Buffer.from(JSON.stringify(value))
-    .toString('base64')
-    .replaceAll('+', '-')
-    .replaceAll('/', '_')
-    .replaceAll('=', '');
-}
-
-function createJwt(expiresAtMs: number) {
-  return `${encodeBase64Url({ alg: 'none' })}.${encodeBase64Url({
-    exp: Math.floor(expiresAtMs / 1000),
-  })}.signature`;
 }
 
 const originalAdapter = instance.defaults.adapter;

--- a/apps/fe/src/providers/AuthProvider.tsx
+++ b/apps/fe/src/providers/AuthProvider.tsx
@@ -15,6 +15,7 @@ import { useAuthLifecycle } from '@/hooks/useAuthLifecycle';
 type AuthContextValue = {
   status: AuthStatus;
   hasAccessToken: boolean;
+  isAuthenticated: boolean;
 };
 
 const AuthContext = createContext<AuthContextValue | null>(null);
@@ -30,13 +31,15 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
     setStatus,
   });
 
-  const hasAccessToken = status === 'authenticated';
+  const isAuthenticated = status === 'authenticated';
+  const hasAccessToken = isAuthenticated;
   const value = useMemo(
     () => ({
       status,
       hasAccessToken,
+      isAuthenticated,
     }),
-    [hasAccessToken, status],
+    [hasAccessToken, isAuthenticated, status],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/apps/fe/src/test-utils/jwt.ts
+++ b/apps/fe/src/test-utils/jwt.ts
@@ -1,0 +1,20 @@
+export function encodeBase64Url(value: unknown) {
+  return Buffer.from(JSON.stringify(value))
+    .toString('base64')
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
+    .replaceAll('=', '');
+}
+
+export function createJwt(
+  payloadOrExpiresAtMs: Record<string, unknown> | number,
+) {
+  const payload =
+    typeof payloadOrExpiresAtMs === 'number'
+      ? { exp: Math.floor(payloadOrExpiresAtMs / 1000) }
+      : payloadOrExpiresAtMs;
+
+  return `${encodeBase64Url({ alg: 'none' })}.${encodeBase64Url(
+    payload,
+  )}.signature`;
+}

--- a/apps/fe/src/test-utils/storage.ts
+++ b/apps/fe/src/test-utils/storage.ts
@@ -1,0 +1,37 @@
+import { vi } from 'vitest';
+
+export function createStorage() {
+  const store = new Map<string, string>();
+
+  return {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (key: string) => store.get(key) ?? null,
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+  } satisfies Storage;
+}
+
+export function installWindowStorage() {
+  const localStorage = createStorage();
+  const sessionStorage = createStorage();
+  const dispatchEvent = vi.fn();
+
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: {
+      localStorage,
+      sessionStorage,
+      dispatchEvent,
+    },
+  });
+
+  return { dispatchEvent, localStorage, sessionStorage };
+}


### PR DESCRIPTION
﻿## 요약
- 테스트용 storage/JWT 헬퍼를 `src/test-utils`로 통합했습니다.
- 리스트박스 단일/체크박스 옵션 렌더링을 공통 컴포넌트로 추출했습니다.
- 데이터 소스 페이지의 선택 상태, 테이블 메시지, 툴바 렌더링 책임을 분리했습니다.
- `useAuthSession()`에서 `isAuthenticated` 파생값을 제공하도록 정리했습니다.

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `yarn lint`
  - `yarn test`
  - `$env:NEXT_PUBLIC_API_URL='http://localhost:8080'; yarn build`
  - Browser smoke: `/data`에서 정렬 드롭다운 선택, 행 선택 후 삭제 버튼 노출, CSV 업로드 모달 열림 확인
  - 참고: env 없이 `yarn build`는 production build의 `NEXT_PUBLIC_API_URL` 필수 검증으로 prerender 단계에서 실패합니다.

## 스크린샷/로그 (선택)
- 필요 시 로컬 smoke 화면 확인 완료

## 롤백/리스크
- 리스크: 드롭다운 옵션 렌더링과 데이터 페이지 상태 분리 과정에서 UI 상태 연결이 바뀔 수 있어 로컬 smoke로 확인했습니다.
- 롤백 방법: 이 PR revert

## 관련 이슈
Closes #267
