### PR TITLE
fix(be): DataSource 삭제 시 하위 엔티티 cascade 삭제 (#288)

### DIFF
--- a/apps/be/src/main/java/com/capstone/logue/anal/repository/AiTaggingJobRepository.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/repository/AiTaggingJobRepository.java
@@ -2,9 +2,12 @@ package com.capstone.logue.anal.repository;
 
 import com.capstone.logue.global.entity.AiTaggingJob;
 import com.capstone.logue.global.entity.enums.JobStage;
-import org.springframework.data.jpa.repository.JpaRepository;
-
+import java.util.Collection;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface AiTaggingJobRepository extends JpaRepository<AiTaggingJob, Long> {
     Optional<AiTaggingJob> findByConversationIdAndStage(Long conversationId, JobStage stage);
@@ -14,4 +17,15 @@ public interface AiTaggingJobRepository extends JpaRepository<AiTaggingJob, Long
     Optional<AiTaggingJob> findTopByAnalysisFlowIdAndStageOrderByCreatedAtDescIdDesc(Long analysisFlowId, JobStage stage);
 
     Optional<AiTaggingJob> findTopByMessageIdAndStageOrderByCreatedAtDescIdDesc(Long messageId, JobStage stage);
+
+    /**
+     * 주어진 AnalysisFlow id 들에 연결된 AiTaggingJob 을 일괄 삭제합니다.
+     * V4 이전에 analysis_flow_id 가 NULL 인 레거시 로우는 message 경로(message.analysisFlow)
+     * 로 매칭되어 함께 정리됩니다.
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM AiTaggingJob j "
+            + "WHERE j.analysisFlow.id IN :analysisFlowIds "
+            + "OR j.message.analysisFlow.id IN :analysisFlowIds")
+    int deleteAllByAnalysisFlowIds(@Param("analysisFlowIds") Collection<Long> analysisFlowIds);
 }

--- a/apps/be/src/main/java/com/capstone/logue/anal/repository/AnalysisCriteriaRepository.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/repository/AnalysisCriteriaRepository.java
@@ -1,14 +1,32 @@
 package com.capstone.logue.anal.repository;
 
 import com.capstone.logue.global.entity.AnalysisCriteria;
-import org.springframework.data.jpa.repository.JpaRepository;
-
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface AnalysisCriteriaRepository extends JpaRepository<AnalysisCriteria, Long> {
 
     Optional<AnalysisCriteria> findTopByAnalysisFlowIdOrderByCreatedAtDescIdDesc(Long analysisFlowId);
 
     List<AnalysisCriteria> findByAnalysisFlowIdOrderByCreatedAtDesc(Long analysisFlowId);
+
+    /**
+     * 주어진 AnalysisFlow id 들에 연결된 AnalysisCriteria 의 id 목록을 조회합니다.
+     * AnalysisResult·FlowDataWarning cascade 삭제 전 식별자 확보용입니다.
+     */
+    @Query("SELECT c.id FROM AnalysisCriteria c WHERE c.analysisFlow.id IN :analysisFlowIds")
+    List<Long> findIdsByAnalysisFlowIds(@Param("analysisFlowIds") Collection<Long> analysisFlowIds);
+
+    /**
+     * 주어진 AnalysisFlow id 들에 연결된 AnalysisCriteria 를 일괄 삭제합니다.
+     * 호출 전에 AnalysisResult·FlowDataWarning 이 먼저 삭제되어야 합니다.
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM AnalysisCriteria c WHERE c.analysisFlow.id IN :analysisFlowIds")
+    int deleteAllByAnalysisFlowIds(@Param("analysisFlowIds") Collection<Long> analysisFlowIds);
 }

--- a/apps/be/src/main/java/com/capstone/logue/anal/repository/AnalysisFlowColumnRepository.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/repository/AnalysisFlowColumnRepository.java
@@ -1,11 +1,21 @@
 package com.capstone.logue.anal.repository;
 
 import com.capstone.logue.global.entity.AnalysisFlowColumn;
-import org.springframework.data.jpa.repository.JpaRepository;
-
+import java.util.Collection;
 import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface AnalysisFlowColumnRepository extends JpaRepository<AnalysisFlowColumn, Long> {
 
     List<AnalysisFlowColumn> findByAnalysisFlowIdOrderByIdAsc(Long analysisFlowId);
+
+    /**
+     * 주어진 AnalysisFlow id 들에 연결된 AnalysisFlowColumn 을 일괄 삭제합니다.
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM AnalysisFlowColumn afc WHERE afc.analysisFlow.id IN :analysisFlowIds")
+    int deleteAllByAnalysisFlowIds(@Param("analysisFlowIds") Collection<Long> analysisFlowIds);
 }

--- a/apps/be/src/main/java/com/capstone/logue/anal/repository/AnalysisFlowRepository.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/repository/AnalysisFlowRepository.java
@@ -1,7 +1,27 @@
 package com.capstone.logue.anal.repository;
 
 import com.capstone.logue.global.entity.AnalysisFlow;
+import java.util.Collection;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface AnalysisFlowRepository extends JpaRepository<AnalysisFlow, Long> {
+
+    /**
+     * 주어진 DataSource id 들에 연결된 AnalysisFlow 의 id 목록을 조회합니다.
+     * 하위 엔티티(메시지·분석기준·태깅잡 등) cascade 삭제 전 식별자 확보용입니다.
+     */
+    @Query("SELECT af.id FROM AnalysisFlow af WHERE af.dataSource.id IN :dataSourceIds")
+    List<Long> findIdsByDataSourceIds(@Param("dataSourceIds") Collection<Long> dataSourceIds);
+
+    /**
+     * 주어진 DataSource id 들에 연결된 AnalysisFlow 를 일괄 삭제합니다.
+     * 호출 전에 모든 하위 엔티티가 먼저 삭제되어야 FK 위반 없이 동작합니다.
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM AnalysisFlow af WHERE af.dataSource.id IN :dataSourceIds")
+    int deleteAllByDataSourceIds(@Param("dataSourceIds") Collection<Long> dataSourceIds);
 }

--- a/apps/be/src/main/java/com/capstone/logue/anal/repository/AnalysisResultRepository.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/repository/AnalysisResultRepository.java
@@ -1,11 +1,21 @@
 package com.capstone.logue.anal.repository;
 
 import com.capstone.logue.global.entity.AnalysisResult;
-import org.springframework.data.jpa.repository.JpaRepository;
-
+import java.util.Collection;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface AnalysisResultRepository extends JpaRepository<AnalysisResult, Long> {
 
     Optional<AnalysisResult> findByAnalysisCriteriaId(Long analysisCriteriaId);
+
+    /**
+     * 주어진 AnalysisCriteria id 들에 연결된 AnalysisResult 를 일괄 삭제합니다.
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM AnalysisResult r WHERE r.analysisCriteria.id IN :analysisCriteriaIds")
+    int deleteAllByAnalysisCriteriaIds(@Param("analysisCriteriaIds") Collection<Long> analysisCriteriaIds);
 }

--- a/apps/be/src/main/java/com/capstone/logue/anal/repository/DataSourceColumnRepository.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/repository/DataSourceColumnRepository.java
@@ -1,11 +1,22 @@
 package com.capstone.logue.anal.repository;
 
 import com.capstone.logue.global.entity.DataSourceColumn;
-import org.springframework.data.jpa.repository.JpaRepository;
-
+import java.util.Collection;
 import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface DataSourceColumnRepository extends JpaRepository<DataSourceColumn, Long> {
 
     List<DataSourceColumn> findByDataSourceId(Long dataSourceId);
+
+    /**
+     * 주어진 DataSource id 들에 연결된 DataSourceColumn 을 일괄 삭제합니다.
+     * 호출 전에 AnalysisFlowColumn 의 data_source_column 참조가 먼저 정리되어야 합니다.
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM DataSourceColumn c WHERE c.dataSource.id IN :dataSourceIds")
+    int deleteAllByDataSourceIds(@Param("dataSourceIds") Collection<Long> dataSourceIds);
 }

--- a/apps/be/src/main/java/com/capstone/logue/anal/repository/FlowDataWarningRepository.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/repository/FlowDataWarningRepository.java
@@ -1,11 +1,21 @@
 package com.capstone.logue.anal.repository;
 
 import com.capstone.logue.global.entity.FlowDataWarning;
-import org.springframework.data.jpa.repository.JpaRepository;
-
+import java.util.Collection;
 import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface FlowDataWarningRepository extends JpaRepository<FlowDataWarning, Long> {
 
     List<FlowDataWarning> findByAnalysisCriteriaId(Long analysisCriteriaId);
+
+    /**
+     * 주어진 AnalysisCriteria id 들에 연결된 FlowDataWarning 을 일괄 삭제합니다.
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM FlowDataWarning w WHERE w.analysisCriteria.id IN :analysisCriteriaIds")
+    int deleteAllByAnalysisCriteriaIds(@Param("analysisCriteriaIds") Collection<Long> analysisCriteriaIds);
 }

--- a/apps/be/src/main/java/com/capstone/logue/anal/repository/MessageRepository.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/repository/MessageRepository.java
@@ -1,11 +1,22 @@
 package com.capstone.logue.anal.repository;
 
 import com.capstone.logue.global.entity.Message;
-import org.springframework.data.jpa.repository.JpaRepository;
-
+import java.util.Collection;
 import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MessageRepository extends JpaRepository<Message, Long> {
 
     List<Message> findByAnalysisFlowIdOrderByCreatedAtAscIdAsc(Long analysisFlowId);
+
+    /**
+     * 주어진 AnalysisFlow id 들에 연결된 Message 를 일괄 삭제합니다.
+     * 호출 전에 AiTaggingJob 의 message 참조가 먼저 정리되어야 합니다.
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Message m WHERE m.analysisFlow.id IN :analysisFlowIds")
+    int deleteAllByAnalysisFlowIds(@Param("analysisFlowIds") Collection<Long> analysisFlowIds);
 }

--- a/apps/be/src/main/java/com/capstone/logue/anal/repository/SourceDataWarningRepository.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/repository/SourceDataWarningRepository.java
@@ -1,11 +1,21 @@
 package com.capstone.logue.anal.repository;
 
 import com.capstone.logue.global.entity.SourceDataWarning;
-import org.springframework.data.jpa.repository.JpaRepository;
-
+import java.util.Collection;
 import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SourceDataWarningRepository extends JpaRepository<SourceDataWarning, Long> {
 
     List<SourceDataWarning> findByDataSourceId(Long dataSourceId);
+
+    /**
+     * 주어진 DataSource id 들에 연결된 SourceDataWarning 을 일괄 삭제합니다.
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM SourceDataWarning w WHERE w.dataSource.id IN :dataSourceIds")
+    int deleteAllByDataSourceIds(@Param("dataSourceIds") Collection<Long> dataSourceIds);
 }

--- a/apps/be/src/main/java/com/capstone/logue/data/service/DataSourceService.java
+++ b/apps/be/src/main/java/com/capstone/logue/data/service/DataSourceService.java
@@ -1,5 +1,14 @@
 package com.capstone.logue.data.service;
 
+import com.capstone.logue.anal.repository.AiTaggingJobRepository;
+import com.capstone.logue.anal.repository.AnalysisCriteriaRepository;
+import com.capstone.logue.anal.repository.AnalysisFlowColumnRepository;
+import com.capstone.logue.anal.repository.AnalysisFlowRepository;
+import com.capstone.logue.anal.repository.AnalysisResultRepository;
+import com.capstone.logue.anal.repository.DataSourceColumnRepository;
+import com.capstone.logue.anal.repository.FlowDataWarningRepository;
+import com.capstone.logue.anal.repository.MessageRepository;
+import com.capstone.logue.anal.repository.SourceDataWarningRepository;
 import com.capstone.logue.data.dto.DataSourceSummary;
 import com.capstone.logue.data.dto.FilePreview;
 import com.capstone.logue.data.dto.GetDataSourceListResponse;
@@ -58,6 +67,15 @@ public class DataSourceService {
     private final DataSourceStorage storage;
     private final CsvParser csvParser;
     private final ObjectMapper objectMapper;
+    private final AnalysisFlowRepository analysisFlowRepository;
+    private final AnalysisCriteriaRepository analysisCriteriaRepository;
+    private final AnalysisResultRepository analysisResultRepository;
+    private final FlowDataWarningRepository flowDataWarningRepository;
+    private final AnalysisFlowColumnRepository analysisFlowColumnRepository;
+    private final AiTaggingJobRepository aiTaggingJobRepository;
+    private final MessageRepository messageRepository;
+    private final SourceDataWarningRepository sourceDataWarningRepository;
+    private final DataSourceColumnRepository dataSourceColumnRepository;
 
     /**
      * CSV 파일을 업로드해 DataSource 엔티티로 저장합니다.
@@ -168,11 +186,13 @@ public class DataSourceService {
     }
 
     /**
-     * DataSource 단건 삭제. 스토리지 파일도 best-effort 로 제거합니다.
+     * DataSource 단건 삭제. 연결된 AnalysisFlow 와 하위 엔티티(메시지·분석기준·결과·경고·태깅잡)
+     * 도 함께 cascade 삭제하며, 스토리지 파일도 best-effort 로 제거합니다.
      */
     @Transactional
     public void deleteOne(Long userId, Long dataSourceId) {
         DataSource dataSource = loadOwnedDataSource(userId, dataSourceId);
+        cascadeDeleteByDataSourceIds(List.of(dataSourceId));
         deleteStorageQuietly(dataSource.getStorageKey());
         dataSourceRepository.delete(dataSource);
     }
@@ -181,7 +201,8 @@ public class DataSourceService {
      * DataSource 다건 삭제.
      *
      * <p>요청 id 중 하나라도 존재하지 않으면 404, 타 사용자 소유면 403 을 발생시키며
-     * 전체 요청을 실패 처리합니다. 모든 id 가 현재 사용자 소유여야 삭제가 수행됩니다.</p>
+     * 전체 요청을 실패 처리합니다. 모든 id 가 현재 사용자 소유여야 삭제가 수행됩니다.
+     * 단건 삭제와 동일하게 연결된 AnalysisFlow 및 하위 엔티티를 cascade 삭제합니다.</p>
      */
     @Transactional
     public void deleteMany(Long userId, Collection<Long> ids) {
@@ -200,10 +221,48 @@ public class DataSourceService {
                 throw new LogueException(ErrorCode.DATASOURCE_FORBIDDEN);
             }
         }
+        cascadeDeleteByDataSourceIds(foundIds);
         for (DataSource dataSource : found) {
             deleteStorageQuietly(dataSource.getStorageKey());
         }
         dataSourceRepository.deleteAll(found);
+    }
+
+    /**
+     * DataSource 에 연결된 모든 하위 엔티티를 자식부터 일괄 삭제합니다.
+     *
+     * <p>FK 제약 위반이 발생하지 않도록 다음 순서로 진행합니다.</p>
+     * <ol>
+     *   <li>AnalysisCriteria 의 자식: AnalysisResult, FlowDataWarning</li>
+     *   <li>AnalysisFlow 의 자식: AnalysisCriteria, AnalysisFlowColumn, AiTaggingJob, Message</li>
+     *   <li>AnalysisFlow 본체</li>
+     *   <li>DataSource 의 그 외 자식: SourceDataWarning, DataSourceColumn</li>
+     * </ol>
+     *
+     * <p>DataSource 본체 삭제는 호출자가 수행합니다.</p>
+     */
+    private void cascadeDeleteByDataSourceIds(Collection<Long> dataSourceIds) {
+        if (dataSourceIds == null || dataSourceIds.isEmpty()) {
+            return;
+        }
+        List<Long> flowIds = analysisFlowRepository.findIdsByDataSourceIds(dataSourceIds);
+        List<Long> criteriaIds = flowIds.isEmpty()
+                ? List.of()
+                : analysisCriteriaRepository.findIdsByAnalysisFlowIds(flowIds);
+
+        if (!criteriaIds.isEmpty()) {
+            analysisResultRepository.deleteAllByAnalysisCriteriaIds(criteriaIds);
+            flowDataWarningRepository.deleteAllByAnalysisCriteriaIds(criteriaIds);
+        }
+        if (!flowIds.isEmpty()) {
+            analysisCriteriaRepository.deleteAllByAnalysisFlowIds(flowIds);
+            analysisFlowColumnRepository.deleteAllByAnalysisFlowIds(flowIds);
+            aiTaggingJobRepository.deleteAllByAnalysisFlowIds(flowIds);
+            messageRepository.deleteAllByAnalysisFlowIds(flowIds);
+            analysisFlowRepository.deleteAllByDataSourceIds(dataSourceIds);
+        }
+        sourceDataWarningRepository.deleteAllByDataSourceIds(dataSourceIds);
+        dataSourceColumnRepository.deleteAllByDataSourceIds(dataSourceIds);
     }
 
     private void validateCsv(MultipartFile file) {

--- a/apps/be/src/test/java/com/capstone/logue/data/service/DataSourceServiceTest.java
+++ b/apps/be/src/test/java/com/capstone/logue/data/service/DataSourceServiceTest.java
@@ -3,13 +3,24 @@ package com.capstone.logue.data.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.capstone.logue.anal.repository.AiTaggingJobRepository;
+import com.capstone.logue.anal.repository.AnalysisCriteriaRepository;
+import com.capstone.logue.anal.repository.AnalysisFlowColumnRepository;
+import com.capstone.logue.anal.repository.AnalysisFlowRepository;
+import com.capstone.logue.anal.repository.AnalysisResultRepository;
+import com.capstone.logue.anal.repository.DataSourceColumnRepository;
+import com.capstone.logue.anal.repository.FlowDataWarningRepository;
+import com.capstone.logue.anal.repository.MessageRepository;
+import com.capstone.logue.anal.repository.SourceDataWarningRepository;
 import com.capstone.logue.data.dto.FilePreview;
 import com.capstone.logue.data.dto.GetDataSourceListResponse;
 import com.capstone.logue.data.dto.SortType;
@@ -30,6 +41,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
@@ -55,6 +67,15 @@ class DataSourceServiceTest {
     @Mock private UserLookupRepository userLookupRepository;
     @Mock private DataSourceStorage storage;
     @Mock private CsvParser csvParser;
+    @Mock private AnalysisFlowRepository analysisFlowRepository;
+    @Mock private AnalysisCriteriaRepository analysisCriteriaRepository;
+    @Mock private AnalysisResultRepository analysisResultRepository;
+    @Mock private FlowDataWarningRepository flowDataWarningRepository;
+    @Mock private AnalysisFlowColumnRepository analysisFlowColumnRepository;
+    @Mock private AiTaggingJobRepository aiTaggingJobRepository;
+    @Mock private MessageRepository messageRepository;
+    @Mock private SourceDataWarningRepository sourceDataWarningRepository;
+    @Mock private DataSourceColumnRepository dataSourceColumnRepository;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -67,7 +88,16 @@ class DataSourceServiceTest {
                 userLookupRepository,
                 storage,
                 csvParser,
-                objectMapper
+                objectMapper,
+                analysisFlowRepository,
+                analysisCriteriaRepository,
+                analysisResultRepository,
+                flowDataWarningRepository,
+                analysisFlowColumnRepository,
+                aiTaggingJobRepository,
+                messageRepository,
+                sourceDataWarningRepository,
+                dataSourceColumnRepository
         );
     }
 
@@ -164,6 +194,70 @@ class DataSourceServiceTest {
 
         verify(storage, never()).delete(anyString());
         verify(dataSourceRepository, never()).deleteAll(any());
+    }
+
+    @Test
+    @DisplayName("DataSource 단건 삭제 시 연결된 AnalysisFlow 와 하위 엔티티가 자식부터 cascade 삭제된 뒤 DataSource 본체가 삭제된다")
+    void deleteOne_withChildEntities_cascadesAndDeletesDataSource() {
+        User owner = User.builder().id(OWNER_ID).email("o@test.com")
+                .providerUserId("p-1").name("o").provider("GOOGLE").build();
+        DataSource mine = DataSource.builder().id(5L).user(owner).fileName("a.csv").fileSize(1L)
+                .storageKey("k1").schemaJson(objectMapper.createObjectNode())
+                .rowCount(0).columnCount(0).build();
+        when(dataSourceRepository.findById(5L)).thenReturn(Optional.of(mine));
+        when(analysisFlowRepository.findIdsByDataSourceIds(List.of(5L)))
+                .thenReturn(List.of(10L, 11L));
+        when(analysisCriteriaRepository.findIdsByAnalysisFlowIds(List.of(10L, 11L)))
+                .thenReturn(List.of(20L, 21L));
+
+        service.deleteOne(OWNER_ID, 5L);
+
+        InOrder order = inOrder(
+                analysisResultRepository,
+                flowDataWarningRepository,
+                analysisCriteriaRepository,
+                analysisFlowColumnRepository,
+                aiTaggingJobRepository,
+                messageRepository,
+                analysisFlowRepository,
+                sourceDataWarningRepository,
+                dataSourceColumnRepository,
+                storage,
+                dataSourceRepository
+        );
+        order.verify(analysisResultRepository).deleteAllByAnalysisCriteriaIds(List.of(20L, 21L));
+        order.verify(flowDataWarningRepository).deleteAllByAnalysisCriteriaIds(List.of(20L, 21L));
+        order.verify(analysisCriteriaRepository).deleteAllByAnalysisFlowIds(List.of(10L, 11L));
+        order.verify(analysisFlowColumnRepository).deleteAllByAnalysisFlowIds(List.of(10L, 11L));
+        order.verify(aiTaggingJobRepository).deleteAllByAnalysisFlowIds(List.of(10L, 11L));
+        order.verify(messageRepository).deleteAllByAnalysisFlowIds(List.of(10L, 11L));
+        order.verify(analysisFlowRepository).deleteAllByDataSourceIds(List.of(5L));
+        order.verify(sourceDataWarningRepository).deleteAllByDataSourceIds(List.of(5L));
+        order.verify(dataSourceColumnRepository).deleteAllByDataSourceIds(List.of(5L));
+        order.verify(storage).delete("k1");
+        order.verify(dataSourceRepository).delete(mine);
+    }
+
+    @Test
+    @DisplayName("연결된 AnalysisFlow 가 없는 DataSource 단건 삭제 시 flow 의존 cascade 는 건너뛰고 본체만 삭제된다")
+    void deleteOne_withoutChildEntities_skipsFlowCascadeAndDeletesDataSource() {
+        User owner = User.builder().id(OWNER_ID).email("o@test.com")
+                .providerUserId("p-1").name("o").provider("GOOGLE").build();
+        DataSource mine = DataSource.builder().id(7L).user(owner).fileName("a.csv").fileSize(1L)
+                .storageKey("k2").schemaJson(objectMapper.createObjectNode())
+                .rowCount(0).columnCount(0).build();
+        when(dataSourceRepository.findById(7L)).thenReturn(Optional.of(mine));
+        when(analysisFlowRepository.findIdsByDataSourceIds(List.of(7L))).thenReturn(List.of());
+
+        service.deleteOne(OWNER_ID, 7L);
+
+        verify(analysisCriteriaRepository, never()).findIdsByAnalysisFlowIds(anyCollection());
+        verify(analysisResultRepository, never()).deleteAllByAnalysisCriteriaIds(anyCollection());
+        verify(analysisFlowRepository, never()).deleteAllByDataSourceIds(anyCollection());
+        verify(sourceDataWarningRepository).deleteAllByDataSourceIds(List.of(7L));
+        verify(dataSourceColumnRepository).deleteAllByDataSourceIds(List.of(7L));
+        verify(storage).delete("k2");
+        verify(dataSourceRepository).delete(mine);
     }
 
     @Test


### PR DESCRIPTION
## 요약
- `DELETE /api/datasources/{id}` 호출 시 연결된 AnalysisFlow 와 하위 엔티티까지 한꺼번에 삭제되도록 서비스 레이어 explicit cascade 추가
- 사용 중인 DataSource 가 409 `DATASOURCE_IN_USE` 로 거절되던 동작을 정상 200 / 204 로 통과시킴

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `cd apps/be && ./gradlew test --tests "com.capstone.logue.data.service.DataSourceServiceTest"` 그린 (신규 cascade 검증 2건 포함)
  - `./gradlew test` 전체 결과는 dev 와 동일 (사전 실패 3건은 #292 로 별도 트래킹)

## 스크린샷/로그 (선택)
삭제 순서 (FK 위반 회피용 자식 우선):
1. AnalysisResult, FlowDataWarning (AnalysisCriteria 의 자식)
2. AnalysisCriteria, AnalysisFlowColumn, AiTaggingJob, Message (AnalysisFlow 의 자식)
3. AnalysisFlow (DataSource 의 자식)
4. SourceDataWarning, DataSourceColumn (DataSource 의 자식)
5. DataSource 본체

서비스 로직은 `cascadeDeleteByDataSourceIds(Collection<Long>)` 단일 헬퍼로 응집했고 `deleteOne` / `deleteMany` 양쪽이 동일 헬퍼를 호출합니다. 각 자식 리포지토리에는 `@Modifying @Query("DELETE FROM ... WHERE ... IN :ids")` 형태의 bulk JPQL 을 추가했습니다.

## 롤백/리스크
- 리스크 포인트:
  - 자식 데이터 동시 삭제로 인한 회복 불가성 (의도된 변경). 분석 기록·메시지·결과·태깅잡까지 함께 사라지므로 사용자 안내 (확인 다이얼로그) 가 FE 에서 별도로 들어가 있는지 확인 권장
  - bulk JPQL `clearAutomatically = true` 옵션이 1차 캐시를 비우므로, 동일 트랜잭션 내에서 이후 다른 자식 엔티티를 다시 로드하는 호출이 없는지 점검 완료
- 롤백 방법:
  - `git revert <merge-commit>` 으로 cascade 헬퍼 + 리포지토리 신규 메서드 + 테스트 일괄 원복

## 관련 이슈
Closes #288

후속:
- 사전 실패 단위 테스트 3건 (#292) — 본 PR 무관, 별도 처리
- `GlobalExceptionHandler.handleDataIntegrityViolation` 가 모든 DIVE 를 `DATASOURCE_IN_USE` 로 일률 매핑하는 부분은 본 PR 의 cascade 가 적용된 이후에는 도달 빈도가 크게 줄어드므로 후속 점검 권장 (이슈 #288 본문에도 노트)