### PR TITLE
feat: 분석 AI API 계약 하드닝

### DIFF
--- a/apps/fe/src/apis/analysis.ts
+++ b/apps/fe/src/apis/analysis.ts
@@ -35,12 +35,12 @@ export type StartAnalysisFlowFromDataSourceResponse = {
 export type GetSummaryResponse = {
   rowCount: number;
   columnCount: number;
-  dataCriteria: string[];
-  measure: string[];
-  dimension: string[];
-  statusCondition: string[];
-  flag: string[];
-  idCriteria: string[];
+  dataCriteria: string[] | null;
+  measure: string[] | null;
+  dimension: string[] | null;
+  statusCondition: string[] | null;
+  flag: string[] | null;
+  idCriteria: string[] | null;
   sourceDataWarning: string | null;
   createdAt: string;
 };

--- a/apps/fe/src/apis/dataSourceRepository.ts
+++ b/apps/fe/src/apis/dataSourceRepository.ts
@@ -7,6 +7,7 @@ import {
   type GetFileResponse,
 } from './datasource';
 import {
+  getServerDataSourceIds,
   getMockDataSource,
   getMockDataSourceListResponse,
   isMockDataSourceId,
@@ -18,12 +19,6 @@ type DataSourceDetailReader = (
 ) => Promise<GetFileResponse>;
 type DataSourcesDeleteRequest = (dataSourceIds: number[]) => Promise<void>;
 type DataSourceDeleteRequest = (dataSourceId: number) => Promise<void>;
-
-function getServerDataSourceIds(dataSourceIds: number[]) {
-  return dataSourceIds.filter(
-    (dataSourceId) => !isMockDataSourceId(dataSourceId),
-  );
-}
 
 async function getMockAwareDataSource(
   dataSourceId: number,

--- a/apps/fe/src/apis/mockDataSource.ts
+++ b/apps/fe/src/apis/mockDataSource.ts
@@ -80,6 +80,16 @@ export function isMockDataSourceId(dataSourceId: number) {
   return dataSourceId === MOCK_MARKETING_CVR_DATA_SOURCE_ID;
 }
 
+export function getMockDataSourceIds(dataSourceIds: number[]) {
+  return dataSourceIds.filter(isMockDataSourceId);
+}
+
+export function getServerDataSourceIds(dataSourceIds: number[]) {
+  return dataSourceIds.filter(
+    (dataSourceId) => !isMockDataSourceId(dataSourceId),
+  );
+}
+
 export function getDeletedMockDataSourceStorageKey(userId: number) {
   return `${DELETED_MOCK_DATA_SOURCE_STORAGE_PREFIX}${userId}`;
 }
@@ -113,7 +123,7 @@ export function markMockDataSourcesDeleted(
   dataSourceIds: number[],
 ) {
   const mockDataSourceIds = Array.from(
-    new Set(dataSourceIds.filter(isMockDataSourceId)),
+    new Set(getMockDataSourceIds(dataSourceIds)),
   );
 
   if (mockDataSourceIds.length === 0) return [];

--- a/apps/fe/src/app/(main)/analysis/[id]/_adapters/normalizeAnalysisError.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_adapters/normalizeAnalysisError.ts
@@ -136,6 +136,13 @@ export function normalizeAnalysisError(
   };
 }
 
+export function getAnalysisErrorMessage(
+  error: unknown,
+  fallbackMessage: string,
+) {
+  return normalizeAnalysisError(error, fallbackMessage).message;
+}
+
 export function normalizeAnalysisStatus(
   status: AnalysisJobStatus | null | undefined,
 ): AnalysisUiStatus {

--- a/apps/fe/src/app/(main)/analysis/[id]/_adapters/normalizeAnalysisError.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_adapters/normalizeAnalysisError.ts
@@ -55,6 +55,13 @@ const ERROR_BY_CODE: Record<string, UserFacingAnalysisError> = {
   },
 };
 
+const FIXED_USER_FACING_MESSAGE_CODES = new Set([
+  'REQUEST_VALIDATION_FAILED',
+  'LLM_OUTPUT_INVALID',
+  'LLM_REFERENCE_VIOLATION',
+  'LLM_CALL_FAILED',
+]);
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
@@ -109,7 +116,9 @@ export function normalizeAnalysisError(
   if (known) {
     return {
       ...known,
-      message: resolveErrorMessage(payload) ?? known.message,
+      message: FIXED_USER_FACING_MESSAGE_CODES.has(code)
+        ? known.message
+        : (resolveErrorMessage(payload) ?? known.message),
     };
   }
 

--- a/apps/fe/src/app/(main)/analysis/[id]/_adapters/normalizeAnalysisError.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_adapters/normalizeAnalysisError.ts
@@ -6,6 +6,13 @@ import type {
 } from '../_models/analysisErrorTypes';
 
 const ERROR_BY_CODE: Record<string, UserFacingAnalysisError> = {
+  REQUEST_VALIDATION_FAILED: {
+    code: 'REQUEST_VALIDATION_FAILED',
+    title: '분석 요청 값을 확인해야 해요',
+    message:
+      '분석에 필요한 입력값이 올바르지 않아 요청을 완료할 수 없습니다. 입력값을 확인한 뒤 다시 시도해 주세요.',
+    retryable: false,
+  },
   LLM_OUTPUT_INVALID: {
     code: 'LLM_OUTPUT_INVALID',
     title: '분석 응답을 해석하지 못했어요',

--- a/apps/fe/src/app/(main)/analysis/[id]/_adapters/normalizeCriteria.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_adapters/normalizeCriteria.ts
@@ -31,6 +31,7 @@ const REQUIRED_FIELD_LABELS = {
   groupBy: '비교 기준',
   sortBy: '정렬 기준',
   sortDirection: '정렬 순서',
+  limitNum: '조회 개수',
 } as const;
 
 function normalizeString(value: string | null | undefined) {
@@ -40,6 +41,10 @@ function normalizeString(value: string | null | undefined) {
 
 function normalizeSortDirection(value: string | null | undefined) {
   return normalizeString(value)?.toUpperCase() ?? null;
+}
+
+function normalizeSortDirectionForRequest(value: string | null | undefined) {
+  return normalizeString(value)?.toLowerCase() ?? null;
 }
 
 function normalizeStringList(values: string[] | null | undefined) {
@@ -112,6 +117,12 @@ function getMissingFields(criteria?: CriteriaInfo | null) {
     !normalizeString(criteria.comparePeriod)
   ) {
     missing.push(REQUIRED_FIELD_LABELS.comparePeriod);
+  }
+  if (
+    analysisType === 'RANKING' &&
+    (criteria.limitNum == null || criteria.limitNum <= 0)
+  ) {
+    missing.push(REQUIRED_FIELD_LABELS.limitNum);
   }
   if (normalizeStringList(criteria.groupBy).length === 0) {
     missing.push(REQUIRED_FIELD_LABELS.groupBy);
@@ -216,7 +227,7 @@ export function createCriteriaEditValues(
 export function createUpdateCriteriaRequest(
   values: CriteriaEditValues,
 ): UpdateQuestionCriteriaRequest {
-  const sortDirection = normalizeSortDirection(values.sortDirection);
+  const sortDirection = normalizeSortDirectionForRequest(values.sortDirection);
 
   return {
     baseDateColumn: values.baseDateColumn || undefined,

--- a/apps/fe/src/app/(main)/analysis/[id]/_adapters/normalizeSummary.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_adapters/normalizeSummary.ts
@@ -27,7 +27,7 @@ export function createSummaryKeyPoints(
   if (!summary) return [];
 
   return SUMMARY_GROUPS.flatMap((group) =>
-    compactStrings(summary[group.key]).map((value) => ({
+    uniqueStrings(summary[group.key]).map((value) => ({
       name: group.name,
       example: value,
     })),

--- a/apps/fe/src/app/(main)/analysis/[id]/_components/LoadingDataPreview.tsx
+++ b/apps/fe/src/app/(main)/analysis/[id]/_components/LoadingDataPreview.tsx
@@ -5,22 +5,34 @@ import loadingSpinner from '@/assets/lottie/loading_spinner.gif';
 
 export type LoadingDataPreviewProps = {
   message?: string;
+  showSpinner?: boolean;
+  tone?: 'default' | 'error';
 };
 
 export default function LoadingDataPreview({
   message = 'CSV 데이터를 분석 중이에요',
+  showSpinner = true,
+  tone = 'default',
 }: LoadingDataPreviewProps) {
   return (
     <div className="flex h-full w-full items-center justify-center bg-white">
       <div className="flex flex-col items-center gap-16">
-        <Image
-          src={loadingSpinner}
-          alt=""
-          aria-hidden
-          unoptimized
-          className="h-40 w-40"
-        />
-        <p className="text-body2 text-gray-700">{message}</p>
+        {showSpinner && (
+          <Image
+            src={loadingSpinner}
+            alt=""
+            aria-hidden
+            unoptimized
+            className="h-40 w-40"
+          />
+        )}
+        <p
+          className={`text-body2 ${
+            tone === 'error' ? 'text-error-500' : 'text-gray-700'
+          }`}
+        >
+          {message}
+        </p>
       </div>
     </div>
   );

--- a/apps/fe/src/app/(main)/analysis/[id]/_fixtures/analysis.fixtures.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_fixtures/analysis.fixtures.ts
@@ -82,6 +82,18 @@ export const unknownWarningCodeCriteriaResponse = {
   },
 } satisfies GetQuestionCriteriaResponse;
 
+export const rankingMissingLimitCriteriaResponse = {
+  ...normalCriteriaResponse,
+  criteria: {
+    ...normalCriteriaResponse.criteria,
+    analysisType: 'RANKING',
+    comparePeriod: null,
+    sortBy: 'conversion_rate',
+    sortDirection: 'DESC',
+    limitNum: null,
+  },
+} satisfies GetQuestionCriteriaResponse;
+
 export const normalResultResponse = {
   resultId: 21,
   summaryMessage: '검증이 완료되었어요.',
@@ -122,6 +134,14 @@ export const rowsNullResultResponse = {
   } as unknown as ResultChartDataInfo,
 } satisfies GetQuestionResultResponse;
 
+export const rowsEmptyResultResponse = {
+  ...normalResultResponse,
+  chartData: {
+    columns: ['channel', 'conversion_rate'],
+    rows: [],
+  } as unknown as ResultChartDataInfo,
+} satisfies GetQuestionResultResponse;
+
 export const failedStatusResponse = {
   status: 'FAILED',
 } satisfies AnalysisStatusResponse;
@@ -145,5 +165,18 @@ export const llmCallFailedError = {
     success: false,
     code: 'LLM_CALL_FAILED',
     message: null,
+  },
+};
+
+export const requestValidationFailedError = {
+  isAxiosError: true,
+  response: {
+    status: 422,
+    data: {
+      request_id: 'job-1',
+      error_code: 'REQUEST_VALIDATION_FAILED',
+      message: 'Invalid analysis criteria.',
+      details: [{ field: 'sort_direction', reason: 'required' }],
+    },
   },
 };

--- a/apps/fe/src/app/(main)/analysis/[id]/_hooks/useAnalysisChat.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_hooks/useAnalysisChat.ts
@@ -1,21 +1,14 @@
 'use client';
 
 import { useCallback, useEffect, useReducer } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import {
-  dataSourceKeys,
-  getDataSource,
-  type FilePreview,
-} from '@/apis/datasource';
-import { getApiErrorMessage } from '@/apis/errors';
 import { useToast } from '@/hooks/useToast';
 import { markAnalysisStartPayloadConsumed } from '@/lib/analysisStartPayload';
 import type { PromptInputValue } from '../../_components/PromptInput';
-import { normalizeAnalysisError } from '../_adapters/normalizeAnalysisError';
+import { getAnalysisErrorMessage } from '../_adapters/normalizeAnalysisError';
 import { createUpdateCriteriaRequest } from '../_adapters/normalizeCriteria';
-import type { DataTableColumn } from '../_components/DataTablePreview';
 import type { CriteriaEditValues } from '../_models/analysisViewModels';
 import { uniqueStrings } from '../_utils/stringList';
+import { useAnalysisDataPreview } from './useAnalysisDataPreview';
 import {
   useAnalysisChatMessages,
   type CriteriaInitialMode,
@@ -55,27 +48,6 @@ const GET_RESULT_ERROR_MESSAGE =
 const GET_DATA_SOURCE_ERROR_MESSAGE =
   'CSV 미리보기를 불러오지 못했어요. 잠시 후 다시 시도해 주세요.';
 
-function getAnalysisErrorMessage(error: unknown, fallbackMessage: string) {
-  return normalizeAnalysisError(error, fallbackMessage).message;
-}
-
-function createPreviewTable(preview?: FilePreview | null) {
-  if (!preview || preview.headers.length === 0) return null;
-
-  const columns: DataTableColumn[] = preview.headers.map((header, index) => ({
-    key: `col-${index}`,
-    label: header || `컬럼 ${index + 1}`,
-  }));
-  const rows = preview.rows.map((row) =>
-    columns.reduce<Record<string, string>>((acc, column, index) => {
-      acc[column.key] = row[index] ?? '';
-      return acc;
-    }, {}),
-  );
-
-  return { columns, rows };
-}
-
 type UseAnalysisChatParams = {
   hasAccessToken: boolean;
   routeConversationId: string;
@@ -114,15 +86,6 @@ export function useAnalysisChat({
     questionSubmissionLocked,
   } = flow;
 
-  const dataSourceQuery = useQuery({
-    queryKey: dataSourceKeys.detail(dataSourceId ?? 0),
-    queryFn: () => {
-      if (dataSourceId === null) throw new Error(INVALID_ROUTE_MESSAGE);
-      return getDataSource(dataSourceId);
-    },
-    enabled: hasAccessToken && dataSourceId !== null,
-  });
-
   const { summary, summaryErrorMessage, summaryPending } = useSummaryPhase({
     analysisFlowId,
     conversationId,
@@ -133,15 +96,17 @@ export function useAnalysisChat({
     routeReady: hasAccessToken && routeReady,
     statusPollIntervalMs: STATUS_POLL_INTERVAL_MS,
   });
-  const dataSourcePreview = hasAccessToken
-    ? dataSourceQuery.data?.preview
-    : undefined;
-  const previewTable = createPreviewTable(dataSourcePreview);
-  const dataSourceErrorMessage = dataSourceQuery.isError
-    ? getApiErrorMessage(dataSourceQuery.error, GET_DATA_SOURCE_ERROR_MESSAGE)
-    : null;
-  const isDataSourceEmpty =
-    hasAccessToken && dataSourceQuery.isSuccess && !previewTable;
+  const {
+    dataSourceErrorMessage,
+    isDataSourceEmpty,
+    isDataSourceLoading,
+    previewTable,
+  } = useAnalysisDataPreview({
+    dataSourceId,
+    enabled: hasAccessToken,
+    errorMessage: GET_DATA_SOURCE_ERROR_MESSAGE,
+    invalidRouteMessage: INVALID_ROUTE_MESSAGE,
+  });
   const { questionAnalysisMutation, updateCriteriaMutation } = useCriteriaPhase(
     {
       getCriteriaErrorMessage: GET_CRITERIA_ERROR_MESSAGE,
@@ -400,7 +365,7 @@ export function useAnalysisChat({
     initialMessage,
     inputDisabled,
     dataSourceErrorMessage,
-    isDataSourceLoading: hasAccessToken && dataSourceQuery.isLoading,
+    isDataSourceLoading,
     isDataSourceEmpty,
     previewTable,
     restMessages,

--- a/apps/fe/src/app/(main)/analysis/[id]/_hooks/useAnalysisChat.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_hooks/useAnalysisChat.ts
@@ -11,6 +11,7 @@ import { getApiErrorMessage } from '@/apis/errors';
 import { useToast } from '@/hooks/useToast';
 import { markAnalysisStartPayloadConsumed } from '@/lib/analysisStartPayload';
 import type { PromptInputValue } from '../../_components/PromptInput';
+import { normalizeAnalysisError } from '../_adapters/normalizeAnalysisError';
 import { createUpdateCriteriaRequest } from '../_adapters/normalizeCriteria';
 import type { DataTableColumn } from '../_components/DataTablePreview';
 import type { CriteriaEditValues } from '../_models/analysisViewModels';
@@ -53,6 +54,10 @@ const GET_RESULT_ERROR_MESSAGE =
 
 const GET_DATA_SOURCE_ERROR_MESSAGE =
   'CSV 미리보기를 불러오지 못했어요. 잠시 후 다시 시도해 주세요.';
+
+function getAnalysisErrorMessage(error: unknown, fallbackMessage: string) {
+  return normalizeAnalysisError(error, fallbackMessage).message;
+}
 
 function createPreviewTable(preview?: FilePreview | null) {
   if (!preview || preview.headers.length === 0) return null;
@@ -191,7 +196,7 @@ export function useAnalysisChat({
           },
           onError: (error) => {
             dispatchFlow({ type: 'question-submission-finished' });
-            const message = getApiErrorMessage(
+            const message = getAnalysisErrorMessage(
               error,
               CREATE_QUESTION_ERROR_MESSAGE,
             );
@@ -295,7 +300,7 @@ export function useAnalysisChat({
               },
               onError: (error) => {
                 dispatchFlow({ type: 'criteria-submission-finished' });
-                const message = getApiErrorMessage(
+                const message = getAnalysisErrorMessage(
                   error,
                   GET_RESULT_ERROR_MESSAGE,
                 );
@@ -307,7 +312,7 @@ export function useAnalysisChat({
         },
         onError: (error) => {
           dispatchFlow({ type: 'criteria-submission-finished' });
-          const message = getApiErrorMessage(
+          const message = getAnalysisErrorMessage(
             error,
             UPDATE_CRITERIA_ERROR_MESSAGE,
           );

--- a/apps/fe/src/app/(main)/analysis/[id]/_hooks/useAnalysisChat.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_hooks/useAnalysisChat.ts
@@ -51,6 +51,9 @@ const UPDATE_CRITERIA_ERROR_MESSAGE =
 const GET_RESULT_ERROR_MESSAGE =
   '최종 분석 결과를 불러오지 못했어요. 잠시 후 다시 시도해 주세요.';
 
+const GET_DATA_SOURCE_ERROR_MESSAGE =
+  'CSV 미리보기를 불러오지 못했어요. 잠시 후 다시 시도해 주세요.';
+
 function createPreviewTable(preview?: FilePreview | null) {
   if (!preview || preview.headers.length === 0) return null;
 
@@ -128,6 +131,12 @@ export function useAnalysisChat({
   const dataSourcePreview = hasAccessToken
     ? dataSourceQuery.data?.preview
     : undefined;
+  const previewTable = createPreviewTable(dataSourcePreview);
+  const dataSourceErrorMessage = dataSourceQuery.isError
+    ? getApiErrorMessage(dataSourceQuery.error, GET_DATA_SOURCE_ERROR_MESSAGE)
+    : null;
+  const isDataSourceEmpty =
+    hasAccessToken && dataSourceQuery.isSuccess && !previewTable;
   const { questionAnalysisMutation, updateCriteriaMutation } = useCriteriaPhase(
     {
       getCriteriaErrorMessage: GET_CRITERIA_ERROR_MESSAGE,
@@ -385,8 +394,10 @@ export function useAnalysisChat({
     handleSubmit,
     initialMessage,
     inputDisabled,
+    dataSourceErrorMessage,
     isDataSourceLoading: hasAccessToken && dataSourceQuery.isLoading,
-    previewTable: createPreviewTable(dataSourcePreview),
+    isDataSourceEmpty,
+    previewTable,
     restMessages,
     shouldShowAnalyzing,
     startInitialQuestion,

--- a/apps/fe/src/app/(main)/analysis/[id]/_hooks/useAnalysisDataPreview.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_hooks/useAnalysisDataPreview.ts
@@ -1,0 +1,60 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import {
+  dataSourceKeys,
+  getDataSource,
+  type FilePreview,
+} from '@/apis/datasource';
+import { getApiErrorMessage } from '@/apis/errors';
+import type { DataTableColumn } from '../_components/DataTablePreview';
+
+function createPreviewTable(preview?: FilePreview | null) {
+  if (!preview || preview.headers.length === 0) return null;
+
+  const columns: DataTableColumn[] = preview.headers.map((header, index) => ({
+    key: `col-${index}`,
+    label: header || `컬럼 ${index + 1}`,
+  }));
+  const rows = preview.rows.map((row) =>
+    columns.reduce<Record<string, string>>((acc, column, index) => {
+      acc[column.key] = row[index] ?? '';
+      return acc;
+    }, {}),
+  );
+
+  return { columns, rows };
+}
+
+type UseAnalysisDataPreviewParams = {
+  dataSourceId: number | null;
+  enabled: boolean;
+  errorMessage: string;
+  invalidRouteMessage: string;
+};
+
+export function useAnalysisDataPreview({
+  dataSourceId,
+  enabled,
+  errorMessage,
+  invalidRouteMessage,
+}: UseAnalysisDataPreviewParams) {
+  const dataSourceQuery = useQuery({
+    queryKey: dataSourceKeys.detail(dataSourceId ?? 0),
+    queryFn: () => {
+      if (dataSourceId === null) throw new Error(invalidRouteMessage);
+      return getDataSource(dataSourceId);
+    },
+    enabled: enabled && dataSourceId !== null,
+  });
+  const previewTable = createPreviewTable(dataSourceQuery.data?.preview);
+
+  return {
+    dataSourceErrorMessage: dataSourceQuery.isError
+      ? getApiErrorMessage(dataSourceQuery.error, errorMessage)
+      : null,
+    isDataSourceEmpty: enabled && dataSourceQuery.isSuccess && !previewTable,
+    isDataSourceLoading: enabled && dataSourceQuery.isLoading,
+    previewTable,
+  };
+}

--- a/apps/fe/src/app/(main)/analysis/[id]/_tests/normalizeAnalysisError.test.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_tests/normalizeAnalysisError.test.ts
@@ -36,9 +36,10 @@ describe('normalizeAnalysisError', () => {
 
     expect(error).toMatchObject({
       code: 'REQUEST_VALIDATION_FAILED',
-      message: 'Invalid analysis criteria.',
       retryable: false,
     });
+    expect(error.message).not.toBe('Invalid analysis criteria.');
+    expect(error.message).toContain('입력값');
   });
 
   it('normalizes FAILED statuses to retryable user-facing errors', () => {

--- a/apps/fe/src/app/(main)/analysis/[id]/_tests/normalizeAnalysisError.test.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_tests/normalizeAnalysisError.test.ts
@@ -4,6 +4,7 @@ import {
   failedStatusResponse,
   llmCallFailedError,
   llmOutputInvalidError,
+  requestValidationFailedError,
 } from '../_fixtures/analysis.fixtures';
 import {
   normalizeAnalysisError,
@@ -27,6 +28,16 @@ describe('normalizeAnalysisError', () => {
     expect(error).toMatchObject({
       code: 'LLM_CALL_FAILED',
       retryable: true,
+    });
+  });
+
+  it('normalizes AI request validation errors', () => {
+    const error = normalizeAnalysisError(requestValidationFailedError);
+
+    expect(error).toMatchObject({
+      code: 'REQUEST_VALIDATION_FAILED',
+      message: 'Invalid analysis criteria.',
+      retryable: false,
     });
   });
 

--- a/apps/fe/src/app/(main)/analysis/[id]/_tests/normalizeCriteria.test.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_tests/normalizeCriteria.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   normalCriteriaResponse,
   partialNullCriteriaResponse,
+  rankingMissingLimitCriteriaResponse,
   unknownWarningCodeCriteriaResponse,
   warningCodeOnlyCriteriaResponse,
 } from '../_fixtures/analysis.fixtures';
@@ -55,6 +56,17 @@ describe('normalizeCriteria', () => {
     });
   });
 
+  it('requires limit count for ranking criteria', () => {
+    const criteria = normalizeCriteria(rankingMissingLimitCriteriaResponse);
+
+    expect(criteria.missingFields).toContain('조회 개수');
+    expect(
+      criteria.warnings.some(
+        (warning) => warning.code === 'MISSING_ANALYSIS_FIELDS',
+      ),
+    ).toBe(true);
+  });
+
   it('converts edit values back to the existing update request contract', () => {
     const criteria = normalizeCriteria(normalCriteriaResponse);
     const request = createUpdateCriteriaRequest(
@@ -66,7 +78,7 @@ describe('normalizeCriteria', () => {
       standardPeriod: '이번 주',
       comparePeriod: '지난 주',
       groupBy: ['channel', 'device'],
-      sortDirection: 'ASC',
+      sortDirection: 'asc',
       confirmed: true,
     });
   });

--- a/apps/fe/src/app/(main)/analysis/[id]/_tests/normalizeResult.test.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_tests/normalizeResult.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   emptyChartResultResponse,
   normalResultResponse,
+  rowsEmptyResultResponse,
   rowsNullResultResponse,
 } from '../_fixtures/analysis.fixtures';
 import { normalizeChartData } from '../_adapters/normalizeChartData';
@@ -35,6 +36,15 @@ describe('normalizeResult', () => {
 
   it('normalizes legacy rows:null chartData to an empty chart model', () => {
     const result = normalizeResult(rowsNullResultResponse);
+
+    expect(result.chart).toMatchObject({
+      type: 'empty',
+      reason: 'empty',
+    });
+  });
+
+  it('normalizes legacy rows:[] chartData to an empty chart model', () => {
+    const result = normalizeResult(rowsEmptyResultResponse);
 
     expect(result.chart).toMatchObject({
       type: 'empty',

--- a/apps/fe/src/app/(main)/analysis/[id]/_tests/normalizeSummary.test.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_tests/normalizeSummary.test.ts
@@ -23,6 +23,23 @@ describe('normalizeSummary', () => {
     expect(summary.emptyMessage).toBeNull();
   });
 
+  it('compacts role arrays before creating options and key points', () => {
+    const summary = normalizeSummary({
+      ...normalSummaryResponse,
+      dataCriteria: [' signup_date ', 'signup_date', ''],
+      measure: null,
+      dimension: [' channel ', 'channel'],
+      statusCondition: null,
+      flag: null,
+      idCriteria: null,
+    });
+
+    expect(
+      summary.keyPoints.filter((item) => item.example === 'signup_date'),
+    ).toHaveLength(1);
+    expect(summary.columnOptions).toEqual(['signup_date', 'channel']);
+  });
+
   it('keeps empty/null summary data renderable', () => {
     const summary = normalizeSummary(summaryTextNullResponse);
 

--- a/apps/fe/src/app/(main)/analysis/[id]/page.tsx
+++ b/apps/fe/src/app/(main)/analysis/[id]/page.tsx
@@ -37,6 +37,17 @@ export default function AnalysisChatPage({
           />
         ) : chat.isDataSourceLoading ? (
           <LoadingDataPreview message="CSV 미리보기를 불러오는 중이에요" />
+        ) : chat.dataSourceErrorMessage ? (
+          <LoadingDataPreview
+            message={chat.dataSourceErrorMessage}
+            showSpinner={false}
+            tone="error"
+          />
+        ) : chat.isDataSourceEmpty ? (
+          <LoadingDataPreview
+            message="표시할 CSV 미리보기 데이터가 없습니다."
+            showSpinner={false}
+          />
         ) : (
           <LoadingDataPreview />
         )

--- a/apps/fe/src/app/(main)/data/[id]/page.tsx
+++ b/apps/fe/src/app/(main)/data/[id]/page.tsx
@@ -2,7 +2,6 @@
 
 import { use, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { getApiErrorMessage, isApiConflictError } from '@/apis/errors';
 import { isMockDataSourceId } from '@/apis/mockDataSource';
 import { ToastPortal } from '@/components';
 import { AUTH_MESSAGES, DATA_SOURCE_MESSAGES } from '@/constants/messages';
@@ -11,6 +10,7 @@ import DataDetailStatus from './_components/DataDetailStatus';
 import DataDetailView from './_components/DataDetailView';
 import { useDataDetail } from './_hooks/useDataDetail';
 import { useDataSourceUserContext } from '../_hooks/useDataSourceUserContext';
+import { getDataSourceDeleteErrorMessage } from '../_utils/dataSourceErrorMessage';
 
 type PageParams = { id: string };
 
@@ -58,9 +58,10 @@ export default function DataDetailPage({
     } catch (error) {
       setDeleteOpen(false);
       showToast(
-        isApiConflictError(error)
-          ? DATA_SOURCE_MESSAGES.deleteConflict
-          : getApiErrorMessage(error, DATA_SOURCE_MESSAGES.detailDeleteError),
+        getDataSourceDeleteErrorMessage(error, {
+          conflict: DATA_SOURCE_MESSAGES.deleteConflict,
+          fallback: DATA_SOURCE_MESSAGES.detailDeleteError,
+        }),
       );
     }
   };

--- a/apps/fe/src/app/(main)/data/_hooks/useDataSourceList.ts
+++ b/apps/fe/src/app/(main)/data/_hooks/useDataSourceList.ts
@@ -4,11 +4,11 @@ import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { dataSourceKeys, type DataSourceSort } from '@/apis/datasource';
 import { getDataSources } from '@/apis/dataSourceRepository';
-import { getApiErrorMessage } from '@/apis/errors';
 import {
   filterVisibleMockDataSources,
   getMockDataSourceListResponse,
 } from '@/apis/mockDataSource';
+import { getDataSourceErrorMessage } from '../_utils/dataSourceErrorMessage';
 
 const DATA_SOURCE_PAGE_SIZE = 20;
 
@@ -56,7 +56,7 @@ export function useDataSourceList({
     isLoading: query.isLoading && !hasDataSources,
     errorMessage:
       query.isError && !hasDataSources
-        ? getApiErrorMessage(query.error, fallbackErrorMessage)
+        ? getDataSourceErrorMessage(query.error, fallbackErrorMessage)
         : null,
   };
 }

--- a/apps/fe/src/app/(main)/data/_hooks/useDeleteDataSources.ts
+++ b/apps/fe/src/app/(main)/data/_hooks/useDeleteDataSources.ts
@@ -4,9 +4,12 @@ import { useCallback } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { deleteDataSources } from '@/apis/dataSourceRepository';
 import { dataSourceKeys } from '@/apis/datasource';
-import { getApiErrorMessage, isApiConflictError } from '@/apis/errors';
-import { isMockDataSourceId } from '@/apis/mockDataSource';
+import {
+  getMockDataSourceIds,
+  getServerDataSourceIds,
+} from '@/apis/mockDataSource';
 import { AUTH_MESSAGES } from '@/constants/messages';
+import { getDataSourceDeleteErrorMessage } from '../_utils/dataSourceErrorMessage';
 
 type UseDeleteDataSourcesOptions = {
   conflictErrorMessage: string;
@@ -34,10 +37,8 @@ export function useDeleteDataSources({
     async (dataSourceIds: number[]) => {
       if (dataSourceIds.length === 0) return;
 
-      const mockDataSourceIds = dataSourceIds.filter(isMockDataSourceId);
-      const serverDataSourceIds = dataSourceIds.filter(
-        (dataSourceId) => !isMockDataSourceId(dataSourceId),
-      );
+      const mockDataSourceIds = getMockDataSourceIds(dataSourceIds);
+      const serverDataSourceIds = getServerDataSourceIds(dataSourceIds);
 
       if (mockDataSourceIds.length > 0 && userId == null) {
         onError(AUTH_MESSAGES.userInfoRequired);
@@ -59,9 +60,10 @@ export function useDeleteDataSources({
         onSuccess();
       } catch (error) {
         onError(
-          isApiConflictError(error)
-            ? conflictErrorMessage
-            : getApiErrorMessage(error, fallbackErrorMessage),
+          getDataSourceDeleteErrorMessage(error, {
+            conflict: conflictErrorMessage,
+            fallback: fallbackErrorMessage,
+          }),
         );
       }
     },

--- a/apps/fe/src/app/(main)/data/_hooks/useDeletedMockDataSources.ts
+++ b/apps/fe/src/app/(main)/data/_hooks/useDeletedMockDataSources.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useMemo, useState } from 'react';
 import {
+  isMockDataSourceId,
   markMockDataSourcesDeleted,
   readDeletedMockDataSourceIds,
 } from '@/apis/mockDataSource';
@@ -57,9 +58,16 @@ export function useDeletedMockDataSources(userId: number | null | undefined) {
     },
     [userId],
   );
+  const isDeletedMockDataSource = useCallback(
+    (dataSourceId: number) =>
+      isMockDataSourceId(dataSourceId) &&
+      deletedMockDataSourceIds.has(dataSourceId),
+    [deletedMockDataSourceIds],
+  );
 
   return {
     deletedMockDataSourceIds,
+    isDeletedMockDataSource,
     markDeletedMockDataSources,
   };
 }

--- a/apps/fe/src/app/(main)/data/_hooks/useUploadDataSource.ts
+++ b/apps/fe/src/app/(main)/data/_hooks/useUploadDataSource.ts
@@ -3,7 +3,7 @@
 import { useCallback } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { dataSourceKeys, uploadDataSource } from '@/apis/datasource';
-import { getApiErrorMessage } from '@/apis/errors';
+import { getDataSourceErrorMessage } from '../_utils/dataSourceErrorMessage';
 
 type UseUploadDataSourceOptions = {
   fallbackErrorMessage: string;
@@ -36,7 +36,7 @@ export function useUploadDataSource({
         });
         onSuccess();
       } catch (error) {
-        throw new Error(getApiErrorMessage(error, fallbackErrorMessage));
+        throw new Error(getDataSourceErrorMessage(error, fallbackErrorMessage));
       }
     },
     [

--- a/apps/fe/src/app/(main)/data/_utils/dataSourceErrorMessage.ts
+++ b/apps/fe/src/app/(main)/data/_utils/dataSourceErrorMessage.ts
@@ -1,0 +1,22 @@
+import { getApiErrorMessage, isApiConflictError } from '@/apis/errors';
+
+type DataSourceDeleteErrorMessages = {
+  conflict: string;
+  fallback: string;
+};
+
+export function getDataSourceErrorMessage(
+  error: unknown,
+  fallbackMessage: string,
+) {
+  return getApiErrorMessage(error, fallbackMessage);
+}
+
+export function getDataSourceDeleteErrorMessage(
+  error: unknown,
+  { conflict, fallback }: DataSourceDeleteErrorMessages,
+) {
+  return isApiConflictError(error)
+    ? conflict
+    : getDataSourceErrorMessage(error, fallback);
+}

--- a/apps/fe/src/app/onboarding/_components/OnboardingOptionGroup.tsx
+++ b/apps/fe/src/app/onboarding/_components/OnboardingOptionGroup.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+type SingleSelectProps = {
+  options: string[];
+  value: string | null;
+  onChange: (value: string) => void;
+};
+
+type MultiSelectProps = {
+  options: string[];
+  values: Set<string>;
+  onToggle: (value: string) => void;
+};
+
+type OptionButtonProps = {
+  active: boolean;
+  children: string;
+  className?: string;
+  indicator?: 'none' | 'radio' | 'checkbox';
+  onClick: () => void;
+};
+
+function optionButtonClass(active: boolean, className = '') {
+  return `rounded-12 border px-16 py-12 text-body2 transition-colors ${
+    active
+      ? 'border-orange-500 bg-orange-100 text-orange-600'
+      : 'border-gray-300 bg-white text-gray-800 hover:border-gray-400'
+  } ${className}`.trim();
+}
+
+function OptionButton({
+  active,
+  children,
+  className,
+  indicator = 'none',
+  onClick,
+}: OptionButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={indicator === 'none' ? active : undefined}
+      className={optionButtonClass(active, className)}
+    >
+      <span>{children}</span>
+      {indicator === 'radio' && (
+        <span
+          aria-hidden
+          className={`relative inline-flex h-[1.8rem] w-[1.8rem] items-center justify-center rounded-full border-2 transition-colors ${
+            active ? 'border-orange-500' : 'border-gray-400'
+          }`}
+        >
+          {active && (
+            <span className="absolute inline-block h-8 w-8 rounded-full bg-orange-500" />
+          )}
+        </span>
+      )}
+      {indicator === 'checkbox' && (
+        <span
+          aria-hidden
+          className={`inline-flex h-[1.8rem] w-[1.8rem] items-center justify-center rounded-4 border-2 transition-colors ${
+            active
+              ? 'border-orange-500 bg-orange-500'
+              : 'border-gray-400 bg-white'
+          }`}
+        >
+          {active && (
+            <svg
+              aria-hidden
+              viewBox="0 0 12 10"
+              className="h-[1rem] w-12 text-white"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M1 5 4.5 8.5 11 1.5" />
+            </svg>
+          )}
+        </span>
+      )}
+    </button>
+  );
+}
+
+export function OnboardingProgressBar({
+  current,
+  total,
+}: {
+  current: number;
+  total: number;
+}) {
+  return (
+    <div className="flex gap-8">
+      {Array.from({ length: total }).map((_, i) => {
+        const filled = i < current;
+        return (
+          <span
+            key={i}
+            className={`h-4 flex-1 rounded-full transition-colors ${
+              filled ? 'bg-orange-500' : 'bg-gray-300'
+            }`}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+export function DomainGrid({ options, value, onChange }: SingleSelectProps) {
+  return (
+    <div className="grid grid-cols-2 gap-12">
+      {options.map((option) => (
+        <OptionButton
+          key={option}
+          active={option === value}
+          onClick={() => onChange(option)}
+        >
+          {option}
+        </OptionButton>
+      ))}
+    </div>
+  );
+}
+
+export function RadioList({ options, value, onChange }: SingleSelectProps) {
+  return (
+    <div className="flex flex-col gap-12">
+      {options.map((option) => (
+        <OptionButton
+          key={option}
+          active={option === value}
+          className="flex items-center justify-between text-left"
+          indicator="radio"
+          onClick={() => onChange(option)}
+        >
+          {option}
+        </OptionButton>
+      ))}
+    </div>
+  );
+}
+
+export function CheckboxList({ options, values, onToggle }: MultiSelectProps) {
+  return (
+    <div className="flex flex-col gap-12">
+      {options.map((option) => (
+        <OptionButton
+          key={option}
+          active={values.has(option)}
+          className="flex items-center justify-between text-left"
+          indicator="checkbox"
+          onClick={() => onToggle(option)}
+        >
+          {option}
+        </OptionButton>
+      ))}
+    </div>
+  );
+}

--- a/apps/fe/src/app/onboarding/page.tsx
+++ b/apps/fe/src/app/onboarding/page.tsx
@@ -5,6 +5,12 @@ import { useRouter } from 'next/navigation';
 import ArrowLeftIcon from '@/assets/icons/arrow-left.svg';
 import ArrowRightIcon from '@/assets/icons/arrow-right.svg';
 import { Button, Stepper } from '@/components';
+import {
+  CheckboxList,
+  DomainGrid,
+  OnboardingProgressBar,
+  RadioList,
+} from './_components/OnboardingOptionGroup';
 
 /**
  * 완료 버튼용 체크 아이콘.
@@ -147,7 +153,7 @@ export default function OnboardingPage() {
                 {copy.title}
               </h3>
               <p className="text-body4 text-gray-700">{copy.description}</p>
-              <ProgressBar current={step} total={3} />
+              <OnboardingProgressBar current={step} total={3} />
             </div>
 
             <div className="flex-1">
@@ -212,154 +218,5 @@ export default function OnboardingPage() {
         </div>
       </div>
     </main>
-  );
-}
-
-/** 상단 진행 막대 (3분할). 현재 단계까지 오렌지, 이후는 회색 */
-function ProgressBar({ current, total }: { current: number; total: number }) {
-  return (
-    <div className="flex gap-8">
-      {Array.from({ length: total }).map((_, i) => {
-        const filled = i < current;
-        return (
-          <span
-            key={i}
-            className={`h-4 flex-1 rounded-full transition-colors ${
-              filled ? 'bg-orange-500' : 'bg-gray-300'
-            }`}
-          />
-        );
-      })}
-    </div>
-  );
-}
-
-/** 도메인 선택: 2열 그리드 카드형 옵션 */
-function DomainGrid({
-  options,
-  value,
-  onChange,
-}: {
-  options: string[];
-  value: string | null;
-  onChange: (v: string) => void;
-}) {
-  return (
-    <div className="grid grid-cols-2 gap-12">
-      {options.map((opt) => {
-        const active = opt === value;
-        return (
-          <button
-            key={opt}
-            type="button"
-            onClick={() => onChange(opt)}
-            className={`rounded-12 border px-16 py-12 text-body2 transition-colors ${
-              active
-                ? 'border-orange-500 bg-orange-100 text-orange-600'
-                : 'border-gray-300 bg-white text-gray-800 hover:border-gray-400'
-            }`}
-          >
-            {opt}
-          </button>
-        );
-      })}
-    </div>
-  );
-}
-
-/** 업무 단일 선택: 라디오 버튼 리스트 */
-function RadioList({
-  options,
-  value,
-  onChange,
-}: {
-  options: string[];
-  value: string | null;
-  onChange: (v: string) => void;
-}) {
-  return (
-    <div className="flex flex-col gap-12">
-      {options.map((opt) => {
-        const active = opt === value;
-        return (
-          <button
-            key={opt}
-            type="button"
-            onClick={() => onChange(opt)}
-            className={`flex items-center justify-between rounded-12 border px-16 py-12 text-left text-body2 transition-colors ${
-              active
-                ? 'border-orange-500 bg-orange-100 text-orange-600'
-                : 'border-gray-300 bg-white text-gray-800 hover:border-gray-400'
-            }`}
-          >
-            <span>{opt}</span>
-            <span
-              className={`relative inline-flex h-[1.8rem] w-[1.8rem] items-center justify-center rounded-full border-2 transition-colors ${
-                active ? 'border-orange-500' : 'border-gray-400'
-              }`}
-            >
-              {active && (
-                <span className="absolute inline-block h-8 w-8 rounded-full bg-orange-500" />
-              )}
-            </span>
-          </button>
-        );
-      })}
-    </div>
-  );
-}
-
-/** 사용 툴 다중 선택: 체크박스 리스트 */
-function CheckboxList({
-  options,
-  values,
-  onToggle,
-}: {
-  options: string[];
-  values: Set<string>;
-  onToggle: (v: string) => void;
-}) {
-  return (
-    <div className="flex flex-col gap-12">
-      {options.map((opt) => {
-        const active = values.has(opt);
-        return (
-          <button
-            key={opt}
-            type="button"
-            onClick={() => onToggle(opt)}
-            className={`flex items-center justify-between rounded-12 border px-16 py-12 text-left text-body2 transition-colors ${
-              active
-                ? 'border-orange-500 bg-orange-100 text-orange-600'
-                : 'border-gray-300 bg-white text-gray-800 hover:border-gray-400'
-            }`}
-          >
-            <span>{opt}</span>
-            <span
-              className={`inline-flex h-[1.8rem] w-[1.8rem] items-center justify-center rounded-4 border-2 transition-colors ${
-                active
-                  ? 'border-orange-500 bg-orange-500'
-                  : 'border-gray-400 bg-white'
-              }`}
-            >
-              {active && (
-                <svg
-                  aria-hidden
-                  viewBox="0 0 12 10"
-                  className="h-[1rem] w-12 text-white"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2.5"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <path d="M1 5 4.5 8.5 11 1.5" />
-                </svg>
-              )}
-            </span>
-          </button>
-        );
-      })}
-    </div>
   );
 }


### PR DESCRIPTION
## 요약
- FE 분석 API 연결 계약을 Spring `/api/anal` 기준으로 단단하게 만들고, normalizer 방어 로직과 최소 UI 상태를 보강했습니다.
- 구조 리뷰에서 나온 분석/데이터소스/온보딩 화면 책임 분리도 함께 반영했습니다.

## 변경 사항
- [x] 기능
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `yarn test`
  - `yarn lint`
  - `git diff --check`

## 스크린샷/로그 (선택)
- 해당 없음

## 롤백/리스크
- 리스크 포인트:
  - BE/AI summary role 배열이 비어 있으면 FE 옵션/요약 표시가 제한될 수 있습니다.
  - `sortDirection`은 lowercase `asc`/`desc` 계약을 기준으로 보냅니다.
  - 실제 API shape는 staging smoke로 한 번 더 확인이 필요합니다.
- 롤백 방법:
  - 이 PR 커밋을 revert합니다.

## 관련 이슈
Closes #290
Closes #303