### PR TITLE
fix: createAnalysisFlow 소유권 검증 누락

### DIFF
--- a/apps/be/src/main/java/com/capstone/logue/anal/controller/AnalController.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/controller/AnalController.java
@@ -70,14 +70,17 @@ public class AnalController {
     @Operation(summary = "AnalysisFlow 시작", description = "대화 내 새로운 분석 흐름을 생성합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "AnalysisFlow 생성 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "대화 또는 데이터 소스 소유자 불일치 (A002, D002)"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 파일을 찾을 수 없음 (D001)"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류 (C004)"),
     })
     @PostMapping("/conversations/{conversationId}/analysisFlows")
     public ResponseEntity<ApiResponse<CreateAnalysisFlowResponse>> createAnalysisFlow(
+            @CurrentUser UserPrincipal userPrincipal,
             @PathVariable Long conversationId,
-            @RequestBody CreateAnalysisFlowRequest request) {
-        return ResponseEntity.ok(ApiResponse.success("Analysis Flow 생성 성공", analService.createAnalysisFlow(conversationId, request)));
+            @Valid @RequestBody CreateAnalysisFlowRequest request) {
+        return ResponseEntity.ok(ApiResponse.success("Analysis Flow 생성 성공",
+                analService.createAnalysisFlow(userPrincipal.userId(), conversationId, request)));
     }
 
     /**

--- a/apps/be/src/main/java/com/capstone/logue/anal/service/AnalService.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/service/AnalService.java
@@ -101,13 +101,19 @@ public class AnalService {
      * @throws LogueException 대화를 찾을 수 없는 경우(CV001), 데이터 소스를 찾을 수 없는 경우(D001)
      */
     public CreateAnalysisFlowResponse createAnalysisFlow(
-            Long conversationId, CreateAnalysisFlowRequest request) {
+            Long userId, Long conversationId, CreateAnalysisFlowRequest request) {
 
         Conversation conversation = conversationRepository.findById(conversationId)
                 .orElseThrow(() -> new LogueException(ErrorCode.CONVERSATION_NOT_FOUND));
+        if (!conversation.getUser().getId().equals(userId)) {
+            throw new LogueException(ErrorCode.FORBIDDEN);
+        }
 
         DataSource dataSource = dataSourceRepository.findById(request.dataSourceId())
                 .orElseThrow(() -> new LogueException(ErrorCode.DATASOURCE_NOT_FOUND));
+        if (!dataSource.getUser().getId().equals(userId)) {
+            throw new LogueException(ErrorCode.DATASOURCE_FORBIDDEN);
+        }
 
         AnalysisFlow analysisFlow = AnalysisFlow.builder()
                 .conversation(conversation)

--- a/apps/be/src/test/java/com/capstone/logue/anal/service/AnalServiceTest.java
+++ b/apps/be/src/test/java/com/capstone/logue/anal/service/AnalServiceTest.java
@@ -202,7 +202,7 @@ class AnalServiceTest {
 
         CreateAnalysisFlowRequest request = new CreateAnalysisFlowRequest(DATASOURCE_ID);
 
-        CreateAnalysisFlowResponse response = analService.createAnalysisFlow(CONVERSATION_ID, request);
+        CreateAnalysisFlowResponse response = analService.createAnalysisFlow(USER_ID, CONVERSATION_ID, request);
 
         assertThat(response.analysisFlowId()).isEqualTo(ANALYSIS_FLOW_ID);
         assertThat(response.dataSourceId()).isEqualTo(DATASOURCE_ID);
@@ -230,7 +230,7 @@ class AnalServiceTest {
 
         CreateAnalysisFlowRequest request = new CreateAnalysisFlowRequest(DATASOURCE_ID);
 
-        assertThatThrownBy(() -> analService.createAnalysisFlow(999L, request))
+        assertThatThrownBy(() -> analService.createAnalysisFlow(USER_ID, 999L, request))
                 .isInstanceOf(LogueException.class)
                 .extracting("errorCode").isEqualTo(ErrorCode.CONVERSATION_NOT_FOUND);
     }
@@ -261,8 +261,65 @@ class AnalServiceTest {
 
         CreateAnalysisFlowRequest request = new CreateAnalysisFlowRequest(999L);
 
-        assertThatThrownBy(() -> analService.createAnalysisFlow(CONVERSATION_ID, request))
+        assertThatThrownBy(() -> analService.createAnalysisFlow(USER_ID, CONVERSATION_ID, request))
                 .isInstanceOf(LogueException.class)
                 .extracting("errorCode").isEqualTo(ErrorCode.DATASOURCE_NOT_FOUND);
     }
+
+    /**
+     * 다른 사용자 소유의 conversation으로 AnalysisFlow 생성 시 {@link ErrorCode#FORBIDDEN} 예외가 발생하는지 검증한다.
+     */
+    @Test
+    @DisplayName("다른 사용자의 conversation으로 AnalysisFlow 생성 시 FORBIDDEN 예외가 발생한다")
+    void createAnalysisFlow_conversationForbidden_throwsException() {
+        Long otherUserId = 99L;
+        User otherUser = User.builder()
+                .id(otherUserId).email("other@test.com")
+                .providerUserId("p-2").name("다른사람").provider("GOOGLE")
+                .build();
+        Conversation conversation = Conversation.builder()
+                .id(CONVERSATION_ID).user(otherUser).title("새 대화")
+                .build();
+
+        when(conversationRepository.findById(CONVERSATION_ID)).thenReturn(Optional.of(conversation));
+
+        CreateAnalysisFlowRequest request = new CreateAnalysisFlowRequest(DATASOURCE_ID);
+
+        assertThatThrownBy(() -> analService.createAnalysisFlow(USER_ID, CONVERSATION_ID, request))
+                .isInstanceOf(LogueException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.FORBIDDEN);
+    }
+
+    /**
+     * 다른 사용자 소유의 dataSource로 AnalysisFlow 생성 시 {@link ErrorCode#DATASOURCE_FORBIDDEN} 예외가 발생하는지 검증한다.
+     */
+    @Test
+    @DisplayName("다른 사용자의 dataSource로 AnalysisFlow 생성 시 DATASOURCE_FORBIDDEN 예외가 발생한다")
+    void createAnalysisFlow_dataSourceForbidden_throwsException() {
+        Long otherUserId = 99L;
+        User owner = User.builder()
+                .id(USER_ID).email("test@test.com")
+                .providerUserId("p-1").name("테스트").provider("GOOGLE")
+                .build();
+        User otherUser = User.builder()
+                .id(otherUserId).email("other@test.com")
+                .providerUserId("p-2").name("다른사람").provider("GOOGLE")
+                .build();
+        Conversation conversation = Conversation.builder()
+                .id(CONVERSATION_ID).user(owner).title("새 대화")
+                .build();
+        DataSource otherDataSource = DataSource.builder()
+                .id(DATASOURCE_ID).user(otherUser).fileName("other.csv")
+                .build();
+
+        when(conversationRepository.findById(CONVERSATION_ID)).thenReturn(Optional.of(conversation));
+        when(dataSourceRepository.findById(DATASOURCE_ID)).thenReturn(Optional.of(otherDataSource));
+
+        CreateAnalysisFlowRequest request = new CreateAnalysisFlowRequest(DATASOURCE_ID);
+
+        assertThatThrownBy(() -> analService.createAnalysisFlow(USER_ID, CONVERSATION_ID, request))
+                .isInstanceOf(LogueException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.DATASOURCE_FORBIDDEN);
+    }
+
 }


### PR DESCRIPTION
## 요약
- `POST /api/anal/conversations/{conversationId}/analysisFlows`에서 conversation 및 dataSource 소유권 검증이 누락되어 타인 리소스로 AnalysisFlow 생성 가능하던 보안 취약점 수정

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `AnalServiceTest` 실행
    - `createAnalysisFlow_conversationForbidden_throwsException` — 타인 conversation 시 FORBIDDEN 확인
    - `createAnalysisFlow_dataSourceForbidden_throwsException` — 타인 dataSource 시 DATASOURCE_FORBIDDEN 확인

## 스크린샷/로그 (선택)
- 해당 없

## 롤백/리스크
- 리스크 포인트: `createAnalysisFlow` 시그니첳에 `userId` 추가되어 하위 호출부 수정 필요 — `AnalController` 외 다른 곳에서 직접 호출 시 컴파일 에러
- 롤백 방법: `AnalController`, `AnalService` 변경분 revert

## 관련 이슈
Closes #298 
