### PR TITLE
chore: Codex 리뷰 및 리팩토링 스킬 2종 추가

### DIFF
--- a/apps/fe/.codex/skills/coderabbit-diff-review/SKILL.md
+++ b/apps/fe/.codex/skills/coderabbit-diff-review/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: coderabbit-diff-review
+description: CodeRabbit-style Git diff and PR review workflow for Codex. Use when the user asks Codex to review a branch, pull request, commit range, staged changes, working-tree diff, or patch in CodeRabbit-like format, especially with Korean findings-first output, severity labels, actionable file/line comments, or references to CodeRabbit review conventions. This skill does not call the real CodeRabbit service.
+---
+
+# CodeRabbit Diff Review
+
+## Review Target
+
+Resolve the diff before reviewing:
+
+1. Use the explicit target if the user provides a PR number, commit range, branch pair, patch, or file list.
+2. If no target is given in a Git repo, review `origin/dev...HEAD`.
+3. If that range is empty, check staged changes, then working-tree changes.
+4. If a PR target is available through GitHub tools, prefer PR patches and changed-file lists over reconstructing the diff manually.
+
+Read enough surrounding code to verify behavior, but keep findings anchored to changed lines or directly affected code.
+
+## Repository Context
+
+When `.coderabbit.yaml` exists, read it before reviewing and apply its review intent:
+
+- Respect `reviews.path_filters` when deciding which files to ignore.
+- Apply matching `reviews.path_instructions` as review priorities for affected paths.
+- Treat lockfiles, generated output, build artifacts, coverage, and vendored dependencies as out of scope unless the user explicitly asks.
+
+For this repo, default PR target is `dev`, and reviews should be written in Korean.
+
+## Finding Taxonomy
+
+Use CodeRabbit-style labels:
+
+- `⚠️ Potential issue`: bug, security problem, data-loss risk, broken contract, race, regression, or failing user flow.
+- `🛠️ Refactor suggestion`: maintainability, performance, consistency, or design improvement that is useful but not necessarily blocking.
+- `🧹 Nitpick`: tiny style, naming, wording, or formatting point. Include only when the user asks for nitpicks or the issue is unusually low-cost and helpful.
+
+Use severity labels:
+
+- `🔴 Critical`: likely outage, security breach, data corruption, or irreversible data loss.
+- `🟠 Major`: significant functional, correctness, performance, auth, migration, or compatibility problem.
+- `🟡 Minor`: real issue with limited blast radius or clear workaround.
+- `🔵 Trivial`: low-impact cleanup.
+- `⚪ Info`: context only; avoid as a finding unless it prevents confusion.
+
+## Review Standards
+
+- Lead with findings, ordered by severity and confidence.
+- Write every finding in Korean, while keeping the CodeRabbit label text in English.
+- Make findings actionable: include file/line, impact, and a concrete recommended fix direction.
+- Cite only issues supported by the diff or nearby code. Do not speculate from missing context.
+- Avoid restating what the patch changes unless it explains a risk.
+- Do not block on pure preference, broad rewrites, or unrelated pre-existing code.
+- Keep reviews high-signal. Prefer no finding over a weak finding.
+- If tests are missing for changed behavior, mention that as residual risk or a finding only when it materially affects confidence.
+
+## Output Format
+
+Use this Korean structure:
+
+```markdown
+**Findings**
+- [⚠️ Potential issue][🟠 Major] `path/to/file.ts:42` 짧은 제목
+  영향: 무엇이 깨지는지 또는 어떤 위험이 생기는지.
+  제안: 어떤 방향으로 고치면 되는지.
+
+**잔여 리스크 / 테스트**
+- 필요한 경우만 짧게 작성.
+```
+
+If there are no actionable findings:
+
+```markdown
+**Findings**
+Blocking finding 없음.
+
+**잔여 리스크 / 테스트**
+- 확인하지 못한 테스트나 남는 리스크가 있으면 한두 줄로만 작성.
+```
+
+When the user asks for an inline-review style response, emit tight `::code-comment{...}` directives for actionable comments and keep the summary brief.

--- a/apps/fe/.codex/skills/coderabbit-diff-review/agents/openai.yaml
+++ b/apps/fe/.codex/skills/coderabbit-diff-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "CodeRabbit Diff Review"
+  short_description: "CodeRabbit식 한국어 diff 리뷰 워크플로"
+  default_prompt: "Use $coderabbit-diff-review to review the current branch diff in Korean using CodeRabbit-style findings."

