### PR TITLE
fix(be): fastApiRestTemplate NoOp ResponseErrorHandler 적용 (#278)

### DIFF
--- a/apps/be/src/main/java/com/capstone/logue/global/config/AppConfig.java
+++ b/apps/be/src/main/java/com/capstone/logue/global/config/AppConfig.java
@@ -5,9 +5,13 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.web.client.ResponseErrorHandler;
 import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
 
 @EnableAsync
 @Configuration
@@ -20,14 +24,44 @@ public class AppConfig {
                 .build();
     }
 
+    /**
+     * FastAPI 전용 RestTemplate.
+     *
+     * <ul>
+     *   <li>요청·응답 직렬화는 snake_case Jackson 모듈 사용 (FastAPI DTO 규약).</li>
+     *   <li>4xx/5xx 응답을 throw 하지 않고 {@code ResponseEntity} 로 그대로 반환한다.
+     *       호출부({@code *AsyncService}) 가 status code 기반 분기 + retry 정책을 직접 제어하므로
+     *       기본 {@code DefaultResponseErrorHandler} 가 throw 하면 inline 분기가 dead code 가 된다 (#278).</li>
+     * </ul>
+     */
     @Bean
     public RestTemplate fastApiRestTemplate(RestTemplateBuilder builder) {
-        // FastAPI 전용 RestTemplate (snake_case 적용)
         ObjectMapper snakeCaseMapper = new ObjectMapper()
                 .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
 
-        return builder
+        RestTemplate restTemplate = builder
                 .messageConverters(new MappingJackson2HttpMessageConverter(snakeCaseMapper))
                 .build();
+        restTemplate.setErrorHandler(new NoOpResponseErrorHandler());
+        return restTemplate;
+    }
+
+    /**
+     * 4xx/5xx 응답에 throw 하지 않는 {@link ResponseErrorHandler}.
+     *
+     * <p>{@link org.springframework.web.client.DefaultResponseErrorHandler} 는 4xx/5xx 에
+     * {@link org.springframework.web.client.RestClientException} 을 던지므로, FastAPI 클라이언트
+     * 호출부의 {@code response.getStatusCode().value()} 분기에 도달하지 못한다 (#278).</p>
+     */
+    private static final class NoOpResponseErrorHandler implements ResponseErrorHandler {
+        @Override
+        public boolean hasError(ClientHttpResponse response) throws IOException {
+            return false;
+        }
+
+        @Override
+        public void handleError(ClientHttpResponse response) throws IOException {
+            // no-op: 호출부가 status code 로 직접 분기·retry 한다.
+        }
     }
 }

