### PR TITLE
fix(be): 데이터 상태 요약 응답을 semantic_role 별로 분류 (#330)

### DIFF
--- a/apps/be/src/main/java/com/capstone/logue/anal/service/AnalService.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/service/AnalService.java
@@ -9,6 +9,7 @@ import com.capstone.logue.auth.provider.SecurityContextProvider;
 import com.capstone.logue.global.entity.*;
 import com.capstone.logue.global.entity.enums.JobStage;
 import com.capstone.logue.global.entity.enums.JobStatus;
+import com.capstone.logue.global.entity.enums.SemanticRoleType;
 import com.capstone.logue.global.exception.ErrorCode;
 import com.capstone.logue.global.exception.LogueException;
 import com.capstone.logue.user.repository.UserRepository;
@@ -22,6 +23,7 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 
 /**
@@ -47,6 +49,7 @@ public class AnalService {
     private final AnalysisFlowRepository analysisFlowRepository;
     private final DataSourceRepository dataSourceRepository;
     private final DataSourceColumnRepository dataSourceColumnRepository;
+    private final AnalysisFlowColumnRepository analysisFlowColumnRepository;
     private final SourceDataWarningRepository sourceDataWarningRepository;
     private final AiTaggingJobRepository aiTaggingJobRepository;
     private final UserRepository userRepository;
@@ -190,30 +193,35 @@ public class AnalService {
 
         DataSource dataSource = analysisFlow.getDataSource();
 
-        List<DataSourceColumn> columns =
-                dataSourceColumnRepository.findByDataSourceId(dataSource.getId());
-
         List<SourceDataWarning> warnings =
                 sourceDataWarningRepository.findByDataSourceId(dataSource.getId());
 
-        List<String> columnNames = columns.stream()
-                .map(DataSourceColumn::getColumnName)
-                .toList();
+        // analysis_flow_columns 의 SemanticRoleType 별로 컬럼명을 분류
+        // (PR #322 이후 파일 분석 SUCCESS 시점에 매핑이 영속화되어 있음)
+        Map<SemanticRoleType, List<String>> namesByRole = analysisFlowColumnRepository
+                .findByAnalysisFlowIdOrderByIdAsc(analysisFlowId)
+                .stream()
+                .collect(Collectors.groupingBy(
+                        AnalysisFlowColumn::getSemanticRole,
+                        Collectors.mapping(
+                                afc -> afc.getDataSourceColumn().getColumnName(),
+                                Collectors.toList()
+                        )
+                ));
 
         String warningMessage = warnings.isEmpty()
                 ? null
                 : warnings.get(0).getComment(); // TODO: 경고 메시지가 여러 개일 경우 처리 정책 필요 (현재 첫 번째만 반환)
 
-        // TODO: ⚠️ 임시 매핑 (나중에 AI 결과 구조 반영 필요)
         return new GetSummaryResponse(
                 dataSource.getRowCount(),
                 dataSource.getColumnCount(),
-                columnNames,
-                List.of(),
-                List.of(),
-                List.of(),
-                List.of(),
-                List.of(),
+                namesByRole.getOrDefault(SemanticRoleType.DATE_CRITERIA, List.of()),
+                namesByRole.getOrDefault(SemanticRoleType.MEASURE, List.of()),
+                namesByRole.getOrDefault(SemanticRoleType.DIMENSION, List.of()),
+                namesByRole.getOrDefault(SemanticRoleType.STATUS_CONDITION, List.of()),
+                namesByRole.getOrDefault(SemanticRoleType.FLAG, List.of()),
+                namesByRole.getOrDefault(SemanticRoleType.ID_CRITERIA, List.of()),
                 warningMessage,
                 dataSource.getCreatedAt().toLocalDateTime()
         );

--- a/apps/be/src/test/java/com/capstone/logue/anal/service/AnalServiceTest.java
+++ b/apps/be/src/test/java/com/capstone/logue/anal/service/AnalServiceTest.java
@@ -68,6 +68,7 @@ class AnalServiceTest {
     @Mock private AnalysisFlowRepository analysisFlowRepository;
     @Mock private DataSourceRepository dataSourceRepository;
     @Mock private DataSourceColumnRepository dataSourceColumnRepository;
+    @Mock private AnalysisFlowColumnRepository analysisFlowColumnRepository;
     @Mock private SourceDataWarningRepository sourceDataWarningRepository;
     @Mock private AiTaggingJobRepository aiTaggingJobRepository;
     @Mock private UserRepository userRepository;
@@ -88,6 +89,7 @@ class AnalServiceTest {
                 analysisFlowRepository,
                 dataSourceRepository,
                 dataSourceColumnRepository,
+                analysisFlowColumnRepository,
                 sourceDataWarningRepository,
                 aiTaggingJobRepository,
                 userRepository,


### PR DESCRIPTION
## 요약
- `GET /api/anal/conversations/{cid}/analysisFlows/{flowId}/summary` 가 모든 컬럼을 `dataCriteria` 한 자리에 우겨넣고 나머지 카테고리 (`measure`/`dimension`/`statusCondition`/`flag`/`idCriteria`) 가 빈 배열로 내려가던 임시 매핑 제거
- `analysis_flow_columns` 의 `SemanticRoleType` 별로 grouping 해 응답 채우도록 수정

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `cd apps/be && ./gradlew test` → BUILD SUCCESSFUL
  - 운영 검증: 동일 CSV (logue_analysis_sample.csv) 업로드 후 summary 응답이 다음과 같이 분류되는지 확인
    - `dataCriteria`: `event_date`
    - `measure`: `landing_sessions`, `signup_complete`
    - `dimension`: `channel`, `device`, `region`
    - `statusCondition`: `user_status`
    - `flag`: `is_internal_test`
    - `idCriteria`: `user_id`

## 스크린샷/로그 (선택)
이전 응답:
```json
"dataCriteria": ["channel","device","event_date","is_internal_test","landing_sessions","region","signup_complete","user_id","user_status"],
"measure": [],
"dimension": [],
"statusCondition": [],
"flag": [],
"idCriteria": []
```

코드 변경 요약:
- `AnalService` 에 `AnalysisFlowColumnRepository` 의존성 주입
- `getSummary` 에서 `findByAnalysisFlowIdOrderByIdAsc` 로 매핑 로드 → `Collectors.groupingBy(SemanticRoleType, mapping(columnName))` 으로 분류
- `namesByRole.getOrDefault(role, List.of())` 로 6개 카테고리 채워 응답
- 기존 `// TODO: ⚠️ 임시 매핑` 주석 제거

## 롤백/리스크
- 리스크 포인트:
  - 의존 PR #322 (analysis_flow_columns 백필) 이전에 업로드된 dataSource 들은 매핑 row 가 없어 모든 카테고리 빈 배열로 응답. 사용자 영향은 "표가 비어있음" 이지만, 신규 업로드는 정상. 기존 케이스 백필이 필요하면 catalog.sql 사용
- 롤백 방법:
  - `git revert <merge-commit>` 으로 `AnalService` / `AnalServiceTest` 변경분 원복

## 관련 이슈
Closes #330