### PR TITLE
fix(be): ConstraintViolationException 핸들러 추가 (#297)

### DIFF
--- a/apps/be/src/main/java/com/capstone/logue/global/exception/GlobalExceptionHandler.java
+++ b/apps/be/src/main/java/com/capstone/logue/global/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.capstone.logue.global.exception;
 import com.capstone.logue.global.discord.DiscordWebhookService;
 import com.capstone.logue.global.response.ApiResponse;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -46,6 +47,19 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiResponse<Void>> handleValidationException(MethodArgumentNotValidException e) {
         log.warn("[ValidationException] {}", e.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.INVALID_INPUT.getHttpStatus())
+                .body(ApiResponse.error(ErrorCode.INVALID_INPUT));
+    }
+
+    /**
+     * `@Validated` 가 적용된 컨트롤러에서 `@PathVariable` · `@RequestParam` 의
+     * 제약 어노테이션(`@Min` · `@NotNull` 등) 위반 시 발생합니다. 핸들러 없으면 500 으로
+     * 폴백되므로 RequestBody 검증 실패와 동일한 400 / `INVALID_INPUT` 으로 정렬합니다.
+     */
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiResponse<Void>> handleConstraintViolation(ConstraintViolationException e) {
+        log.warn("[ConstraintViolation] {}", e.getMessage());
         return ResponseEntity
                 .status(ErrorCode.INVALID_INPUT.getHttpStatus())
                 .body(ApiResponse.error(ErrorCode.INVALID_INPUT));

--- a/apps/be/src/test/java/com/capstone/logue/global/exception/GlobalExceptionHandlerTest.java
+++ b/apps/be/src/test/java/com/capstone/logue/global/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,37 @@
+package com.capstone.logue.global.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.capstone.logue.global.discord.DiscordWebhookService;
+import com.capstone.logue.global.response.ApiResponse;
+import jakarta.validation.ConstraintViolationException;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(MockitoExtension.class)
+class GlobalExceptionHandlerTest {
+
+    @Mock private DiscordWebhookService discordWebhookService;
+
+    @Test
+    @DisplayName("ConstraintViolationException 발생 시 400 INVALID_INPUT 응답을 반환한다")
+    void handleConstraintViolation_returns400InvalidInput() {
+        GlobalExceptionHandler handler = new GlobalExceptionHandler(discordWebhookService);
+        ConstraintViolationException exception =
+                new ConstraintViolationException("must be greater than or equal to 1", Set.of());
+
+        ResponseEntity<ApiResponse<Void>> response = handler.handleConstraintViolation(exception);
+
+        assertThat(response.getStatusCode()).isEqualTo(ErrorCode.INVALID_INPUT.getHttpStatus());
+        ApiResponse<Void> body = response.getBody();
+        assertThat(body).isNotNull();
+        assertThat(body.isSuccess()).isFalse();
+        assertThat(body.getCode()).isEqualTo(ErrorCode.INVALID_INPUT.getCode());
+        assertThat(body.getMessage()).isEqualTo(ErrorCode.INVALID_INPUT.getMessage());
+    }
+}


### PR DESCRIPTION
## 요약
- `@Validated` 컨트롤러의 `@PathVariable` / `@RequestParam` 제약 어노테이션 위반 시 발생하는 `ConstraintViolationException` 을 400 / `INVALID_INPUT` 으로 처리하도록 `GlobalExceptionHandler` 에 핸들러 추가
- 핸들러 부재 시 500 으로 폴백되던 잠재 회귀를 선제 차단

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `cd apps/be && ./gradlew test` → BUILD SUCCESSFUL
  - 신규 단위 테스트 `GlobalExceptionHandlerTest.handleConstraintViolation_returns400InvalidInput` 추가 (400 status, `INVALID_INPUT` code/message 검증)

## 스크린샷/로그 (선택)
처리 정책:
- `MethodArgumentNotValidException` (RequestBody 검증 실패) 과 동일하게 400 / `INVALID_INPUT` 매핑
- 로그 prefix `[ConstraintViolation]` 으로 디버깅 시 구분 가능하게 분리

## 롤백/리스크
- 리스크 포인트: 기존에 500 으로 폴백되던 케이스가 400 으로 변경. 현재 운영에서 해당 예외 발생 경로가 없어 사용자 영향 없음
- 롤백 방법: `git revert <merge-commit>` 으로 핸들러 + 테스트 일괄 원복

## 관련 이슈
Closes #297