### PR TITLE
fix(be): 파일 분석 SUCCESS 시 analysis_flow_columns 백필 추가 (#321)

### DIFF
--- a/apps/be/src/main/java/com/capstone/logue/anal/service/JobStateService.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/service/JobStateService.java
@@ -140,6 +140,32 @@ public class JobStateService {
 
         dataSourceColumnRepository.saveAll(columns);
 
+        // 같은 플로우의 column → semantic_role 매핑을 analysis_flow_columns 로 영속화
+        // (질문 분석 단계에서 QuestionAnalysisRequestBuilder 가 이 매핑으로 catalog 보냄)
+        AnalysisFlow analysisFlow = job.getAnalysisFlow();
+        Map<String, DataSourceColumn> columnByName = columns.stream()
+                .collect(Collectors.toMap(DataSourceColumn::getColumnName, c -> c));
+        List<AnalysisFlowColumn> flowColumns = columnRoles.stream()
+                .map(role -> {
+                    DataSourceColumn col = columnByName.get(role.columnName());
+                    if (col == null) {
+                        throw new LogueException(ErrorCode.COLUMN_NOT_FOUND);
+                    }
+                    SemanticRoleType semanticRole;
+                    try {
+                        semanticRole = SemanticRoleType.valueOf(role.semanticRole());
+                    } catch (IllegalArgumentException e) {
+                        throw new LogueException(ErrorCode.COLUMN_NOT_FOUND);
+                    }
+                    return AnalysisFlowColumn.builder()
+                            .analysisFlow(analysisFlow)
+                            .dataSourceColumn(col)
+                            .semanticRole(semanticRole)
+                            .build();
+                })
+                .collect(Collectors.toList());
+        analysisFlowColumnRepository.saveAll(flowColumns);
+
         List<SourceDataWarning> warnings = responseWarnings.stream()
                 .map(w -> {
                     SourceWarningKey key = SourceWarningKey.valueOf(w.code());


### PR DESCRIPTION
## 요약
- 파일 분석 SUCCESS 경로가 `analysis_flow_columns` 를 채우지 않아 후속 질문 분석이 항상 UNSUPPORTED_QUESTION 으로 떨어지던 문제 수정
- `JobStateService.saveResultAndMarkSuccess` 에 column → semantic_role 매핑 저장 단계 추가

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `cd apps/be && ./gradlew test` → BUILD SUCCESSFUL
  - 운영 검증: CSV 업로드 직후 `select * from analysis_flow_columns where analysis_flow_id = <flow>;` 가 컬럼 수만큼 row 반환하는지, 그리고 RANKING / COMPARISON 정상 질문이 unsupported 가 아닌 정상 분류로 분기하는지 확인

## 스크린샷/로그 (선택)
원인 흐름:
- AI `/v1/llm/data-sources/analyze` → 200, `columnRoles[].semanticRole` 반환
- BE 가 `data_source_columns` 와 `source_data_warnings` 만 저장하고 `analysis_flow_columns` 는 생성 안 함
- `QuestionAnalysisRequestBuilder:90-95` 가 `analysisFlowColumnRepository.findByAnalysisFlowIdOrderByIdAsc(flow.getId())` 로 조회 → empty
- 모든 컬럼이 `DEFAULT_SEMANTIC_ROLE = DIMENSION` 으로 LLM 한테 가서 날짜 / measure 식별 실패 → UNSUPPORTED_QUESTION

본 PR 적용 후:
- `dataSourceColumnRepository.saveAll(columns)` 직후 같은 트랜잭션 안에서 `AnalysisFlowColumn` row 들을 saveAll
- `ColumnRoleInfo.semanticRole` 문자열은 `SemanticRoleType` enum 으로 변환, 알 수 없는 컬럼명·enum 값은 `COLUMN_NOT_FOUND (D006)` 로 502 매핑 (기존 컨벤션과 동일)

## 롤백/리스크
- 리스크 포인트:
  - 같은 파일 분석 호출에서 `AnalysisFlowColumn` row 가 새로 생기므로 트랜잭션이 약간 길어짐. 컬럼 수가 보통 한 자리 / 두 자리라 영향 미미
  - AI 가 모르는 `semanticRole` 문자열을 보내면 기존엔 silent fallback 이었지만 이제는 `COLUMN_NOT_FOUND` 로 끊김. 다만 enum 값 6종 (DATE_CRITERIA / MEASURE / DIMENSION / STATUS_CONDITION / FLAG / ID_CRITERIA) 외엔 AI 가 보낼 일이 없도록 prompt 가 강제하고 있어 운영 영향 없음
- 롤백 방법:
  - `git revert <merge-commit>` 으로 `JobStateService` 변경분 일괄 원복

## 관련 이슈
Closes #321

후속:
- 이미 `analysis_flow_columns` 가 비어있는 기존 dataSource 들은 본 PR 머지만으로는 안 채워짐. 막힌 케이스만 SQL 로 backfill 하거나 (이미 catalog.sql 작성), 무시하고 새 업로드부터 적용해도 무방