### PR TITLE
fix(be): analysis_flow_columns 중복 INSERT 제거, result async 트랜잭션 race 해소 (#325)

### DIFF
--- a/apps/be/src/main/java/com/capstone/logue/anal/service/JobStateService.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/service/JobStateService.java
@@ -317,25 +317,9 @@ public class JobStateService {
 
         AnalysisCriteria savedCriteria = analysisCriteriaRepository.save(criteria);
 
-        List<FlowColumnInfo> flowColumns = response.flowColumns() == null ? List.of() : response.flowColumns();
-        if (!flowColumns.isEmpty()) {
-            Map<String, DataSourceColumn> columnByName = new HashMap<>();
-            for (DataSourceColumn col : dataSourceColumnRepository.findByDataSourceId(flow.getDataSource().getId())) {
-                columnByName.put(col.getColumnName(), col);
-            }
-            for (FlowColumnInfo fc : flowColumns) {
-                DataSourceColumn dsColumn = columnByName.get(fc.columnName());
-                if (dsColumn == null) {
-                    throw new LogueException(ErrorCode.COLUMN_NOT_FOUND);
-                }
-                AnalysisFlowColumn afc = AnalysisFlowColumn.builder()
-                        .analysisFlow(flow)
-                        .dataSourceColumn(dsColumn)
-                        .semanticRole(SemanticRoleType.valueOf(fc.semanticRole()))
-                        .build();
-                analysisFlowColumnRepository.save(afc);
-            }
-        }
+        // analysis_flow_columns 의 base 매핑은 파일 분석 SUCCESS 시점에 이미 영속화되므로
+        // 질문 분석 응답의 flowColumns 는 동일 row 를 중복 INSERT 만 유발해 무시한다.
+        // (FlowColumnInfo 는 "이 질문에 사용된 컬럼 subset" 의미라 base 매핑을 덮어쓰면 안 됨)
 
         List<FlowWarningInfo> warnings = response.warnings() == null ? List.of() : response.warnings();
         for (FlowWarningInfo w : warnings) {

--- a/apps/be/src/main/java/com/capstone/logue/anal/service/QuestionCriteriaService.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/service/QuestionCriteriaService.java
@@ -32,6 +32,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
@@ -224,7 +226,21 @@ public class QuestionCriteriaService {
                 .status(JobStatus.QUEUED)
                 .build();
         AiTaggingJob savedJob = aiTaggingJobRepository.save(resultJob);
-        analysisResultAsyncService.resolveResultAsync(savedJob.getId());
+
+        // outer 트랜잭션 commit 전에 @Async 스레드가 findById 하면 INSERT 가 아직 안 보여
+        // JOB_NOT_FOUND 가 나므로, afterCommit 시점으로 미뤄 async 호출을 트리거한다.
+        // 트랜잭션 경계가 없는 호출 (단위 테스트 등) 에서는 즉시 호출로 폴백한다.
+        Long jobId = savedJob.getId();
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    analysisResultAsyncService.resolveResultAsync(jobId);
+                }
+            });
+        } else {
+            analysisResultAsyncService.resolveResultAsync(jobId);
+        }
     }
 
     /**


### PR DESCRIPTION
## 요약
- 질문 분석 SUCCESS 시점이 `analysis_flow_columns` 에 base 매핑을 또 INSERT 해 중복 row 가 쌓이던 문제 수정 (FE 요약 표 이상 표시의 직접 원인)
- 분석 기준 확정 직후 result 단계 `@Async` 가 outer 트랜잭션 commit 전에 `findById` 해 `JOB_NOT_FOUND (AN001)` 로 실패하던 race condition 해소

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `cd apps/be && ./gradlew test` → BUILD SUCCESSFUL
  - 운영 검증
    - 새 CSV 업로드 → 질문 분석 완료 직후 `select count(*) from analysis_flow_columns where analysis_flow_id = <flow>` 가 데이터 소스 컬럼 수와 동일한지
    - 분석 기준 확정 직후 result async 가 정상 진행 (`JOB_NOT_FOUND` 없음)

## 스크린샷/로그 (선택)
원인 1 — duplicate INSERT
- 파일 분석 SUCCESS: `JobStateService.saveResultAndMarkSuccess` (PR #322) 가 모든 컬럼 row 백필
- 질문 분석 SUCCESS: `JobStateService:321-338` 가 AI 응답의 `flowColumns` 를 다시 INSERT
- `FlowColumnInfo` 의 본래 의미는 "이 질문에 사용된 컬럼 subset" 이라 base 매핑을 또 영속화할 필요 없음 → 해당 블록 제거

원인 2 — async race
- `QuestionCriteriaService.confirmCriteria` 의 `@Transactional` 안에서 `aiTaggingJobRepository.save(resultJob)` 직후 `analysisResultAsyncService.resolveResultAsync(savedJob.getId())` 호출
- async 스레드가 outer 트랜잭션 commit 전에 동작 → `findById` 가 INSERT 미가시 → `JOB_NOT_FOUND`
- `TransactionSynchronizationManager.registerSynchronization` 의 `afterCommit` 으로 호출 시점 미룸
- 트랜잭션 경계가 없는 호출 (단위 테스트 등) 에서는 동일 호출이 즉시 실행되도록 `isSynchronizationActive()` 체크로 폴백

## 롤백/리스크
- 리스크 포인트:
  - 질문 분석 응답의 `flowColumns` 가 무시되므로, 만약 향후 LLM 이 base 매핑을 "조정" 하는 의미로 응답한다면 그 변경은 반영 안 됨. 현재 base 매핑(file analysis 결과) 이 source of truth 라는 전제와 일치
  - afterCommit 호출은 트랜잭션 정상 commit 후에만 실행되므로 롤백 시 result async 가 시작되지 않음 (의도된 동작)
- 롤백 방법:
  - `git revert <merge-commit>` 으로 두 파일 변경분 일괄 원복

## 관련 이슈
Closes #325