### PR TITLE
refactor: 데이터 소스 리팩토링 백로그 정리

### DIFF
--- a/apps/fe/src/app/(main)/analysis/[id]/_components/CriterionSelect.tsx
+++ b/apps/fe/src/app/(main)/analysis/[id]/_components/CriterionSelect.tsx
@@ -3,10 +3,10 @@
 import ArrowDownIcon from '@/assets/icons/arrow-down.svg';
 import {
   ListboxCheckboxOptionList,
-  ListboxOptionList,
   ListboxDropdownShell,
   LISTBOX_DROPDOWN_PANEL_BASE_CLASS,
   LISTBOX_DROPDOWN_TRIGGER_BASE_CLASS,
+  SimpleListboxDropdown,
 } from '@/components';
 
 type CommonProps = {
@@ -32,22 +32,36 @@ type MultiProps = CommonProps & {
 export type CriterionSelectProps = SingleProps | MultiProps;
 
 export default function CriterionSelect(props: CriterionSelectProps) {
-  const optionFocusSelector = props.multi
-    ? '[role="option"]:not([aria-disabled="true"])'
-    : '[role="option"]:not([disabled]):not([aria-disabled="true"])';
+  if (!props.multi) {
+    return (
+      <SimpleListboxDropdown
+        className={props.className}
+        icon={ArrowDownIcon}
+        iconClassName="icon-12 text-gray-700"
+        label={props.value}
+        options={props.options.map((opt) => ({
+          value: opt,
+          label: opt,
+        }))}
+        panelClassName="w-max min-w-full"
+        triggerClassName="text-body2 text-gray-900"
+        value={props.value}
+        onChange={props.onChange}
+      />
+    );
+  }
 
-  const buttonLabel = props.multi
-    ? props.values.length === 0
+  const buttonLabel =
+    props.values.length === 0
       ? '?좏깮'
       : props.values.length === 1
         ? props.values[0]
-        : `${props.values[0]} ??${props.values.length - 1}`
-    : props.value;
+        : `${props.values[0]} ??${props.values.length - 1}`;
 
   return (
     <ListboxDropdownShell
       className={props.className}
-      optionSelector={optionFocusSelector}
+      optionSelector="[role='option']:not([aria-disabled='true'])"
       triggerClassName={`${LISTBOX_DROPDOWN_TRIGGER_BASE_CLASS} text-body2 text-gray-900`}
       trigger={({ open }) => (
         <>
@@ -60,36 +74,24 @@ export default function CriterionSelect(props: CriterionSelectProps) {
           />
         </>
       )}
-      panel={({ closeAndFocusButton, panelProps }) => (
+      panel={({ panelProps }) => (
         <div
           {...panelProps}
-          aria-multiselectable={props.multi ? true : undefined}
+          aria-multiselectable
           className={`${LISTBOX_DROPDOWN_PANEL_BASE_CLASS} w-max min-w-full`}
         >
-          {props.multi && props.headerLabel && (
+          {props.headerLabel && (
             <div className="border-b border-gray-200 px-12 py-8 text-body4 text-gray-600">
               {props.headerLabel}
             </div>
           )}
 
-          {props.multi ? (
-            <ListboxCheckboxOptionList
-              maxSelect={props.maxSelect}
-              options={props.options}
-              values={props.values}
-              onChange={props.onChange}
-            />
-          ) : (
-            <ListboxOptionList
-              closeAndFocusButton={closeAndFocusButton}
-              options={props.options.map((opt) => ({
-                value: opt,
-                label: opt,
-              }))}
-              value={props.value}
-              onChange={props.onChange}
-            />
-          )}
+          <ListboxCheckboxOptionList
+            maxSelect={props.maxSelect}
+            options={props.options}
+            values={props.values}
+            onChange={props.onChange}
+          />
         </div>
       )}
     />

--- a/apps/fe/src/app/(main)/analysis/page.tsx
+++ b/apps/fe/src/app/(main)/analysis/page.tsx
@@ -1,18 +1,17 @@
 'use client';
 
 import { ToastPortal } from '@/components';
-import { useMyInfo } from '@/hooks/useMyInfo';
+import { AUTH_MESSAGES } from '@/constants/messages';
+import { useAuthenticatedUser } from '@/hooks/useAuthenticatedUser';
 import { useStartAnalysis } from '@/hooks/useStartAnalysis';
 import { useToast } from '@/hooks/useToast';
 import { validateCsvFile } from '@/lib/fileValidation';
-import { useAuthSession } from '@/providers/AuthProvider';
 import GreetingSection from './_components/GreetingSection';
 import PromptInput, { type PromptInputValue } from './_components/PromptInput';
 import SampleDataSection from './_components/SampleDataSection';
 
 const FALLBACK_USER_NAME = '사용자';
 const MISSING_FILE_MESSAGE = '분석할 CSV 파일을 먼저 추가해 주세요.';
-const LOGIN_REQUIRED_MESSAGE = '로그인이 필요해요. 다시 로그인해 주세요.';
 const START_ANALYSIS_ERROR_MESSAGE =
   '분석을 시작하지 못했어요. 잠시 후 다시 시도해 주세요.';
 
@@ -23,15 +22,11 @@ const ANALYSIS_FILE_MESSAGES = {
 };
 
 export default function AnalysisPage() {
-  const { isAuthenticated } = useAuthSession();
+  const { isAuthenticated, isUserInfoError, isUserInfoLoading, myInfo } =
+    useAuthenticatedUser();
   const { toast, showToast } = useToast();
-  const {
-    data: myInfo,
-    isError: isUserInfoError,
-    isLoading: isUserInfoLoading,
-  } = useMyInfo(isAuthenticated);
   const startAnalysis = useStartAnalysis({
-    loginRequiredMessage: LOGIN_REQUIRED_MESSAGE,
+    loginRequiredMessage: AUTH_MESSAGES.loginRequired,
     fallbackErrorMessage: START_ANALYSIS_ERROR_MESSAGE,
     onError: showToast,
   });

--- a/apps/fe/src/app/(main)/data/[id]/page.tsx
+++ b/apps/fe/src/app/(main)/data/[id]/page.tsx
@@ -5,21 +5,14 @@ import { useRouter } from 'next/navigation';
 import { getApiErrorMessage, isApiConflictError } from '@/apis/errors';
 import { isMockDataSourceId } from '@/apis/mockDataSource';
 import { ToastPortal } from '@/components';
-import { useMyInfo } from '@/hooks/useMyInfo';
+import { AUTH_MESSAGES, DATA_SOURCE_MESSAGES } from '@/constants/messages';
 import { useToast } from '@/hooks/useToast';
-import { useAuthSession } from '@/providers/AuthProvider';
 import DataDetailStatus from './_components/DataDetailStatus';
 import DataDetailView from './_components/DataDetailView';
 import { useDataDetail } from './_hooks/useDataDetail';
-import { useDeletedMockDataSources } from '../_hooks/useDeletedMockDataSources';
+import { useDataSourceUserContext } from '../_hooks/useDataSourceUserContext';
 
 type PageParams = { id: string };
-
-const DELETE_ERROR_MESSAGE = '파일 삭제에 실패했습니다.';
-const DELETE_CONFLICT_ERROR_MESSAGE =
-  '연결된 분석 채팅이 있어 현재 삭제할 수 없어요. 채팅 삭제 기능이 준비되면 함께 삭제할 수 있습니다.';
-const USER_INFO_REQUIRED_MESSAGE =
-  '사용자 정보를 확인한 뒤 다시 시도해 주세요.';
 
 export default function DataDetailPage({
   params,
@@ -28,10 +21,14 @@ export default function DataDetailPage({
 }) {
   const { id } = use(params);
   const router = useRouter();
-  const { hasAccessToken, isAuthenticated, status } = useAuthSession();
-  const { data: myInfo } = useMyInfo(isAuthenticated);
-  const { deletedMockDataSourceIds, markDeletedMockDataSources } =
-    useDeletedMockDataSources(myInfo?.id);
+  const {
+    deletedMockDataSourceIds,
+    hasAccessToken,
+    isAuthenticated,
+    markDeletedMockDataSources,
+    myInfo,
+    status,
+  } = useDataSourceUserContext();
   const [deleteOpen, setDeleteOpen] = useState(false);
   const { toast, showToast } = useToast();
 
@@ -49,7 +46,7 @@ export default function DataDetailPage({
   const handleDeleteConfirm = async () => {
     try {
       if (isMockDataSourceId(dataSourceId)) {
-        if (!myInfo?.id) throw new Error(USER_INFO_REQUIRED_MESSAGE);
+        if (!myInfo?.id) throw new Error(AUTH_MESSAGES.userInfoRequired);
 
         markDeletedMockDataSources([dataSourceId]);
       } else {
@@ -62,8 +59,8 @@ export default function DataDetailPage({
       setDeleteOpen(false);
       showToast(
         isApiConflictError(error)
-          ? DELETE_CONFLICT_ERROR_MESSAGE
-          : getApiErrorMessage(error, DELETE_ERROR_MESSAGE),
+          ? DATA_SOURCE_MESSAGES.deleteConflict
+          : getApiErrorMessage(error, DATA_SOURCE_MESSAGES.detailDeleteError),
       );
     }
   };

--- a/apps/fe/src/app/(main)/data/_components/DataSourceTable.tsx
+++ b/apps/fe/src/app/(main)/data/_components/DataSourceTable.tsx
@@ -1,0 +1,85 @@
+import type { DataSourceSummary } from '@/apis/datasource';
+import { Checkbox } from '@/components';
+import DataSourceRow from './DataSourceRow';
+
+type DataSourceTableProps = {
+  allSelected: boolean;
+  chatDisabled: boolean;
+  chatPendingDataSourceId: number | null;
+  dataSources: DataSourceSummary[];
+  onChat: (dataSource: DataSourceSummary) => void;
+  onOpenDetail: (id: number) => void;
+  onToggleAll: () => void;
+  onToggleOne: (id: number) => void;
+  partiallySelected: boolean;
+  selectedVisibleIds: ReadonlySet<number>;
+  tableMessage: string | null;
+};
+
+export default function DataSourceTable({
+  allSelected,
+  chatDisabled,
+  chatPendingDataSourceId,
+  dataSources,
+  onChat,
+  onOpenDetail,
+  onToggleAll,
+  onToggleOne,
+  partiallySelected,
+  selectedVisibleIds,
+  tableMessage,
+}: DataSourceTableProps) {
+  return (
+    <div className="overflow-hidden rounded-12 border border-gray-300 bg-white">
+      <table className="w-full border-collapse text-body4">
+        <thead>
+          <tr className="bg-gray-200 text-gray-900">
+            <th className="w-[5.6rem] py-16 pl-24 text-left">
+              <Checkbox
+                size="md"
+                checked={allSelected}
+                indeterminate={partiallySelected}
+                onCheckedChange={onToggleAll}
+                aria-label="데이터 소스 전체 선택"
+              />
+            </th>
+            <th className="py-16 text-left font-semibold">파일명</th>
+            <th className="w-[14rem] py-16 text-left font-semibold">
+              파일 크기
+            </th>
+            <th className="w-[16rem] py-16 text-left font-semibold">
+              최근 업로드
+            </th>
+            <th className="w-[14rem] py-16 pr-24 text-right font-semibold">
+              액션
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {tableMessage ? (
+            <tr>
+              <td colSpan={5} className="px-24 py-40 text-center text-gray-600">
+                {tableMessage}
+              </td>
+            </tr>
+          ) : (
+            dataSources.map((dataSource) => (
+              <DataSourceRow
+                key={dataSource.dataSourceId}
+                checked={selectedVisibleIds.has(dataSource.dataSourceId)}
+                chatDisabled={chatDisabled}
+                chatPending={
+                  chatPendingDataSourceId === dataSource.dataSourceId
+                }
+                dataSource={dataSource}
+                onChat={onChat}
+                onOpenDetail={onOpenDetail}
+                onToggle={onToggleOne}
+              />
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/fe/src/app/(main)/data/_components/SortDropdown.tsx
+++ b/apps/fe/src/app/(main)/data/_components/SortDropdown.tsx
@@ -1,12 +1,7 @@
 'use client';
 
 import DownIcon from '@/assets/icons/down.svg';
-import {
-  ListboxOptionList,
-  ListboxDropdownShell,
-  LISTBOX_DROPDOWN_PANEL_BASE_CLASS,
-  LISTBOX_DROPDOWN_TRIGGER_BASE_CLASS,
-} from '@/components';
+import { SimpleListboxDropdown } from '@/components';
 
 export type SortOption<T extends string = string> = {
   value: T;
@@ -27,33 +22,16 @@ export default function SortDropdown<T extends string>({
   const selectedLabel = options.find((o) => o.value === value)?.label ?? '';
 
   return (
-    <ListboxDropdownShell
-      triggerClassName={`${LISTBOX_DROPDOWN_TRIGGER_BASE_CLASS} text-body4 text-gray-700`}
-      trigger={({ open }) => (
-        <>
-          <span>{selectedLabel}</span>
-          <DownIcon
-            aria-hidden
-            className={`icon-16 text-gray-900 transition-transform ${
-              open ? 'rotate-180' : ''
-            }`}
-          />
-        </>
-      )}
-      panel={({ closeAndFocusButton, panelProps }) => (
-        <div
-          {...panelProps}
-          className={`${LISTBOX_DROPDOWN_PANEL_BASE_CLASS} min-w-[14rem] py-8`}
-        >
-          <ListboxOptionList
-            closeAndFocusButton={closeAndFocusButton}
-            options={options}
-            value={value}
-            variant="radio"
-            onChange={onChange}
-          />
-        </div>
-      )}
+    <SimpleListboxDropdown
+      icon={DownIcon}
+      iconClassName="icon-16 text-gray-900"
+      label={selectedLabel}
+      options={options}
+      panelClassName="min-w-[14rem] py-8"
+      triggerClassName="text-body4 text-gray-700"
+      value={value}
+      variant="radio"
+      onChange={onChange}
     />
   );
 }

--- a/apps/fe/src/app/(main)/data/_hooks/useDataSourceUserContext.ts
+++ b/apps/fe/src/app/(main)/data/_hooks/useDataSourceUserContext.ts
@@ -1,0 +1,16 @@
+'use client';
+
+import { useAuthenticatedUser } from '@/hooks/useAuthenticatedUser';
+import { useDeletedMockDataSources } from './useDeletedMockDataSources';
+
+export function useDataSourceUserContext() {
+  const authenticatedUser = useAuthenticatedUser();
+  const { deletedMockDataSourceIds, markDeletedMockDataSources } =
+    useDeletedMockDataSources(authenticatedUser.myInfo?.id);
+
+  return {
+    ...authenticatedUser,
+    deletedMockDataSourceIds,
+    markDeletedMockDataSources,
+  };
+}

--- a/apps/fe/src/app/(main)/data/_hooks/useDeleteDataSources.ts
+++ b/apps/fe/src/app/(main)/data/_hooks/useDeleteDataSources.ts
@@ -6,9 +6,7 @@ import { deleteDataSources } from '@/apis/dataSourceRepository';
 import { dataSourceKeys } from '@/apis/datasource';
 import { getApiErrorMessage, isApiConflictError } from '@/apis/errors';
 import { isMockDataSourceId } from '@/apis/mockDataSource';
-
-const USER_INFO_REQUIRED_MESSAGE =
-  '사용자 정보를 확인한 뒤 다시 시도해 주세요.';
+import { AUTH_MESSAGES } from '@/constants/messages';
 
 type UseDeleteDataSourcesOptions = {
   conflictErrorMessage: string;
@@ -42,7 +40,7 @@ export function useDeleteDataSources({
       );
 
       if (mockDataSourceIds.length > 0 && userId == null) {
-        onError(USER_INFO_REQUIRED_MESSAGE);
+        onError(AUTH_MESSAGES.userInfoRequired);
         return;
       }
 

--- a/apps/fe/src/app/(main)/data/page.tsx
+++ b/apps/fe/src/app/(main)/data/page.tsx
@@ -3,70 +3,52 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { type DataSourceSummary, type DataSourceSort } from '@/apis/datasource';
-import {
-  Checkbox,
-  ConfirmModal,
-  FileUploadModal,
-  ToastPortal,
-} from '@/components';
+import { ConfirmModal, FileUploadModal, ToastPortal } from '@/components';
+import { AUTH_MESSAGES, DATA_SOURCE_MESSAGES } from '@/constants/messages';
 import { useStartAnalysis } from '@/hooks/useStartAnalysis';
-import { useMyInfo } from '@/hooks/useMyInfo';
 import { useToast } from '@/hooks/useToast';
 import { validateCsvFile } from '@/lib/fileValidation';
-import { useAuthSession } from '@/providers/AuthProvider';
+import DataSourceTable from './_components/DataSourceTable';
 import DataSourceToolbar from './_components/DataSourceToolbar';
-import DataSourceRow from './_components/DataSourceRow';
-import { useDeletedMockDataSources } from './_hooks/useDeletedMockDataSources';
 import { useDataSourceList } from './_hooks/useDataSourceList';
 import { useDataSourceSelection } from './_hooks/useDataSourceSelection';
+import { useDataSourceUserContext } from './_hooks/useDataSourceUserContext';
 import { useDeleteDataSources } from './_hooks/useDeleteDataSources';
 import { useUploadDataSource } from './_hooks/useUploadDataSource';
 import { getTableMessage } from './_utils/tableMessage';
 
 const DELETE_ILLUST_SRC = '/illusts/delete.svg';
-const LOGIN_REQUIRED_MESSAGE = '로그인이 필요해요. 다시 로그인해 주세요.';
-const LIST_ERROR_MESSAGE = '데이터 소스 목록을 불러오지 못했어요.';
-const UPLOAD_ERROR_MESSAGE =
-  '파일 업로드에 실패했어요. 잠시 후 다시 시도해 주세요.';
-const DELETE_ERROR_MESSAGE =
-  '파일 삭제에 실패했어요. 잠시 후 다시 시도해 주세요.';
-const DELETE_CONFLICT_ERROR_MESSAGE =
-  '연결된 분석 채팅이 있어 현재 삭제할 수 없어요. 채팅 삭제 기능이 준비되면 함께 삭제할 수 있습니다.';
-const START_CHAT_ERROR_MESSAGE =
-  '분석 채팅을 시작하지 못했어요. 잠시 후 다시 시도해 주세요.';
 
 const SORT_OPTIONS = [
   { value: 'MOST_USED', label: '사용량 많은 순' },
   { value: 'LATEST', label: '최근 업로드 순' },
 ] satisfies Array<{ value: DataSourceSort; label: string }>;
 
-const DATA_FILE_MESSAGES = {
-  invalidType: '파일 형식이 맞지 않습니다.',
-  empty: '빈 CSV 파일은 업로드할 수 없어요.',
-  tooLarge: '파일이 너무 커요. 50MB까지만 업로드 가능해요.',
-};
-
 export default function DataPage() {
   const router = useRouter();
-  const { hasAccessToken, isAuthenticated, status } = useAuthSession();
-  const { data: myInfo } = useMyInfo(isAuthenticated);
-  const { deletedMockDataSourceIds, markDeletedMockDataSources } =
-    useDeletedMockDataSources(myInfo?.id);
+  const {
+    deletedMockDataSourceIds,
+    hasAccessToken,
+    isAuthenticated,
+    markDeletedMockDataSources,
+    myInfo,
+    status,
+  } = useDataSourceUserContext();
   const { toast, showToast } = useToast();
   const [sortKey, setSortKey] = useState<DataSourceSort>('LATEST');
   const [page, setPage] = useState(0);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [uploadOpen, setUploadOpen] = useState(false);
   const startAnalysis = useStartAnalysis({
-    loginRequiredMessage: LOGIN_REQUIRED_MESSAGE,
-    fallbackErrorMessage: START_CHAT_ERROR_MESSAGE,
+    loginRequiredMessage: AUTH_MESSAGES.loginRequired,
+    fallbackErrorMessage: DATA_SOURCE_MESSAGES.startChatError,
     onError: (message) => showToast(message, 'error'),
   });
 
   const dataSourcesQuery = useDataSourceList({
     deletedMockDataSourceIds,
     enabled: isAuthenticated,
-    fallbackErrorMessage: LIST_ERROR_MESSAGE,
+    fallbackErrorMessage: DATA_SOURCE_MESSAGES.listError,
     page,
     sort: sortKey,
   });
@@ -81,18 +63,18 @@ export default function DataPage() {
     toggleOne,
   } = useDataSourceSelection(dataSources);
   const uploadDataSourceMutation = useUploadDataSource({
-    fallbackErrorMessage: UPLOAD_ERROR_MESSAGE,
+    fallbackErrorMessage: DATA_SOURCE_MESSAGES.uploadError,
     hasAccessToken,
-    loginRequiredMessage: LOGIN_REQUIRED_MESSAGE,
+    loginRequiredMessage: AUTH_MESSAGES.loginRequired,
     onSuccess: () => {
       clearSelection();
       setUploadOpen(false);
-      showToast('파일을 업로드했습니다.', 'success');
+      showToast(DATA_SOURCE_MESSAGES.uploadSuccess, 'success');
     },
   });
   const deleteDataSourcesMutation = useDeleteDataSources({
-    conflictErrorMessage: DELETE_CONFLICT_ERROR_MESSAGE,
-    fallbackErrorMessage: DELETE_ERROR_MESSAGE,
+    conflictErrorMessage: DATA_SOURCE_MESSAGES.deleteConflict,
+    fallbackErrorMessage: DATA_SOURCE_MESSAGES.deleteError,
     onDeletedMockDataSources: markDeletedMockDataSources,
     onError: (message) => {
       setDeleteOpen(false);
@@ -101,7 +83,7 @@ export default function DataPage() {
     onSuccess: () => {
       clearSelection();
       setDeleteOpen(false);
-      showToast('파일을 삭제했습니다.', 'success');
+      showToast(DATA_SOURCE_MESSAGES.deleteSuccess, 'success');
     },
     userId: myInfo?.id,
   });
@@ -109,13 +91,13 @@ export default function DataPage() {
   const chatPendingDataSourceId = startAnalysis.pendingDataSourceId;
   const tableMessage = getTableMessage({
     dataSourceCount: dataSources.length,
-    emptyMessage: '업로드된 데이터 소스가 없습니다.',
+    emptyMessage: DATA_SOURCE_MESSAGES.tableEmpty,
     errorMessage: dataSourcesQuery.errorMessage,
     hasAccessToken,
     isError: dataSourcesQuery.isError,
     isLoading: dataSourcesQuery.isLoading,
-    loadingMessage: '데이터 소스 목록을 불러오는 중이에요.',
-    loginRequiredMessage: LOGIN_REQUIRED_MESSAGE,
+    loadingMessage: DATA_SOURCE_MESSAGES.tableLoading,
+    loginRequiredMessage: AUTH_MESSAGES.loginRequired,
     status,
   });
 
@@ -127,7 +109,7 @@ export default function DataPage() {
 
   const handleUploadClick = () => {
     if (!hasAccessToken) {
-      showToast(LOGIN_REQUIRED_MESSAGE, 'error');
+      showToast(AUTH_MESSAGES.loginRequired, 'error');
       return;
     }
 
@@ -145,7 +127,7 @@ export default function DataPage() {
 
   const handleChat = (dataSource: DataSourceSummary) => {
     if (!hasAccessToken) {
-      showToast(LOGIN_REQUIRED_MESSAGE, 'error');
+      showToast(AUTH_MESSAGES.loginRequired, 'error');
       return;
     }
 
@@ -177,65 +159,26 @@ export default function DataPage() {
         onUploadClick={handleUploadClick}
       />
 
-      <div className="overflow-hidden rounded-12 border border-gray-300 bg-white">
-        <table className="w-full border-collapse text-body4">
-          <thead>
-            <tr className="bg-gray-200 text-gray-900">
-              <th className="w-[5.6rem] py-16 pl-24 text-left">
-                <Checkbox
-                  size="md"
-                  checked={allSelected}
-                  indeterminate={partiallySelected}
-                  onCheckedChange={toggleAll}
-                  aria-label="데이터 소스 전체 선택"
-                />
-              </th>
-              <th className="py-16 text-left font-semibold">파일명</th>
-              <th className="w-[14rem] py-16 text-left font-semibold">
-                파일 크기
-              </th>
-              <th className="w-[16rem] py-16 text-left font-semibold">
-                최근 업로드
-              </th>
-              <th className="w-[14rem] py-16 pr-24 text-right font-semibold">
-                액션
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {tableMessage ? (
-              <tr>
-                <td
-                  colSpan={5}
-                  className="px-24 py-40 text-center text-gray-600"
-                >
-                  {tableMessage}
-                </td>
-              </tr>
-            ) : (
-              dataSources.map((dataSource) => (
-                <DataSourceRow
-                  key={dataSource.dataSourceId}
-                  checked={selectedVisibleIds.has(dataSource.dataSourceId)}
-                  chatDisabled={startAnalysis.isPending}
-                  chatPending={
-                    chatPendingDataSourceId === dataSource.dataSourceId
-                  }
-                  dataSource={dataSource}
-                  onChat={handleChat}
-                  onOpenDetail={goToDetail}
-                  onToggle={toggleOne}
-                />
-              ))
-            )}
-          </tbody>
-        </table>
-      </div>
+      <DataSourceTable
+        allSelected={allSelected}
+        chatDisabled={startAnalysis.isPending}
+        chatPendingDataSourceId={chatPendingDataSourceId}
+        dataSources={dataSources}
+        partiallySelected={partiallySelected}
+        selectedVisibleIds={selectedVisibleIds}
+        tableMessage={tableMessage}
+        onChat={handleChat}
+        onOpenDetail={goToDetail}
+        onToggleAll={toggleAll}
+        onToggleOne={toggleOne}
+      />
 
       <FileUploadModal
         open={uploadOpen}
         onClose={() => setUploadOpen(false)}
-        validateFile={(file) => validateCsvFile(file, DATA_FILE_MESSAGES)}
+        validateFile={(file) =>
+          validateCsvFile(file, DATA_SOURCE_MESSAGES.fileValidation)
+        }
         onError={(message) => showToast(message, 'error')}
         onUpload={uploadDataSourceMutation.upload}
       />
@@ -244,10 +187,10 @@ export default function DataPage() {
         open={deleteOpen}
         onClose={() => setDeleteOpen(false)}
         onConfirm={() => void handleDeleteConfirm()}
-        title="파일을 삭제하시겠어요?"
-        description="삭제 후엔 복구할 수 없어요."
-        confirmLabel="삭제하기"
-        cancelLabel="취소하기"
+        title={DATA_SOURCE_MESSAGES.deleteTitle}
+        description={DATA_SOURCE_MESSAGES.deleteDescription}
+        confirmLabel={DATA_SOURCE_MESSAGES.deleteConfirmLabel}
+        cancelLabel={DATA_SOURCE_MESSAGES.deleteCancelLabel}
         confirmDisabled={deleteDataSourcesMutation.isPending}
         icon={
           <>

--- a/apps/fe/src/app/(main)/layout.tsx
+++ b/apps/fe/src/app/(main)/layout.tsx
@@ -19,8 +19,7 @@ import {
   OAUTH_LOGIN_POPUP_BLOCKED_MESSAGE,
   startOAuthLogin,
 } from '@/lib/authRedirect';
-import { useMyInfo } from '@/hooks/useMyInfo';
-import { useAuthSession } from '@/providers/AuthProvider';
+import { useAuthenticatedUser } from '@/hooks/useAuthenticatedUser';
 import DataSourceSearchInput from './_components/DataSourceSearchInput';
 import UserProfileSlot from './_components/UserProfileSlot';
 
@@ -34,12 +33,8 @@ export default function MainLayout({ children }: { children: ReactNode }) {
   const router = useRouter();
   const pathname = usePathname();
   const queryClient = useQueryClient();
-  const { isAuthenticated } = useAuthSession();
-  const {
-    data: myInfo,
-    isError: isUserInfoError,
-    isLoading: isUserInfoLoading,
-  } = useMyInfo(isAuthenticated);
+  const { isAuthenticated, isUserInfoError, isUserInfoLoading, myInfo } =
+    useAuthenticatedUser();
 
   const showDataSearch = pathname.startsWith('/data');
   const handleLogout = () => {

--- a/apps/fe/src/components/ListboxDropdownShell/SimpleListboxDropdown.tsx
+++ b/apps/fe/src/components/ListboxDropdownShell/SimpleListboxDropdown.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import type { ComponentType, SVGProps } from 'react';
+import ListboxDropdownShell, {
+  LISTBOX_DROPDOWN_PANEL_BASE_CLASS,
+  LISTBOX_DROPDOWN_TRIGGER_BASE_CLASS,
+} from './ListboxDropdownShell';
+import {
+  ListboxOptionList,
+  type ListboxOption,
+  type ListboxOptionListProps,
+} from './ListboxOptionList';
+
+type DropdownIcon = ComponentType<SVGProps<SVGSVGElement>>;
+
+export type SimpleListboxDropdownProps<T extends string = string> = {
+  className?: string;
+  icon: DropdownIcon;
+  iconClassName: string;
+  label: string;
+  onChange: (next: T) => void;
+  options: readonly ListboxOption<T>[];
+  panelClassName?: string;
+  triggerClassName: string;
+  value: T;
+  variant?: ListboxOptionListProps<T>['variant'];
+};
+
+export default function SimpleListboxDropdown<T extends string>({
+  className,
+  icon: Icon,
+  iconClassName,
+  label,
+  onChange,
+  options,
+  panelClassName = '',
+  triggerClassName,
+  value,
+  variant,
+}: SimpleListboxDropdownProps<T>) {
+  return (
+    <ListboxDropdownShell
+      className={className}
+      triggerClassName={`${LISTBOX_DROPDOWN_TRIGGER_BASE_CLASS} ${triggerClassName}`}
+      trigger={({ open }) => (
+        <>
+          <span>{label}</span>
+          <Icon
+            aria-hidden
+            className={`${iconClassName} transition-transform ${
+              open ? 'rotate-180' : ''
+            }`}
+          />
+        </>
+      )}
+      panel={({ closeAndFocusButton, panelProps }) => (
+        <div
+          {...panelProps}
+          className={`${LISTBOX_DROPDOWN_PANEL_BASE_CLASS} ${panelClassName}`.trim()}
+        >
+          <ListboxOptionList
+            closeAndFocusButton={closeAndFocusButton}
+            options={options}
+            value={value}
+            variant={variant}
+            onChange={onChange}
+          />
+        </div>
+      )}
+    />
+  );
+}

--- a/apps/fe/src/components/index.ts
+++ b/apps/fe/src/components/index.ts
@@ -95,6 +95,8 @@ export type {
   ListboxOption,
   ListboxOptionListProps,
 } from './ListboxDropdownShell/ListboxOptionList';
+export { default as SimpleListboxDropdown } from './ListboxDropdownShell/SimpleListboxDropdown';
+export type { SimpleListboxDropdownProps } from './ListboxDropdownShell/SimpleListboxDropdown';
 
 export { default as MenuTab } from './MenuTab/MenuTab';
 export type { MenuTabProps } from './MenuTab/MenuTab';

--- a/apps/fe/src/constants/messages.ts
+++ b/apps/fe/src/constants/messages.ts
@@ -1,0 +1,27 @@
+export const AUTH_MESSAGES = {
+  loginRequired: '로그인이 필요해요. 다시 로그인해 주세요.',
+  userInfoRequired: '사용자 정보를 확인한 뒤 다시 시도해 주세요.',
+} as const;
+
+export const DATA_SOURCE_MESSAGES = {
+  listError: '데이터 소스 목록을 불러오지 못했어요.',
+  uploadError: '파일 업로드에 실패했어요. 잠시 후 다시 시도해 주세요.',
+  deleteError: '파일 삭제에 실패했어요. 잠시 후 다시 시도해 주세요.',
+  detailDeleteError: '파일 삭제에 실패했습니다.',
+  deleteConflict:
+    '연결된 분석 채팅이 있어 현재 삭제할 수 없어요. 채팅 삭제 기능이 준비되면 함께 삭제할 수 있습니다.',
+  startChatError: '분석 채팅을 시작하지 못했어요. 잠시 후 다시 시도해 주세요.',
+  tableLoading: '데이터 소스 목록을 불러오는 중이에요.',
+  tableEmpty: '업로드된 데이터 소스가 없습니다.',
+  uploadSuccess: '파일을 업로드했습니다.',
+  deleteSuccess: '파일을 삭제했습니다.',
+  deleteTitle: '파일을 삭제하시겠어요?',
+  deleteDescription: '삭제 후엔 복구할 수 없어요.',
+  deleteConfirmLabel: '삭제하기',
+  deleteCancelLabel: '취소하기',
+  fileValidation: {
+    invalidType: '파일 형식이 맞지 않습니다.',
+    empty: '빈 CSV 파일은 업로드할 수 없어요.',
+    tooLarge: '파일이 너무 커요. 50MB까지만 업로드 가능해요.',
+  },
+} as const;

--- a/apps/fe/src/hooks/useAuthenticatedUser.ts
+++ b/apps/fe/src/hooks/useAuthenticatedUser.ts
@@ -1,0 +1,22 @@
+'use client';
+
+import { useAuthSession } from '@/providers/AuthProvider';
+import { useMyInfo } from './useMyInfo';
+
+export function useAuthenticatedUser() {
+  const { hasAccessToken, isAuthenticated, status } = useAuthSession();
+  const {
+    data: myInfo,
+    isError: isUserInfoError,
+    isLoading: isUserInfoLoading,
+  } = useMyInfo(isAuthenticated);
+
+  return {
+    hasAccessToken,
+    isAuthenticated,
+    isUserInfoError,
+    isUserInfoLoading,
+    myInfo,
+    status,
+  };
+}


### PR DESCRIPTION
## 요약
- 데이터 소스 페이지의 테이블 렌더링을 `DataSourceTable`로 분리했습니다.
- 단일 선택 리스트박스 공통 래퍼 `SimpleListboxDropdown`을 추가하고 정렬/분석 기준 단일 선택 경로에 적용했습니다.
- 인증 세션과 사용자 정보 조합을 `useAuthenticatedUser`, 데이터 소스 사용자 컨텍스트를 `useDataSourceUserContext`로 정리했습니다.
- 인증 및 데이터 소스 관련 중복 문구를 `AUTH_MESSAGES`, `DATA_SOURCE_MESSAGES`로 이동했습니다.

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `yarn lint`
  - `yarn test`
  - `$env:NEXT_PUBLIC_API_URL='http://localhost:8080'; yarn build`
  - `/data` 브라우저 스모크: 정렬 드롭다운 선택, 행 체크박스 선택 후 삭제 버튼 노출, CSV 업로드 모달 오픈 확인

## 스크린샷/로그 (선택)
- `/data` 업로드 모달 브라우저 스모크 완료

## 롤백/리스크
- 리스크 요인: 구조 분리 위주의 변경이나 인증/데이터 소스 페이지 import 경로와 리스트박스 공통 래퍼가 영향을 받습니다.
- 롤백 방법: 이 PR 커밋을 revert합니다.

## 관련 이슈
Closes #269