--- a/apps/be/src/test/java/com/capstone/logue/global/config/FastApiRestTemplateTest.java
+++ b/apps/be/src/test/java/com/capstone/logue/global/config/FastApiRestTemplateTest.java
@@ -1,0 +1,94 @@
+package com.capstone.logue.global.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+
+/**
+ * {@link AppConfig#fastApiRestTemplate} 의 에러 핸들러 동작 단위 테스트.
+ *
+ * <p>기본 {@code DefaultResponseErrorHandler} 는 4xx/5xx 에 throw 하므로 호출부의
+ * {@code response.getStatusCode().value()} 분기가 dead code 가 된다. 본 빈은 NoOp
+ * {@link org.springframework.web.client.ResponseErrorHandler} 를 박아 4xx/5xx 응답도
+ * 그대로 {@link ResponseEntity} 로 반환되도록 한다 (#278).</p>
+ */
+class FastApiRestTemplateTest {
+
+    private RestTemplate fastApiRestTemplate;
+    private MockRestServiceServer server;
+
+    @BeforeEach
+    void setUp() {
+        fastApiRestTemplate = new AppConfig().fastApiRestTemplate(new RestTemplateBuilder());
+        server = MockRestServiceServer.createServer(fastApiRestTemplate);
+    }
+
+    @Test
+    @DisplayName("502 응답에 throw 하지 않고 ResponseEntity 를 반환한다")
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void fastApiRestTemplate_5xx_doesNotThrow() {
+        server.expect(requestTo("http://test/v1/llm/data-sources/analyze"))
+                .andRespond(withStatus(HttpStatus.BAD_GATEWAY)
+                        .body("{\"error_code\":\"LLM_CALL_FAILED\"}")
+                        .contentType(MediaType.APPLICATION_JSON));
+
+        ResponseEntity<Map> response = fastApiRestTemplate.exchange(
+                "http://test/v1/llm/data-sources/analyze",
+                HttpMethod.POST,
+                new HttpEntity<>("{}"),
+                Map.class
+        );
+
+        assertThat(response.getStatusCode().value()).isEqualTo(502);
+        assertThat(response.getBody()).containsEntry("error_code", "LLM_CALL_FAILED");
+    }
+
+    @Test
+    @DisplayName("422 응답에 throw 하지 않고 ResponseEntity 를 반환한다")
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void fastApiRestTemplate_4xx_doesNotThrow() {
+        server.expect(requestTo("http://test/v1/llm/data-sources/analyze"))
+                .andRespond(withStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+                        .body("{\"error_code\":\"REQUEST_VALIDATION_FAILED\"}")
+                        .contentType(MediaType.APPLICATION_JSON));
+
+        ResponseEntity<Map> response = fastApiRestTemplate.exchange(
+                "http://test/v1/llm/data-sources/analyze",
+                HttpMethod.POST,
+                new HttpEntity<>("{}"),
+                Map.class
+        );
+
+        assertThat(response.getStatusCode().value()).isEqualTo(422);
+        assertThat(response.getBody()).containsEntry("error_code", "REQUEST_VALIDATION_FAILED");
+    }
+
+    @Test
+    @DisplayName("500 응답에 throw 하지 않는다 (sanity check, RestClientException 미발생)")
+    void fastApiRestTemplate_5xx_noRestClientException() {
+        server.expect(requestTo("http://test/v1/llm/data-sources/analyze"))
+                .andRespond(withStatus(HttpStatus.INTERNAL_SERVER_ERROR));
+
+        assertThatCode(() -> fastApiRestTemplate.exchange(
+                "http://test/v1/llm/data-sources/analyze",
+                HttpMethod.POST,
+                new HttpEntity<>("{}"),
+                String.class
+        )).doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
## 요약
- #278 보고된 Spring 측 retry dead code 수정
- `AppConfig.fastApiRestTemplate` 에 NoOp `ResponseErrorHandler` 적용해 4xx/5xx 응답이 throw 되지 않고 `ResponseEntity` 로 반환되도록 함
- 3개 Async 서비스 (`AnalysisResultAsyncService`, `QuestionAnalysisAsyncService`, `FileAnalysisAsyncService`) 의 기존 inline `status >= 5xx` retry 분기가 실제로 동작하게 됨 (한 군데 빈 수정으로 일괄 정상화)

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - 신규 단위 테스트 `FastApiRestTemplateTest` 3종 추가
    - 502 응답 시 throw 없이 `ResponseEntity` 반환 + body 의 `error_code` 읽힘
    - 422 응답 시 throw 없이 `ResponseEntity` 반환 + body 의 `error_code` 읽힘
    - 500 응답 시 `RestClientException` 미발생 (sanity)
  - `./gradlew test --tests "com.capstone.logue.global.config.FastApiRestTemplateTest"` → **3 passed**
  - 기존 `*AsyncServiceTest` (`./gradlew test --tests "*AsyncServiceTest"`) → 전부 그린. Mockito 로 `FastApiClient` 를 stub 한 경로라 본 변경 전후 결과 동일 (5xx retry / 4xx 즉시 FAILED / 네트워크 retry / blank plainText FAILED 시나리오 영향 없음)
- 기존 로컬 환경 한정 실패 3건 (`LogueApplicationTests` 컨텍스트 로드 / `AnalServiceTest.createAnalysisFlow_success` Mockito invocation count / `UserControllerTest` OAuth status) 은 본 PR 변경과 무관한 pre-existing 결함

## 스크린샷/로그 (선택)
**Before** (default `DefaultResponseErrorHandler`):
- 5xx 응답 → `HttpServerErrorException` throw → 호출부의 `catch (Exception e)` 에서 잡혀 `markFailed` 즉시 호출, retry 발동 안 됨
- inline `if (status >= 500)` 라인은 dead code

**After** (NoOp `ResponseErrorHandler`):
- 5xx 응답 → `RestTemplate.exchange()` 가 `ResponseEntity` 그대로 반환
- 호출부의 `getStatusCode().value() >= 500` 분기 도달 → `handleRetryOrFail` 호출, 미팅노트 5️⃣ 의 retry 정책 (3회 max + exponential backoff) 정상 발동

## 롤백/리스크
- 리스크 포인트:
  - `fastApiRestTemplate` 만 NoOp 적용. 일반 `restTemplate` 빈은 default error handler 유지 (다른 외부 API 호출 영향 없음)
  - NoOp 핸들러는 `private static final` inner class 라 외부 노출 없음
  - 호출부 (`*AsyncService`) 코드는 그대로
- 롤백 방법:
  - `git revert <merge-commit>` (`AppConfig.setErrorHandler` 라인 + NoOp inner class + 신규 테스트 클래스 일괄 원복)

## 관련 이슈
Closes #278

발견 경로: #276 (`chore: AI 서비스 레이어 응답 정책 통일`) PR #279 작업 중 FastAPI 측 502 매핑 변경의 Spring 영향 분석 과정에서 발견. PR #279 의 502 `LLM_CALL_FAILED` 매핑이 본 PR 머지 후 정상 retry 분기로 흘러갈 수 있게 됨.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 외부 API 연동 시 오류 응답 처리 개선으로 서비스 안정성 향상

* **테스트**
  * 외부 API 오류 응답 처리 동작 검증을 위한 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/26-ewha-capstone-logue/logue/pull/281?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->