### PR TITLE
test(be): dev 사전 실패 단위 테스트 3건 정리 (#292)

### DIFF
--- a/apps/be/src/test/java/com/capstone/logue/LogueApplicationTests.java
+++ b/apps/be/src/test/java/com/capstone/logue/LogueApplicationTests.java
@@ -1,8 +1,12 @@
 package com.capstone.logue;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
+// #294: 테스트 환경에 Postgres datasource 가 없어 컨텍스트 로딩이 실패한다.
+// Testcontainers 도입 후 @Disabled 제거 예정.
+@Disabled("#294 - 테스트 datasource 셋업 후 활성화")
 @SpringBootTest
 class LogueApplicationTests {
 

--- a/apps/be/src/test/java/com/capstone/logue/anal/service/AnalServiceTest.java
+++ b/apps/be/src/test/java/com/capstone/logue/anal/service/AnalServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -206,7 +207,9 @@ class AnalServiceTest {
         assertThat(response.analysisFlowId()).isEqualTo(ANALYSIS_FLOW_ID);
         assertThat(response.dataSourceId()).isEqualTo(DATASOURCE_ID);
         verify(analysisFlowRepository).save(any(AnalysisFlow.class));
-        verify(aiTaggingJobRepository).save(any(AiTaggingJob.class));
+        // AnalService.createAnalysisFlow 는 INSERT 직후 생성된 jobId 로 requestPayload 를
+        // 채워 한 번 더 save 하므로 총 2회 호출된다.
+        verify(aiTaggingJobRepository, times(2)).save(any(AiTaggingJob.class));
         verify(fileAnalysisAsyncService).analyzeFileAsync(eq(1L), eq(DATASOURCE_ID));
     }
 

--- a/apps/be/src/test/java/com/capstone/logue/user/controller/UserControllerTest.java
+++ b/apps/be/src/test/java/com/capstone/logue/user/controller/UserControllerTest.java
@@ -130,17 +130,17 @@ class UserControllerTest {
 
 
     /**
-     * 토큰 없이 요청 시 OAuth2 로그인 페이지로 리다이렉트(302)되는지 검증합니다.
+     * 토큰 없이 요청 시 401 Unauthorized 가 반환되는지 검증합니다.
      *
-     * <p>미인증 요청에 대해 Spring Security가 OAuth2 인증 흐름으로
-     * 리다이렉트하는 기본 동작을 검증합니다.</p>
+     * <p>{@code SecurityConfig.authenticationEntryPoint} 가 미인증 API 요청에 대해
+     * OAuth2 리다이렉트 대신 401 JSON 응답을 직접 작성하므로, 그 동작을 그대로 검증합니다.</p>
      */
     @Test
-    @DisplayName("토큰 없이 요청 시 OAuth2 로그인 페이지로 리다이렉트된다")
+    @DisplayName("토큰 없이 요청 시 401 Unauthorized 를 반환한다")
     @WithAnonymousUser
-    void getMyInfo_noToken_returns302() throws Exception {
+    void getMyInfo_noToken_returns401() throws Exception {
         mockMvc.perform(get("/api/user/me"))
-                .andExpect(status().is3xxRedirection());
+                .andExpect(status().isUnauthorized());
     }
 
 


### PR DESCRIPTION
## 요약
- dev 브랜치에서 `./gradlew test` 시 사전 실패하던 단위 테스트 3건을 의도된 운영 동작 기준으로 정렬

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `cd apps/be && ./gradlew test` → BUILD SUCCESSFUL

## 스크린샷/로그 (선택)
처리 내역:

1. `AnalServiceTest.createAnalysisFlow_success`
   - 프로덕션 `AnalService.createAnalysisFlow` 가 INSERT 직후 생성된 jobId 로 `requestPayload` 를 채워 한 번 더 save 하는 두 번째 호출이 의도된 동작
   - `verify(aiTaggingJobRepository).save(...)` 를 `times(2)` 로 갱신하고 의도 설명 주석 추가

2. `UserControllerTest.getMyInfo_noToken_returns302` → `getMyInfo_noToken_returns401`
   - `SecurityConfig.authenticationEntryPoint` 가 미인증 API 요청에 대해 OAuth2 리다이렉트 대신 401 JSON 응답을 직접 작성하므로 그 동작이 truth
   - 테스트 메서드명, DisplayName, 기대값을 `status().isUnauthorized()` 로 갱신

3. `LogueApplicationTests.contextLoads`
   - 원인: 테스트 환경에 Postgres datasource 미설정 → Hikari `Failed to determine a suitable driver class` → Flyway → JPA 초기화 실패 체인
   - 본 PR 에서는 클래스 레벨 `@Disabled("#294 ...")` 로 우회 처리 (메서드 레벨 `@Disabled` 는 `@SpringBootTest` 컨텍스트 로딩이 먼저 발생해 효과 없음)
   - 적정 fix (Testcontainers Postgres 권장) 는 #294 에서 처리

## 롤백/리스크
- 리스크 포인트:
  - `LogueApplicationTests` 가 SKIP 으로 처리되어 `@SpringBootTest` 전체 와이어업 smoke 가 잠시 비활성화. CI 에 다른 의존 단계가 있다면 점검 필요
  - 나머지 두 테스트는 기대값을 운영 동작에 맞춘 것이므로 거동 변경 없음
- 롤백 방법:
  - `git revert <merge-commit>` 로 3개 테스트 파일 일괄 원복

## 관련 이슈
Closes #292

후속:
- #294 — `LogueApplicationTests` 테스트 datasource 셋업 (Testcontainers 권장) 후 `@Disabled` 제거