### PR TITLE
fix(be): jakarta validation provider 추가 및 multipart media type 핸들러 (#310)

### DIFF
--- a/apps/be/build.gradle
+++ b/apps/be/build.gradle
@@ -32,6 +32,7 @@ dependencyManagement {
 dependencies {
 	//Web
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
 

--- a/apps/be/src/main/java/com/capstone/logue/global/exception/GlobalExceptionHandler.java
+++ b/apps/be/src/main/java/com/capstone/logue/global/exception/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestHeaderException;
@@ -86,6 +87,19 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MissingServletRequestPartException.class)
     public ResponseEntity<ApiResponse<Void>> handleMissingRequestPart(MissingServletRequestPartException e) {
         log.warn("[MissingRequestPart] {}", e.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.MISSING_REQUEST_PARAMETER.getHttpStatus())
+                .body(ApiResponse.error(ErrorCode.MISSING_REQUEST_PARAMETER));
+    }
+
+    /**
+     * multipart/form-data 가 아닌 Content-Type 으로 multipart 엔드포인트(예: 파일 업로드)
+     * 호출 시 발생합니다. `MissingServletRequestPartException` 과는 다른 예외이므로
+     * 별도 핸들러로 매핑하지 않으면 500 으로 폴백됩니다.
+     */
+    @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMediaTypeNotSupported(HttpMediaTypeNotSupportedException e) {
+        log.warn("[MediaTypeNotSupported] {}", e.getMessage());
         return ResponseEntity
                 .status(ErrorCode.MISSING_REQUEST_PARAMETER.getHttpStatus())
                 .body(ApiResponse.error(ErrorCode.MISSING_REQUEST_PARAMETER));


### PR DESCRIPTION
## 요약
- `spring-boot-starter-validation` 의존성을 추가해 그동안 무력화 상태였던 `@Valid` / `@NotNull` 등 Bean Validation 어노테이션 실제 동작 복원
- `HttpMediaTypeNotSupportedException` 핸들러 추가로 잘못된 Content-Type 으로 multipart 엔드포인트 호출 시 500 폴백 차단 → 400 `MISSING_REQUEST_PARAMETER`

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `cd apps/be && ./gradlew test` → BUILD SUCCESSFUL
  - 운영 부팅 후 다음 두 케이스 검증 권장
    - `POST /api/anal/conversations/{id}/analysisFlows` 빈 body → 400 (이전 500)
    - `POST /api/datasources` 파일 없이 호출 → 400 (이전 500)

## 스크린샷/로그 (선택)
운영 부팅 로그에서 다음 경고가 발생하던 상태였습니다.

```
o.s.v.b.OptionalValidatorFactoryBean : Failed to set up a Bean Validation provider:
jakarta.validation.NoProviderFoundException: Unable to create a Configuration,
because no Jakarta Bean Validation provider could be found.
Add a provider like Hibernate Validator (RI) to your classpath.
```

결과적으로 컨트롤러의 `@Valid @RequestBody` 와 DTO 필드의 `@NotNull` 등이 전부 런타임에서 무시되어, 정상이라면 400 으로 끊겨야 할 요청이 service 까지 도달해 `findById(null)` → 500 폴백.

본 PR 이 반영되면 `MethodArgumentNotValidException` 가 정상 발생해 기존 핸들러(`handleValidationException`) 가 400 `INVALID_INPUT` 로 매핑합니다.

## 롤백/리스크
- 리스크 포인트:
  - 그동안 검증이 무력화되어 통과하던 입력들이 400 으로 거절되기 시작. 정상 동작이지만 클라이언트 측 요청이 잘못된 케이스가 있었다면 가시화됨
- 롤백 방법:
  - `git revert <merge-commit>` 으로 build.gradle 의존성 + 핸들러 일괄 원복

## 관련 이슈
Closes #310