### PR TITLE
fix: AI Dockerfile 누락 디렉토리 추가 (#285)

### DIFF
--- a/apps/ai/Dockerfile
+++ b/apps/ai/Dockerfile
@@ -8,8 +8,13 @@ COPY pyproject.toml uv.lock ./
 RUN uv sync --no-dev --frozen --no-cache
 
 COPY main.py .
+COPY config ./config
 COPY core ./core
+COPY llm ./llm
+COPY observability ./observability
+COPY prompts ./prompts
 COPY routers ./routers
+COPY rules ./rules
 COPY schemas ./schemas
 COPY services ./services
 


### PR DESCRIPTION
## 요약
- 운영 컨테이너 부팅 실패 (`ModuleNotFoundError: No module named 'config'`) 핫픽스
- `apps/ai/Dockerfile` 의 COPY 누락 5개 디렉토리 추가: `config`, `llm`, `observability`, `prompts`, `rules`

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트

## 원인
런타임 import 그래프상 다음 모듈들이 이미지에 부재해 uvicorn 부트 시점에 `ModuleNotFoundError` 발생:

| 누락 모듈 | 사용처 |
|---|---|
| `config/` | `services/*` 의 `is_mock_mode()` |
| `llm/` | `services/*/v1_baseline.py` 의 `LLMClient`, `load_system_prompt` |
| `prompts/` | `llm/prompt_loader.py` 가 런타임 파일 읽기 |
| `rules/` | `services/file_analysis_service.py` 의 `source_warnings` |
| `observability/` | (import 그래프 외부 참조 없으나 안전 차원 동봉) |

## 테스트
- [x] 정적 검증: `pytest -q` 152 passed (import 그래프 무결성)
- [ ] 로컬 docker build 검증: colima 미가용으로 스킵
- 머지 후 DoD: ECR push → 컨테이너 정상 부팅 + `/health` 200 확인

## 롤백/리스크
- 리스크: 추가 5개 디렉토리만 COPY, 이미지 크기 소폭 증가 외 동작 변경 없음
- 롤백: `git revert <merge-commit>`

## 관련 이슈
Closes #285