--- a/apps/fe/.codex/skills/fe-structural-refactor-backlog/SKILL.md
+++ b/apps/fe/.codex/skills/fe-structural-refactor-backlog/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: fe-structural-refactor-backlog
+description: apps/fe structural refactoring backlog scanner for Codex. Use when the user asks to scan the Logue frontend codebase for architecture-level or design-level refactoring opportunities, explicitly excluding PR diff review, line-level CodeRabbit findings, naming nits, tiny bugs, convention violations, and single-file cleanup. Output must be Korean and follow the strict numbered backlog format.
+---
+
+# FE Structural Refactor Backlog
+
+## 역할
+
+너는 `apps/fe` (Next.js 16 + React 19 + TypeScript) 코드베이스의 **구조적 리팩토링 백로그**를 뽑아내는 시니어 리뷰어다.
+
+## 절대 규칙
+
+- 이 레포는 CodeRabbit이 PR 단위 라인 리뷰를 **이미 수행 중**이다. 단순 라인 단위 지적, 변수명, 타입 좁히기, 작은 버그, 컨벤션 위반은 **CodeRabbit이 한다**. 너는 그걸 절대 다시 하지 않는다.
+- 이 스킬은 diff 리뷰가 아니다. 사용자가 명시적으로 diff를 보조 컨텍스트로 주지 않는 한, 현재 변경 라인 대신 `apps/fe` 코드베이스 구조를 스캔한다.
+- 너는 오직 **구조/설계 레벨**의 리팩토링 포인트만 뽑는다. 즉:
+  - 컴포넌트가 너무 커서 분리가 필요한 지점
+  - 비슷한 로직이 여러 파일에 흩어져 있는 중복
+  - 커스텀 훅으로 추출해야 할 패턴
+  - TanStack Query 키/캐시 일관성 -- **단일 PR/파일 수준의 queryKey 오타나 한 곳의 invalidate 누락은 CodeRabbit 담당이라 언급하지 마라.** 여러 파일에 걸친 키 네이밍 컨벤션 불일치나 캐시 무효화 전략 부재 같은 시스템 차원 문제만.
+  - Tailwind 클래스 중복 -- **한 컴포넌트 안의 클래스 정리는 CodeRabbit이 한다.** 너는 여러 컴포넌트에 반복되는 클래스 조합을 추출해 디자인 토큰화/컴포넌트화할 후보만 지적.
+  - 폴더 구조 응집도 (features vs components 경계, 도메인 분리)
+  - 관심사 분리 위반 (presentation vs container, 데이터 페칭이 잘못된 레이어에 박힌 케이스)
+- 최대 **5개 항목**까지만. 노이즈는 절대 금지. 4개여도 좋고 3개여도 좋다. **억지로 채우지 마라.**
+
+## 컨텍스트 수집
+
+- 사용자가 분석 대상을 좁히지 않으면 `apps/fe/src`를 기준으로 살핀다.
+- 반복 패턴, 과도하게 큰 컴포넌트, 폴더 간 결합, query key 관례, 반복되는 UI 클래스 조합을 검색한다.
+- 각 항목이 단일 파일 정리가 아니라 구조/설계 문제인지 확인할 만큼 주변 파일을 읽는다.
+- 사용자가 직접 컨텍스트를 붙이면 `# 다음은 분석 대상 컨텍스트다` 이후의 자료로 간주한다.
+
+## 출력 규칙
+
+- 응답에 서두 인사나 메타 설명을 절대 넣지 마라. 첫 줄이 곧 `## 1.` 으로 시작해야 한다.
+- 만약 뽑을 게 정말 없다면 `_(이번 스캔에선 구조적 리팩토링 포인트 없음)_` 한 줄만 출력하고 끝낸다.
+
+```markdown
+_(이번 스캔에선 구조적 리팩토링 포인트 없음)_
+```
+
+## 출력 포맷
+
+```markdown
+## 1. <한 줄 제목>
+- **위치**: `path/to/file.tsx`, `path/to/other.ts` (또는 디렉터리 단위)
+- **현상**: 지금 무엇이 문제인가 (구조적 관점에서)
+- **제안**: 어떻게 리팩토링할지 (구체적 단계 또는 패턴 이름)
+- **영향도**: low | mid | high
+- **추정 시간**: 30분 / 1시간 / 반나절 / 1일
+
+## 2. ...
+```

--- a/apps/fe/.codex/skills/fe-structural-refactor-backlog/agents/openai.yaml
+++ b/apps/fe/.codex/skills/fe-structural-refactor-backlog/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "FE Structural Refactor Backlog"
+  short_description: "apps/fe 구조적 리팩토링 백로그 스캔 워크플로"
+  default_prompt: "Use $fe-structural-refactor-backlog to scan apps/fe for structural refactoring backlog items."


### PR DESCRIPTION
## 요약
- CodeRabbit 리뷰 형식을 본뜬 Codex diff 리뷰 스킬을 추가했습니다.
- `apps/fe` 코드베이스를 diff 제외 구조/설계 레벨로 스캔하는 리팩토링 백로그 스킬을 추가했습니다.

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트
- [x] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `quick_validate.py apps/fe/.codex/skills/coderabbit-diff-review`
  - `quick_validate.py apps/fe/.codex/skills/fe-structural-refactor-backlog`
  - `agents/openai.yaml`의 `$coderabbit-diff-review` default prompt 확인
  - `agents/openai.yaml`의 `$fe-structural-refactor-backlog` default prompt 확인
  - 각 SKILL.md 출력 규칙 수동 점검

## 사용 예시
- `Use $coderabbit-diff-review to review the current branch diff.`
- `$coderabbit-diff-review 기준으로 현재 브랜치 diff 리뷰해줘.`
- `Use $fe-structural-refactor-backlog to scan apps/fe for structural refactoring backlog items.`
- `$fe-structural-refactor-backlog 기준으로 apps/fe 구조적 리팩토링 백로그 뽑아줘.`

## 스크린샷/로그 (선택)
- 해당 없음

## 롤백/리스크
- 리스크 포인트: 프로젝트 전용 Codex skill 추가라 런타임 코드에는 영향이 없습니다.
- 롤백 방법: 추가된 `apps/fe/.codex/skills/coderabbit-diff-review`, `apps/fe/.codex/skills/fe-structural-refactor-backlog` 폴더를 제거합니다.

## 관련 이슈
Closes #334
Closes #337