### PR TITLE
fix(ai): 카탈로그 미존재 지표·기간 질문을 unsupported 응답으로 분기 (#344)

### DIFF
--- a/apps/ai/rules/unsupported_backstop.py
+++ b/apps/ai/rules/unsupported_backstop.py
@@ -1,0 +1,62 @@
+"""답변 불가 질문 결정론적 backstop.
+
+LLM 이 카탈로그(metric_name / period / analysis_type) 밖의 식별자를 담은
+`analysis_criteria` 를 반환한 경우, 비즈니스 검증으로 502 를 던지는 대신
+`unsupported_question` 응답으로 전환하기 위한 멤버십 기반 사전 감지기.
+
+여기서는 "카탈로그 멤버십" 위반만 다룬다. metric_name 은 유효하지만
+formula/metric_type 가 어긋난 경우는 LLM 오류이며 기존 비즈니스 검증
+(`rules.business_validation`) 의 책임이므로 unsupported 로 취급하지 않는다.
+"""
+
+from __future__ import annotations
+
+from schemas.api.question_analysis import (
+    QuestionAnalysisRequest,
+    QuestionAnalysisResponse,
+    UnsupportedQuestion,
+)
+
+
+def detect_unsupported(
+    response: QuestionAnalysisResponse,
+    request: QuestionAnalysisRequest,
+) -> UnsupportedQuestion | None:
+    """카탈로그 밖 식별자로 인해 답변 불가능한 응답인지 결정론적으로 감지한다.
+
+    `analysis_criteria` 가 없으면(이미 unsupported 등) 판단 대상이 아니므로 None.
+    멤버십 위반이 하나라도 있으면 사유를 묶어 `UnsupportedQuestion` 을 반환한다.
+    """
+    if response.analysis_criteria is None:
+        return None
+
+    c = response.analysis_criteria
+    catalog = request.catalog
+
+    metric_names = {m.metric_name for m in catalog.predefined_metrics}
+    periods = set(catalog.supported_periods)
+    analysis_types = set(catalog.analysis_types)
+
+    reasons: list[str] = []
+
+    if c.metric_name not in metric_names:
+        reasons.append(
+            f"metric_name '{c.metric_name}' 은 catalog.predefined_metrics 에 없습니다."
+        )
+    if c.standard_period not in periods:
+        reasons.append(
+            f"standard_period '{c.standard_period}' 은 catalog.supported_periods 에 없습니다."
+        )
+    if c.compare_period is not None and c.compare_period not in periods:
+        reasons.append(
+            f"compare_period '{c.compare_period}' 은 catalog.supported_periods 에 없습니다."
+        )
+    if c.analysis_type not in analysis_types:
+        reasons.append(
+            f"analysis_type '{c.analysis_type}' 은 catalog.analysis_types 에 없습니다."
+        )
+
+    if not reasons:
+        return None
+
+    return UnsupportedQuestion(reason="; ".join(reasons), detected_intent=None)

--- a/apps/ai/services/analysis_criteria_service.py
+++ b/apps/ai/services/analysis_criteria_service.py
@@ -17,6 +17,7 @@ import logging
 from config.settings import is_mock_mode
 from core.errors import AppError, ErrorDetail, LLMCallFailedError
 from rules.business_validation import validate as validate_business_rules
+from rules.unsupported_backstop import detect_unsupported
 from schemas.api.question_analysis import (
     QuestionAnalysisRequest,
     QuestionAnalysisResponse,
@@ -47,6 +48,18 @@ def resolve(req: QuestionAnalysisRequest) -> QuestionAnalysisResponse:
             request_id=req.request_id,
             details=[ErrorDetail(reason="업스트림 LLM 호출 중 오류가 발생했습니다.")],
         ) from exc
+
+    # 카탈로그 밖 식별자로 답변 불가한 응답은 비즈니스 검증(502) 대신
+    # unsupported_question 응답으로 결정론적 전환한다.
+    unsupported = detect_unsupported(response, req)
+    if unsupported is not None:
+        return QuestionAnalysisResponse(
+            request_id=req.request_id,
+            analysis_criteria=None,
+            flow_columns=[],
+            warnings=[],
+            unsupported_question=unsupported,
+        )
 
     validate_business_rules(response, req)
     return response

--- a/apps/ai/tests/test_analysis_criteria_resolve.py
+++ b/apps/ai/tests/test_analysis_criteria_resolve.py
@@ -114,10 +114,14 @@ def test_cross_field_violation_returns_422() -> None:
 # ---------- LLM 출력 검증 502 ----------
 
 
-def test_unknown_metric_name_returns_502_reference(
+def test_unknown_metric_name_returns_unsupported_question(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """LLM 이 카탈로그에 없는 metric_name 을 반환 → LLM_REFERENCE_VIOLATION."""
+    """LLM 이 카탈로그에 없는 metric_name 을 반환 → unsupported_question 으로 전환 (200).
+
+    카탈로그 멤버십 위반은 결정론적 backstop 이 답변 불가로 전환하므로
+    더 이상 502 LLM_REFERENCE_VIOLATION 으로 흘러가지 않는다.
+    """
 
     def fake_llm(req: QuestionAnalysisRequest) -> QuestionAnalysisResponse:
         return QuestionAnalysisResponse.model_validate({
@@ -138,12 +142,11 @@ def test_unknown_metric_name_returns_502_reference(
 
     response = client.post(ENDPOINT, json=_valid_request_payload())
 
-    assert response.status_code == 502
+    assert response.status_code == 200
     body = response.json()
-    assert body["error_code"] == "LLM_REFERENCE_VIOLATION"
-    assert any(
-        "metric_name" in (d.get("field") or "") for d in body["details"]
-    )
+    assert body["analysis_criteria"] is None
+    assert body["unsupported_question"] is not None
+    assert "ghost_metric" in body["unsupported_question"]["reason"]
 
 
 def test_mutual_exclusion_violation_returns_502_output_invalid(

--- a/apps/ai/tests/test_unsupported_backstop.py
+++ b/apps/ai/tests/test_unsupported_backstop.py
@@ -1,0 +1,161 @@
+"""rules.unsupported_backstop 단위 + resolve() 통합 테스트.
+
+카탈로그(metric_name / period / analysis_type) 밖 식별자를 담은 criteria 가
+502 비즈니스 위반 대신 unsupported_question 응답으로 전환되는지 검증.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rules.unsupported_backstop import detect_unsupported
+from schemas.api.question_analysis import (
+    AnalysisCriteria,
+    Catalog,
+    DataSource,
+    DataSourceColumn,
+    FlowWarningKeyCatalog,
+    PredefinedMetric,
+    Question,
+    QuestionAnalysisRequest,
+    QuestionAnalysisResponse,
+    UnsupportedQuestion,
+)
+from services import analysis_criteria_service as svc
+
+
+def _request() -> QuestionAnalysisRequest:
+    return QuestionAnalysisRequest(
+        request_id="req_X",
+        conversation_id=1,
+        question=Question(content="?"),
+        data_source=DataSource(
+            id=1,
+            columns=[
+                DataSourceColumn(
+                    column_name="signed_at",
+                    data_type="datetime",
+                    semantic_role="DATE_CRITERIA",
+                    null_ratio=0.0,
+                    sample_values=[],
+                ),
+                DataSourceColumn(
+                    column_name="channel",
+                    data_type="string",
+                    semantic_role="DIMENSION",
+                    null_ratio=0.0,
+                    sample_values=[],
+                ),
+            ],
+        ),
+        catalog=Catalog(
+            analysis_types=["COMPARISON", "RANKING"],
+            metric_types=["RATIO"],
+            predefined_metrics=[
+                PredefinedMetric(
+                    metric_name="cr", display_name="전환율", metric_type="RATIO",
+                    formula_numerator="a", formula_denominator="b",
+                ),
+            ],
+            supported_periods=["this_week", "last_week"],
+            flow_warning_keys=[
+                FlowWarningKeyCatalog(
+                    code="QUESTION_DATA_MISMATCH", name="...", comment="...",
+                ),
+            ],
+        ),
+    )
+
+
+def _criteria(**overrides) -> AnalysisCriteria:
+    base = dict(
+        analysis_type="COMPARISON", metric_name="cr", metric_type="RATIO",
+        formula_numerator="a", formula_denominator="b",
+        base_date_column="signed_at",
+        standard_period="this_week", compare_period="last_week",
+        sort_by="delta", sort_direction="asc",
+        group_by=["channel"], limit_num=None, filters=[],
+    )
+    base.update(overrides)
+    return AnalysisCriteria(**base)
+
+
+def _response(criteria: AnalysisCriteria) -> QuestionAnalysisResponse:
+    return QuestionAnalysisResponse(request_id="req_X", analysis_criteria=criteria)
+
+
+# ---------- detect_unsupported 단위 ----------
+
+
+def test_unknown_metric_name_returns_unsupported() -> None:
+    result = detect_unsupported(_response(_criteria(metric_name="ghost")), _request())
+    assert isinstance(result, UnsupportedQuestion)
+    assert "ghost" in result.reason
+    assert result.detected_intent is None
+
+
+def test_unknown_standard_period_returns_unsupported() -> None:
+    result = detect_unsupported(
+        _response(_criteria(standard_period="this_year")), _request(),
+    )
+    assert isinstance(result, UnsupportedQuestion)
+    assert "this_year" in result.reason
+
+
+def test_unknown_analysis_type_returns_unsupported() -> None:
+    req = _request()
+    req.catalog.analysis_types = ["RANKING"]
+    # RANKING 형태 제약을 만족시켜 criteria 생성 후 catalog 멤버십만 위반시킨다.
+    result = detect_unsupported(
+        _response(
+            _criteria(
+                analysis_type="COMPARISON",
+                compare_period="last_week",
+            )
+        ),
+        req,
+    )
+    assert isinstance(result, UnsupportedQuestion)
+    assert "COMPARISON" in result.reason
+
+
+def test_unknown_compare_period_returns_unsupported() -> None:
+    result = detect_unsupported(
+        _response(_criteria(compare_period="this_year")), _request(),
+    )
+    assert isinstance(result, UnsupportedQuestion)
+    assert "this_year" in result.reason
+
+
+def test_fully_valid_criteria_returns_none() -> None:
+    assert detect_unsupported(_response(_criteria()), _request()) is None
+
+
+def test_no_criteria_returns_none() -> None:
+    response = QuestionAnalysisResponse(
+        request_id="req_X",
+        unsupported_question=UnsupportedQuestion(reason="이미 unsupported"),
+    )
+    assert detect_unsupported(response, _request()) is None
+
+
+# ---------- resolve() 통합 ----------
+
+
+def test_resolve_out_of_catalog_metric_yields_unsupported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_call_llm 이 카탈로그 밖 metric_name 을 반환하면 resolve() 는
+    analysis_criteria 가 None 이고 unsupported_question 이 채워진 응답을 돌려준다."""
+
+    def fake_llm(req: QuestionAnalysisRequest) -> QuestionAnalysisResponse:
+        return _response(_criteria(metric_name="ghost_metric"))
+
+    monkeypatch.setattr(svc, "_call_llm", fake_llm)
+
+    result = svc.resolve(_request())
+
+    assert result.analysis_criteria is None
+    assert result.unsupported_question is not None
+    assert "ghost_metric" in result.unsupported_question.reason
+    assert result.request_id == "req_X"


### PR DESCRIPTION
## 요약
- 카탈로그에 없는 지표/기간/분석유형을 참조하는 LLM 분석 기준을 결과 단계로 보내지 않고 `unsupported_question` 응답으로 전환하는 결정적 백스톱을 추가합니다.

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `cd apps/ai && uv run pytest tests/test_unsupported_backstop.py tests/test_analysis_criteria_resolve.py tests/test_business_validation.py`
  - 전체 스위트 159 passed

## 스크린샷/로그 (선택)
- 해당 없음

## 롤백/리스크
- 리스크 포인트: 기존에 502 `LLM_REFERENCE_VIOLATION` 으로 응답하던 "카탈로그에 없는 metric_name" 경로가 이제 200 `unsupported_question` 으로 바뀝니다. BE 는 200 + `unsupported_question` 을 이미 `UNSUPPORTED_QUESTION` 으로 처리하므로 정합합니다 (#345 와 연동). 유효 지표인데 formula 만 틀린 경우는 그대로 검증 오류로 남습니다.
- 롤백 방법: 본 커밋 revert

## 관련 이슈
Closes #344

> 참고: #343 와 동일하게 `analysis_criteria_service.resolve()` 를 수정합니다. 머지 순서 충돌 시 `detect_unsupported` 단축 반환을 검증보다 앞에, 추론 경고 추가를 검증 뒤에 두도록 해소해 주세요.
