### PR TITLE
feat: 데이터 소스 삭제 API 계약 보강 (#333)

### DIFF
--- a/apps/fe/src/apis/datasource.test.ts
+++ b/apps/fe/src/apis/datasource.test.ts
@@ -1,0 +1,67 @@
+import type {
+  AxiosAdapter,
+  AxiosResponse,
+  InternalAxiosRequestConfig,
+} from 'axios';
+import { afterEach, describe, expect, it } from 'vitest';
+import instance from '../lib/axios';
+import { deleteDataSource, deleteDataSources } from './datasource';
+
+const originalAdapter = instance.defaults.adapter;
+
+function createSuccessResponse(
+  config: InternalAxiosRequestConfig,
+): AxiosResponse {
+  return {
+    config,
+    data: {
+      success: true,
+      data: {},
+    },
+    headers: {},
+    status: 200,
+    statusText: 'OK',
+  };
+}
+
+function installRequestRecorder() {
+  const requests: InternalAxiosRequestConfig[] = [];
+
+  const adapter: AxiosAdapter = async (config) => {
+    requests.push(config);
+
+    return createSuccessResponse(config);
+  };
+
+  instance.defaults.adapter = adapter;
+
+  return requests;
+}
+
+afterEach(() => {
+  instance.defaults.adapter = originalAdapter;
+});
+
+describe('data source delete APIs', () => {
+  it('calls the Swagger multi-delete endpoint with comma-separated ids', async () => {
+    const requests = installRequestRecorder();
+
+    await expect(deleteDataSources([1, 2, 3])).resolves.toBeUndefined();
+
+    expect(requests[0]).toMatchObject({
+      method: 'delete',
+      url: '/api/datasources?id=1,2,3',
+    });
+  });
+
+  it('calls the Swagger single-delete endpoint', async () => {
+    const requests = installRequestRecorder();
+
+    await expect(deleteDataSource(1)).resolves.toBeUndefined();
+
+    expect(requests[0]).toMatchObject({
+      method: 'delete',
+      url: '/api/datasources/1',
+    });
+  });
+});


### PR DESCRIPTION
## 요약
- Swagger 기준 datasource 단건/다건 DELETE API 호출 경로를 테스트로 고정했습니다.

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `yarn test -- src/apis/datasource.test.ts`
  - `yarn lint`

## 스크린샷/로그 (선택)
- 별도 첨부 없음

## 롤백/리스크
- 리스크 포인트: production 로직 변경 없이 테스트만 추가한 PR입니다.
- 롤백 방법: 이 PR revert

## 관련 이슈
Closes #333