### PR TITLE
fix(ai): 분석 컬럼 null 비율 기반 CRITICAL_NULL_DETECTED 경고 추론 추가 (#343)

### DIFF
--- a/apps/ai/rules/warning_rules.py
+++ b/apps/ai/rules/warning_rules.py
@@ -12,7 +12,8 @@ from schemas.enums import FlowWarningKey
 
 
 # 분석에 사용된 컬럼의 null 비율이 이 값 이상이면 CRITICAL_NULL_DETECTED 추론.
-CRITICAL_NULL_RATIO_THRESHOLD = 0.5
+# 0.3 은 프롬프트/평가 기준과 동일한 임계값.
+CRITICAL_NULL_RATIO_THRESHOLD = 0.3
 
 
 def validate_warning_codes(

--- a/apps/ai/rules/warning_rules.py
+++ b/apps/ai/rules/warning_rules.py
@@ -4,9 +4,15 @@ from __future__ import annotations
 
 from core.errors import ErrorDetail
 from schemas.api.question_analysis import (
+    FlowWarning,
     QuestionAnalysisRequest,
     QuestionAnalysisResponse,
 )
+from schemas.enums import FlowWarningKey
+
+
+# 분석에 사용된 컬럼의 null 비율이 이 값 이상이면 CRITICAL_NULL_DETECTED 추론.
+CRITICAL_NULL_RATIO_THRESHOLD = 0.5
 
 
 def validate_warning_codes(
@@ -27,7 +33,66 @@ def validate_warning_codes(
     return issues
 
 
-# TODO: LLM 응답에 warning 이 없을 때 데이터 기반으로 warning 추론 추가:
-# - critical_null_detected: criteria.group_by 컬럼 중 null_ratio >= 임계값
-# - question_data_mismatch: 질문 vs data_source 컬럼 미스매치
-# 본 PR 는 LLM emit 한 코드 검증만, 추론은 LLM 연동 시 함께 도입.
+def infer_data_warnings(
+    response: QuestionAnalysisResponse,
+    request: QuestionAnalysisRequest,
+) -> list[FlowWarning]:
+    """데이터 기반으로 CRITICAL_NULL_DETECTED warning 을 추론한다.
+
+    analysis_criteria 가 참조하는 컬럼(base_date_column / group_by / filters[].field /
+    데이터 소스 컬럼과 매칭되는 formula_numerator·denominator) 중 null_ratio 가
+    임계값 이상인 컬럼이 있으면 단일 warning 을 반환한다.
+    catalog.flow_warning_keys 에 CRITICAL_NULL_DETECTED 가 정의돼 있지 않으면
+    추론하지 않는다 (catalog 미정의 코드는 emit 금지).
+    """
+    criteria = response.analysis_criteria
+    if criteria is None:
+        return []
+
+    catalog_codes = {w.code for w in request.catalog.flow_warning_keys}
+    if FlowWarningKey.CRITICAL_NULL_DETECTED not in catalog_codes:
+        return []
+
+    column_names = {c.column_name for c in request.data_source.columns}
+
+    referenced: list[str] = [criteria.base_date_column]
+    referenced.extend(criteria.group_by)
+    referenced.extend(f.field for f in criteria.filters)
+    for formula in (criteria.formula_numerator, criteria.formula_denominator):
+        if formula is not None and formula in column_names:
+            referenced.append(formula)
+
+    null_ratios = {c.column_name: c.null_ratio for c in request.data_source.columns}
+
+    offending: list[str] = []
+    for name in referenced:
+        ratio = null_ratios.get(name)
+        if ratio is not None and ratio >= CRITICAL_NULL_RATIO_THRESHOLD:
+            if name not in offending:
+                offending.append(name)
+
+    if not offending:
+        return []
+
+    return [
+        FlowWarning(
+            code=FlowWarningKey.CRITICAL_NULL_DETECTED,
+            related_fields=offending,
+            detail="분석 사용 컬럼의 null 비율이 임계값을 초과합니다.",
+        )
+    ]
+
+
+def apply_inferred_warnings(
+    response: QuestionAnalysisResponse,
+    request: QuestionAnalysisRequest,
+) -> None:
+    """추론된 warning 을 response.warnings 에 코드 기준 dedupe 하며 추가한다.
+
+    동일 code 가 이미 LLM 응답에 존재하면 기존 것을 유지하고 추가하지 않는다.
+    """
+    existing_codes = {w.code for w in response.warnings}
+    for warning in infer_data_warnings(response, request):
+        if warning.code not in existing_codes:
+            response.warnings.append(warning)
+            existing_codes.add(warning.code)

--- a/apps/ai/services/analysis_criteria_service.py
+++ b/apps/ai/services/analysis_criteria_service.py
@@ -17,6 +17,7 @@ import logging
 from config.settings import is_mock_mode
 from core.errors import AppError, ErrorDetail, LLMCallFailedError
 from rules.business_validation import validate as validate_business_rules
+from rules.warning_rules import apply_inferred_warnings
 from schemas.api.question_analysis import (
     QuestionAnalysisRequest,
     QuestionAnalysisResponse,
@@ -49,6 +50,9 @@ def resolve(req: QuestionAnalysisRequest) -> QuestionAnalysisResponse:
         ) from exc
 
     validate_business_rules(response, req)
+    # 검증 통과 후 데이터 기반 warning 을 추론한다. 추론 코드는 catalog 정의를
+    # 보장하므로 post-validation 단계에서 추가해도 참조 무결성을 깨지 않는다.
+    apply_inferred_warnings(response, req)
     return response
 
 

--- a/apps/ai/tests/test_warning_inference.py
+++ b/apps/ai/tests/test_warning_inference.py
@@ -1,0 +1,156 @@
+"""warning_rules.infer_data_warnings / apply_inferred_warnings 단위 테스트.
+
+데이터 기반 CRITICAL_NULL_DETECTED 추론 로직만 컴팩트하게 검증한다.
+요청/응답 구성은 test_business_validation.py 스타일을 따른다.
+"""
+
+from __future__ import annotations
+
+from rules.warning_rules import (
+    CRITICAL_NULL_RATIO_THRESHOLD,
+    apply_inferred_warnings,
+    infer_data_warnings,
+)
+from schemas.api.question_analysis import (
+    AnalysisCriteria,
+    Catalog,
+    DataSource,
+    DataSourceColumn,
+    Filter,
+    FlowWarning,
+    FlowWarningKeyCatalog,
+    PredefinedMetric,
+    Question,
+    QuestionAnalysisRequest,
+    QuestionAnalysisResponse,
+)
+from schemas.enums import FlowWarningKey
+
+
+def _request(*, null_ratio: float = 0.0, with_null_key: bool = True) -> QuestionAnalysisRequest:
+    flow_warning_keys: list[FlowWarningKeyCatalog] = []
+    if with_null_key:
+        flow_warning_keys.append(
+            FlowWarningKeyCatalog(
+                code="CRITICAL_NULL_DETECTED", name="...", comment="...",
+            ),
+        )
+    return QuestionAnalysisRequest(
+        request_id="req_X",
+        conversation_id=1,
+        question=Question(content="?"),
+        data_source=DataSource(
+            id=1,
+            columns=[
+                DataSourceColumn(
+                    column_name="signed_at",
+                    data_type="datetime",
+                    semantic_role="DATE_CRITERIA",
+                    null_ratio=0.0,
+                    sample_values=[],
+                ),
+                DataSourceColumn(
+                    column_name="channel",
+                    data_type="string",
+                    semantic_role="DIMENSION",
+                    null_ratio=null_ratio,
+                    sample_values=[],
+                ),
+                DataSourceColumn(
+                    column_name="amount",
+                    data_type="double",
+                    semantic_role="MEASURE",
+                    null_ratio=null_ratio,
+                    sample_values=[],
+                ),
+            ],
+        ),
+        catalog=Catalog(
+            analysis_types=["COMPARISON", "RANKING"],
+            metric_types=["RATIO"],
+            predefined_metrics=[
+                PredefinedMetric(
+                    metric_name="cr", display_name="전환율", metric_type="RATIO",
+                    formula_numerator="amount", formula_denominator="b",
+                ),
+            ],
+            supported_periods=["this_week", "last_week"],
+            flow_warning_keys=flow_warning_keys,
+        ),
+    )
+
+
+def _criteria(**overrides) -> AnalysisCriteria:
+    base = dict(
+        analysis_type="COMPARISON", metric_name="cr", metric_type="RATIO",
+        formula_numerator="amount", formula_denominator="b",
+        base_date_column="signed_at",
+        standard_period="this_week", compare_period="last_week",
+        sort_by="delta", sort_direction="asc",
+        group_by=["channel"], limit_num=None, filters=[],
+    )
+    base.update(overrides)
+    return AnalysisCriteria(**base)
+
+
+def _response(criteria: AnalysisCriteria, warnings=None) -> QuestionAnalysisResponse:
+    return QuestionAnalysisResponse(
+        request_id="req_X",
+        analysis_criteria=criteria,
+        warnings=warnings or [],
+    )
+
+
+def test_group_by_high_null_infers_critical_null() -> None:
+    warnings = infer_data_warnings(
+        _response(_criteria()), _request(null_ratio=0.5),
+    )
+    assert len(warnings) == 1
+    assert warnings[0].code == FlowWarningKey.CRITICAL_NULL_DETECTED
+    assert "channel" in (warnings[0].related_fields or [])
+
+
+def test_all_columns_below_threshold_returns_empty() -> None:
+    below = CRITICAL_NULL_RATIO_THRESHOLD - 0.01
+    warnings = infer_data_warnings(
+        _response(_criteria()), _request(null_ratio=below),
+    )
+    assert warnings == []
+
+
+def test_catalog_without_critical_null_key_returns_empty() -> None:
+    warnings = infer_data_warnings(
+        _response(_criteria()), _request(null_ratio=0.9, with_null_key=False),
+    )
+    assert warnings == []
+
+
+def test_apply_dedupes_when_llm_already_emitted() -> None:
+    response = _response(
+        _criteria(),
+        warnings=[FlowWarning(code="CRITICAL_NULL_DETECTED", detail="llm")],
+    )
+    apply_inferred_warnings(response, _request(null_ratio=0.9))
+    null_warnings = [
+        w for w in response.warnings
+        if w.code == FlowWarningKey.CRITICAL_NULL_DETECTED
+    ]
+    assert len(null_warnings) == 1
+    assert null_warnings[0].detail == "llm"
+
+
+def test_formula_column_high_null_detected() -> None:
+    # group_by(channel) 은 낮고, formula_numerator(amount) 만 임계값 초과.
+    req = _request(null_ratio=0.0)
+    req.data_source.columns[2].null_ratio = 0.7  # amount
+    warnings = infer_data_warnings(_response(_criteria()), req)
+    assert len(warnings) == 1
+    assert "amount" in (warnings[0].related_fields or [])
+
+
+def test_apply_appends_when_no_existing_warning() -> None:
+    response = _response(_criteria())
+    apply_inferred_warnings(response, _request(null_ratio=0.8))
+    assert any(
+        w.code == FlowWarningKey.CRITICAL_NULL_DETECTED for w in response.warnings
+    )


### PR DESCRIPTION
## 요약
- 질문 분석에서 분석에 사용되는 컬럼의 null 비율이 임계값 이상이면 `CRITICAL_NULL_DETECTED` 경고를 데이터 기반으로 생성합니다.

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `cd apps/ai && uv run pytest tests/test_warning_inference.py tests/test_business_validation.py`
  - 전체 스위트 158 passed (회귀 없음)

## 스크린샷/로그 (선택)
- 해당 없음

## 롤백/리스크
- 리스크 포인트: 추론 경고는 비즈니스 검증 통과 이후에 추가되며, `catalog.flow_warning_keys` 에 `CRITICAL_NULL_DETECTED` 가 있을 때만 생성됩니다. 임계값 0.5 는 상수(`CRITICAL_NULL_RATIO_THRESHOLD`)로 분리했습니다.
- 롤백 방법: 본 커밋 revert

## 관련 이슈
Closes #343

> 참고: #344 와 동일하게 `analysis_criteria_service.resolve()` 를 수정합니다. 나중에 머지되는 쪽에서 순서를 `detect_unsupported` 단축 반환, `validate_business_rules`, `apply_inferred_warnings` 로 해소해 주세요.
