### PR TITLE
fix(be): result async LazyInitializationException 방지로 dataSource 재조회 (#325 follow-up)

### DIFF
--- a/apps/be/src/main/java/com/capstone/logue/anal/service/JobStateService.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/service/JobStateService.java
@@ -361,7 +361,13 @@ public class JobStateService {
                 .findTopByAnalysisFlowIdOrderByCreatedAtDescIdDesc(flow.getId())
                 .orElseThrow(() -> new LogueException(ErrorCode.CRITERIA_NOT_FOUND));
 
-        return new ResultJobContext(criteria, flow.getDataSource());
+        // flow.getDataSource() 는 LAZY proxy 라 트랜잭션 종료 후 async 스레드에서 접근 시
+        // LazyInitializationException 이 난다. 분리된 id 로 재조회해 detached 가 아닌
+        // 완전 로딩된 엔티티를 컨텍스트에 담는다.
+        DataSource dataSource = dataSourceRepository.findById(flow.getDataSource().getId())
+                .orElseThrow(() -> new LogueException(ErrorCode.DATASOURCE_NOT_FOUND));
+
+        return new ResultJobContext(criteria, dataSource);
     }
 
     /**


### PR DESCRIPTION
## 요약
- PR #326 머지 후 운영 검증 중 발견된 후속 버그
- 분석 기준 확정 → result async 단계에서 `LazyInitializationException: Could not initialize proxy [DataSource#…]` 로 실패
- `flow.getDataSource()` 가 LAZY proxy 인데 outer 트랜잭션 종료 후 async 스레드가 `getStorageKey()` 호출 시 session 닫혀 fail
- `markResultRunningAndGetContext` 안에서 `dataSourceRepository.findById(...)` 로 명시 재조회해 완전 로딩된 엔티티를 컨텍스트에 담음

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `cd apps/be && ./gradlew test` → BUILD SUCCESSFUL
  - 운영 검증
    - CSV 업로드 → 질문 분석 → 분석 기준 확정 → result async 가 `LazyInitializationException` 없이 진행
    - `ResultAggregationService.aggregate` 가 정상 호출되어 차트 데이터 산출

## 스크린샷/로그 (선택)
운영 스택 트레이스 (PR #326 적용 직후):
```
ERROR ResultAggregationService: CSV 읽기 실패: dataSourceId=23
org.hibernate.LazyInitializationException: Could not initialize proxy [DataSource#23] - no session
  at DataSource$HibernateProxy.getStorageKey(Unknown Source)
  at ResultAggregationService.aggregate(ResultAggregationService.java:62)
  at AnalysisResultAsyncService.resolveResultAsync(AnalysisResultAsyncService.java:60)
```

PR #326 의 afterCommit 패턴으로 race condition 자체는 풀렸지만, async 가 detached 엔티티의 LAZY field 에 접근하는 path 가 새로 드러난 케이스입니다.

## 롤백/리스크
- 리스크 포인트:
  - `data_sources` 조회가 한 번 더 발생 (1 row, id 기반 PK 조회라 비용 무시 가능)
  - 해당 dataSource 가 삭제된 경우 `DATASOURCE_NOT_FOUND` 가 result async 에서 발생 — 기존 LazyInit 도 동일 시나리오에서 깨졌으므로 동작 변화 없음
- 롤백 방법:
  - `git revert <merge-commit>` 으로 `JobStateService` 변경분 원복

## 관련 이슈
Refs #325 (PR #326 follow-up)