### PR TITLE
fix(be): 분석 기준 상태 응답에 실패 사유 코드 추가 (#345)

### DIFF
--- a/apps/be/src/main/java/com/capstone/logue/anal/dto/spring/response/GetQuestionCriteriaStatusResponse.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/dto/spring/response/GetQuestionCriteriaStatusResponse.java
@@ -4,8 +4,19 @@ package com.capstone.logue.anal.dto.spring.response;
  * 분석 기준 도출 작업 상태 응답 DTO입니다.
  *
  * <p>{@code status} 값: QUEUED / RUNNING / RETRYING / SUCCESS / FAILED / CANCELED</p>
+ *
+ * <p>{@code failureCode} 는 {@code status} 가 FAILED 일 때 실패 원인을 구분하기 위한
+ * 머신 리더블 코드입니다. 의도된 "지원하지 않는 질문" 실패와 일시적 실패를 클라이언트가
+ * 구분할 수 있게 합니다.</p>
+ *
+ * <ul>
+ *     <li>{@code UNSUPPORTED_QUESTION}: 지원하지 않는 질문으로 인한 의도된 실패</li>
+ *     <li>{@code ANALYSIS_FAILED}: 그 외 분석 실패(일시적 실패 포함)</li>
+ *     <li>{@code null}: FAILED 가 아닌 경우</li>
+ * </ul>
  */
 public record GetQuestionCriteriaStatusResponse(
-        String status
+        String status,
+        String failureCode
 ) {
 }

--- a/apps/be/src/main/java/com/capstone/logue/anal/service/QuestionCriteriaService.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/service/QuestionCriteriaService.java
@@ -301,7 +301,25 @@ public class QuestionCriteriaService {
                 .findTopByMessageIdAndStageOrderByCreatedAtDescIdDesc(messageId, JobStage.ANALYSIS_CRITERIA)
                 .orElseThrow(() -> new LogueException(ErrorCode.CRITERIA_NOT_FOUND));
 
-        return new GetQuestionCriteriaStatusResponse(job.getStatus().name());
+        // FAILED 인 경우에만 실패 원인 코드를 계산해 함께 내려준다. (그 외에는 null)
+        return new GetQuestionCriteriaStatusResponse(job.getStatus().name(), resolveFailureCode(job));
+    }
+
+    /**
+     * FAILED 작업의 실패 원인을 머신 리더블 코드로 변환합니다.
+     *
+     * <p>errorMessage 가 {@code UNSUPPORTED_QUESTION} 으로 시작하면 의도된 실패로 보고
+     * {@code UNSUPPORTED_QUESTION}, 그 외에는 {@code ANALYSIS_FAILED} 를 반환합니다.
+     * FAILED 가 아니면 {@code null} 을 반환합니다.</p>
+     */
+    private String resolveFailureCode(AiTaggingJob job) {
+        if (job.getStatus() != JobStatus.FAILED) {
+            return null;
+        }
+        String msg = job.getErrorMessage();
+        return (msg != null && msg.startsWith("UNSUPPORTED_QUESTION"))
+                ? "UNSUPPORTED_QUESTION"
+                : "ANALYSIS_FAILED";
     }
 
     /**

--- a/apps/be/src/test/java/com/capstone/logue/anal/service/QuestionCriteriaServiceTest.java
+++ b/apps/be/src/test/java/com/capstone/logue/anal/service/QuestionCriteriaServiceTest.java
@@ -442,7 +442,7 @@ class QuestionCriteriaServiceTest {
     }
 
     @Test
-    @DisplayName("getCriteriaStatus: Job 상태 문자열 반환")
+    @DisplayName("getCriteriaStatus: Job 상태 문자열 반환 (RUNNING 이면 failureCode 는 null)")
     void getCriteriaStatus_returnsStatus() {
         stubAccess();
         Message message = Message.builder().id(MESSAGE_ID).analysisFlow(flow).role(MessageRole.USER).content("Q?").build();
@@ -460,5 +460,74 @@ class QuestionCriteriaServiceTest {
                 CONVERSATION_ID, ANALYSIS_FLOW_ID, MESSAGE_ID);
 
         assertThat(response.status()).isEqualTo("RUNNING");
+        assertThat(response.failureCode()).isNull();
+    }
+
+    @Test
+    @DisplayName("getCriteriaStatus: SUCCESS Job 은 failureCode 가 null")
+    void getCriteriaStatus_successHasNullFailureCode() {
+        stubAccess();
+        Message message = Message.builder().id(MESSAGE_ID).analysisFlow(flow).role(MessageRole.USER).content("Q?").build();
+        when(messageRepository.findById(MESSAGE_ID)).thenReturn(Optional.of(message));
+
+        AiTaggingJob job = AiTaggingJob.builder()
+                .id(JOB_ID).conversation(conversation).analysisFlow(flow).message(message)
+                .stage(JobStage.ANALYSIS_CRITERIA).status(JobStatus.SUCCESS)
+                .build();
+        when(aiTaggingJobRepository.findTopByMessageIdAndStageOrderByCreatedAtDescIdDesc(
+                MESSAGE_ID, JobStage.ANALYSIS_CRITERIA))
+                .thenReturn(Optional.of(job));
+
+        GetQuestionCriteriaStatusResponse response = service.getCriteriaStatus(
+                CONVERSATION_ID, ANALYSIS_FLOW_ID, MESSAGE_ID);
+
+        assertThat(response.status()).isEqualTo("SUCCESS");
+        assertThat(response.failureCode()).isNull();
+    }
+
+    @Test
+    @DisplayName("getCriteriaStatus: FAILED + UNSUPPORTED_QUESTION 메시지면 failureCode 가 UNSUPPORTED_QUESTION")
+    void getCriteriaStatus_failedUnsupportedQuestion() {
+        stubAccess();
+        Message message = Message.builder().id(MESSAGE_ID).analysisFlow(flow).role(MessageRole.USER).content("Q?").build();
+        when(messageRepository.findById(MESSAGE_ID)).thenReturn(Optional.of(message));
+
+        AiTaggingJob job = AiTaggingJob.builder()
+                .id(JOB_ID).conversation(conversation).analysisFlow(flow).message(message)
+                .stage(JobStage.ANALYSIS_CRITERIA).status(JobStatus.QUEUED)
+                .build();
+        job.markFailed("UNSUPPORTED_QUESTION: 분석할 수 없는 질문입니다.");
+        when(aiTaggingJobRepository.findTopByMessageIdAndStageOrderByCreatedAtDescIdDesc(
+                MESSAGE_ID, JobStage.ANALYSIS_CRITERIA))
+                .thenReturn(Optional.of(job));
+
+        GetQuestionCriteriaStatusResponse response = service.getCriteriaStatus(
+                CONVERSATION_ID, ANALYSIS_FLOW_ID, MESSAGE_ID);
+
+        assertThat(response.status()).isEqualTo("FAILED");
+        assertThat(response.failureCode()).isEqualTo("UNSUPPORTED_QUESTION");
+    }
+
+    @Test
+    @DisplayName("getCriteriaStatus: FAILED + 일반 에러 메시지면 failureCode 가 ANALYSIS_FAILED")
+    void getCriteriaStatus_failedGenericError() {
+        stubAccess();
+        Message message = Message.builder().id(MESSAGE_ID).analysisFlow(flow).role(MessageRole.USER).content("Q?").build();
+        when(messageRepository.findById(MESSAGE_ID)).thenReturn(Optional.of(message));
+
+        AiTaggingJob job = AiTaggingJob.builder()
+                .id(JOB_ID).conversation(conversation).analysisFlow(flow).message(message)
+                .stage(JobStage.ANALYSIS_CRITERIA).status(JobStatus.QUEUED)
+                .build();
+        job.markFailed("FastAPI 호출 실패: connection reset");
+        when(aiTaggingJobRepository.findTopByMessageIdAndStageOrderByCreatedAtDescIdDesc(
+                MESSAGE_ID, JobStage.ANALYSIS_CRITERIA))
+                .thenReturn(Optional.of(job));
+
+        GetQuestionCriteriaStatusResponse response = service.getCriteriaStatus(
+                CONVERSATION_ID, ANALYSIS_FLOW_ID, MESSAGE_ID);
+
+        assertThat(response.status()).isEqualTo("FAILED");
+        assertThat(response.failureCode()).isEqualTo("ANALYSIS_FAILED");
     }
 }


### PR DESCRIPTION
## 요약
- 분석 기준 상태 응답에 `failureCode` 를 추가해, 지원 불가(`UNSUPPORTED_QUESTION`)와 일반 실패(`ANALYSIS_FAILED`)를 구분할 수 있게 합니다.

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `cd apps/be && ./gradlew test --tests "com.capstone.logue.anal.service.QuestionCriteriaServiceTest"` (15 passed)
  - `./gradlew compileJava compileTestJava` 성공

## 스크린샷/로그 (선택)
- 해당 없음

## 롤백/리스크
- 리스크 포인트: 상태 응답 record 에 nullable 필드를 추가하는 가산적 변경이라 응답 소비 측에 비파괴적입니다. `errorMessage` null 가드 처리. FE 의 사유 코드 메시지 매핑은 별도 작업입니다.
- 롤백 방법: 본 커밋 revert

## 관련 이슈
Closes #345
