### PR TITLE
fix(be): FastAPI 응답 unknown 필드 무시 설정으로 에러 envelope status 분기 복구

### DIFF
--- a/apps/be/src/main/java/com/capstone/logue/global/config/AppConfig.java
+++ b/apps/be/src/main/java/com/capstone/logue/global/config/AppConfig.java
@@ -1,5 +1,6 @@
 package com.capstone.logue.global.config;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import org.springframework.boot.web.client.RestTemplateBuilder;
@@ -32,12 +33,16 @@ public class AppConfig {
      *   <li>4xx/5xx 응답을 throw 하지 않고 {@code ResponseEntity} 로 그대로 반환한다.
      *       호출부({@code *AsyncService}) 가 status code 기반 분기 + retry 정책을 직접 제어하므로
      *       기본 {@code DefaultResponseErrorHandler} 가 throw 하면 inline 분기가 dead code 가 된다 (#278).</li>
+     *   <li>모르는 필드를 만나도 역직렬화에 실패하지 않는다. FastAPI 에러 응답은 성공 DTO 와
+     *       다른 envelope({@code error_code} 등)를 내려보내므로, 기본 {@code FAIL_ON_UNKNOWN_PROPERTIES}
+     *       가 켜져 있으면 body 파싱이 status code 분기보다 먼저 throw 되어 위 #278 분기가 무력화된다 (#316).</li>
      * </ul>
      */
     @Bean
     public RestTemplate fastApiRestTemplate(RestTemplateBuilder builder) {
         ObjectMapper snakeCaseMapper = new ObjectMapper()
-                .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+                .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
         RestTemplate restTemplate = builder
                 .messageConverters(new MappingJackson2HttpMessageConverter(snakeCaseMapper))


### PR DESCRIPTION
## 요약
- FastAPI 에러 응답(error_code envelope)에서 Jackson 역직렬화가 status code 분기보다 먼저 throw 되던 문제를 해결

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

`fastApiRestTemplate` 은 NoOpResponseErrorHandler 로 4xx/5xx 를 throw 하지 않고 status code 로 분기하도록 설계(#278)돼 있으나,
`exchange(..., DTO.class)` 가 에러 envelope(`{request_id, error_code, message, details}`)까지 성공 DTO 로 역직렬화하려다
`UnrecognizedPropertyException` 으로 죽어 분기 로직이 dead code 가 됐습니다.
FastAPI 전용 ObjectMapper 에 `FAIL_ON_UNKNOWN_PROPERTIES=false` 를 설정해 body 파싱이 status 분기를 무력화하지 않도록 했습니다.

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `./gradlew compileJava` 통과
  - FastAPI 502(error_code) 응답 시 RestClientException 대신 5xx 재시도 분기로 진입함을 확인 필요(스테이징)

## 스크린샷/로그 (선택)
변경 전:
```
RestClientException: Error while extracting response ...
Caused by: UnrecognizedPropertyException: Unrecognized field "error_code"
  (4 known properties: "request_id", "column_roles", "data_status_summary", "warnings")
```

## 롤백/리스크
- 리스크 포인트: 성공 응답에서 알 수 없는 필드가 조용히 무시됨 (2xx 스키마 검증은 *AsyncService 의 후처리에서 별도 수행)
- 적용 범위는 fastApiRestTemplate 한정, 전역 ObjectMapper 에는 영향 없음
- 롤백 방법: 해당 커밋 revert

## 관련 이슈
Closes #316
