### PR TITLE
fix(be): 차단성 경고 미해소 시 분석 기준 확정 차단 (#346)

### DIFF
--- a/apps/be/src/main/java/com/capstone/logue/anal/service/QuestionCriteriaService.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/service/QuestionCriteriaService.java
@@ -21,6 +21,7 @@ import com.capstone.logue.global.entity.AnalysisFlow;
 import com.capstone.logue.global.entity.Conversation;
 import com.capstone.logue.global.entity.FlowDataWarning;
 import com.capstone.logue.global.entity.Message;
+import com.capstone.logue.global.entity.enums.FlowWarningKey;
 import com.capstone.logue.global.entity.enums.JobStage;
 import com.capstone.logue.global.entity.enums.JobStatus;
 import com.capstone.logue.global.entity.enums.MessageRole;
@@ -62,6 +63,14 @@ public class QuestionCriteriaService {
     private final AnalysisResultAsyncService analysisResultAsyncService;
     private final FastApiClient fastApiClient;
     private final ObjectMapper objectMapper;
+
+    /**
+     * 확정(분석 결과 단계 진입)을 차단하는 경고 코드 집합입니다.
+     * 해당 경고가 해소되지 않은 채 확정 요청이 들어오면 확정을 막습니다.
+     * (현재는 질문·데이터 불일치만 차단성으로 취급하며, 핵심 null 감지는 확인용 soft 경고로 유지합니다.)
+     */
+    private static final Set<FlowWarningKey> BLOCKING_WARNINGS =
+            Set.of(FlowWarningKey.QUESTION_DATA_MISMATCH);
 
     private static final String MESSAGE_CRITERIA_READY =
             "질문 분석이 완료되었어요. 아래 분석 기준으로 검증을 진행해도 될까요?";
@@ -204,6 +213,20 @@ public class QuestionCriteriaService {
         }
 
         boolean wasConfirmed = Boolean.TRUE.equals(criteria.getIsConfirmed());
+
+        // 확정 전이(미확정 -> 확정) 시에만 차단성 경고를 검사한다.
+        // 해소되지 않은 차단성 경고가 남아 있으면 확정 및 결과 단계 진입을 막는다.
+        // (단순 수정은 통과시키며, 경고 해소 UX 는 후속 작업으로 처리한다.)
+        if (!wasConfirmed && request.confirmed()) {
+            List<FlowDataWarning> warnings = flowDataWarningRepository
+                    .findByAnalysisCriteriaId(criteria.getId());
+            boolean blocked = warnings.stream()
+                    .anyMatch(w -> BLOCKING_WARNINGS.contains(w.getCode()));
+            if (blocked) {
+                throw new LogueException(ErrorCode.CRITERIA_BLOCKED_BY_WARNING);
+            }
+        }
+
         applyUpdate(criteria, request);
         analysisCriteriaRepository.save(criteria);
 

--- a/apps/be/src/main/java/com/capstone/logue/global/exception/ErrorCode.java
+++ b/apps/be/src/main/java/com/capstone/logue/global/exception/ErrorCode.java
@@ -52,6 +52,7 @@ public enum ErrorCode {
     CRITERIA_ALREADY_CONFIRMED(HttpStatus.CONFLICT, "AN104", "이미 확정된 분석 기준입니다."),
     UNSUPPORTED_QUESTION(HttpStatus.BAD_REQUEST, "AN105", "이번 MVP에서 지원하지 않는 질문 유형입니다."),
     DATASOURCE_NOT_READY(HttpStatus.BAD_REQUEST, "AN106", "데이터 상태 요약이 완료되어야 질문을 분석할 수 있습니다."),
+    CRITERIA_BLOCKED_BY_WARNING(HttpStatus.BAD_REQUEST, "AN107", "차단성 경고가 해소되지 않아 분석 기준을 확정할 수 없습니다."),
 
     // Analysis Result
     RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "AN201", "분석 결과를 찾을 수 없습니다."),

--- a/apps/be/src/test/java/com/capstone/logue/anal/service/QuestionCriteriaServiceTest.java
+++ b/apps/be/src/test/java/com/capstone/logue/anal/service/QuestionCriteriaServiceTest.java
@@ -324,6 +324,8 @@ class QuestionCriteriaServiceTest {
         when(analysisCriteriaRepository.findTopByAnalysisFlowIdOrderByCreatedAtDescIdDesc(ANALYSIS_FLOW_ID))
                 .thenReturn(Optional.of(criteria));
         when(analysisCriteriaRepository.save(any(AnalysisCriteria.class))).thenReturn(criteria);
+        when(flowDataWarningRepository.findByAnalysisCriteriaId(CRITERIA_ID))
+                .thenReturn(List.of());
 
         AiTaggingJob resultJob = AiTaggingJob.builder()
                 .id(JOB_ID).conversation(conversation).analysisFlow(flow).message(message)
@@ -344,6 +346,83 @@ class QuestionCriteriaServiceTest {
         assertThat(criteria.getConfirmedAt()).isNotNull();
         verify(analysisCriteriaRepository).save(criteria);
         verify(analysisResultAsyncService).resolveResultAsync(JOB_ID);
+    }
+
+    @Test
+    @DisplayName("updateCriteria: confirmed=true 인데 차단성 경고(QUESTION_DATA_MISMATCH)가 있으면 CRITERIA_BLOCKED_BY_WARNING 이고 결과 비동기 미호출")
+    void updateCriteria_confirmBlockedByWarning() {
+        stubAccess();
+        Message message = Message.builder().id(MESSAGE_ID).analysisFlow(flow).role(MessageRole.USER).content("Q?").build();
+        when(messageRepository.findById(MESSAGE_ID)).thenReturn(Optional.of(message));
+
+        AnalysisCriteria criteria = AnalysisCriteria.builder()
+                .id(CRITERIA_ID).analysisFlow(flow)
+                .analysisType(AnalysisType.COMPARISON).metricName("conversion_rate")
+                .metricType(MetricType.RATIO)
+                .baseDateColumn("signed_at").standardPeriod("this_week").comparePeriod("last_week")
+                .sortBy("delta").sortDirection("asc")
+                .groupBy(objectMapper.valueToTree(List.of("channel")))
+                .isConfirmed(false)
+                .build();
+        when(analysisCriteriaRepository.findTopByAnalysisFlowIdOrderByCreatedAtDescIdDesc(ANALYSIS_FLOW_ID))
+                .thenReturn(Optional.of(criteria));
+
+        FlowDataWarning warning = FlowDataWarning.builder()
+                .id(1L).analysisCriteria(criteria)
+                .code(FlowWarningKey.QUESTION_DATA_MISMATCH)
+                .name(FlowWarningKey.QUESTION_DATA_MISMATCH.getName())
+                .comment(FlowWarningKey.QUESTION_DATA_MISMATCH.getComment())
+                .build();
+        when(flowDataWarningRepository.findByAnalysisCriteriaId(CRITERIA_ID))
+                .thenReturn(List.of(warning));
+
+        UpdateQuestionCriteriaRequest request = new UpdateQuestionCriteriaRequest(
+                "signed_at", "this_week", "last_week",
+                List.of("channel"),
+                "delta", "asc", null, List.of(), true);
+
+        assertThatThrownBy(() -> service.updateCriteria(
+                CONVERSATION_ID, ANALYSIS_FLOW_ID, MESSAGE_ID, request))
+                .isInstanceOf(LogueException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.CRITERIA_BLOCKED_BY_WARNING);
+
+        assertThat(criteria.getIsConfirmed()).isFalse();
+        verify(analysisCriteriaRepository, never()).save(any());
+        verify(analysisResultAsyncService, never()).resolveResultAsync(any());
+    }
+
+    @Test
+    @DisplayName("updateCriteria: confirmed=false(단순 수정) 면 차단성 경고가 있어도 통과")
+    void updateCriteria_pureEditWithWarningAllowed() {
+        stubAccess();
+        Message message = Message.builder().id(MESSAGE_ID).analysisFlow(flow).role(MessageRole.USER).content("Q?").build();
+        when(messageRepository.findById(MESSAGE_ID)).thenReturn(Optional.of(message));
+
+        AnalysisCriteria criteria = AnalysisCriteria.builder()
+                .id(CRITERIA_ID).analysisFlow(flow)
+                .analysisType(AnalysisType.COMPARISON).metricName("conversion_rate")
+                .metricType(MetricType.RATIO)
+                .baseDateColumn("signed_at").standardPeriod("this_week").comparePeriod("last_week")
+                .sortBy("delta").sortDirection("asc")
+                .groupBy(objectMapper.valueToTree(List.of("channel")))
+                .isConfirmed(false)
+                .build();
+        when(analysisCriteriaRepository.findTopByAnalysisFlowIdOrderByCreatedAtDescIdDesc(ANALYSIS_FLOW_ID))
+                .thenReturn(Optional.of(criteria));
+        when(analysisCriteriaRepository.save(any(AnalysisCriteria.class))).thenReturn(criteria);
+
+        UpdateQuestionCriteriaRequest request = new UpdateQuestionCriteriaRequest(
+                "signed_at", "this_week", "last_week",
+                List.of("channel", "device"),
+                "delta", "asc", null, List.of(), false);
+
+        UpdateQuestionCriteriaResponse response = service.updateCriteria(
+                CONVERSATION_ID, ANALYSIS_FLOW_ID, MESSAGE_ID, request);
+
+        assertThat(response.analysisCriteriaId()).isEqualTo(CRITERIA_ID);
+        assertThat(criteria.getIsConfirmed()).isFalse();
+        verify(analysisCriteriaRepository).save(criteria);
+        verify(analysisResultAsyncService, never()).resolveResultAsync(any());
     }
 
     @Test


### PR DESCRIPTION
## 요약
- 차단성 경고(`QUESTION_DATA_MISMATCH`)가 해소되지 않은 분석 기준의 확정을 막아, 결과 단계 진입을 차단합니다.

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `cd apps/be && ./gradlew test --tests "com.capstone.logue.anal.service.QuestionCriteriaServiceTest"` (14 passed)
  - `./gradlew compileJava compileTestJava` 성공

## 스크린샷/로그 (선택)
- 해당 없음

## 롤백/리스크
- 리스크 포인트: 신규 ErrorCode `CRITERIA_BLOCKED_BY_WARNING`(AN107). 확정 전이(미확정에서 확정)에서만 검사하고 단순 수정은 통과합니다. `CRITICAL_NULL_DETECTED` 는 soft 경고로 유지합니다. 차단 경고 집합과 해소(override) 플로우는 후속 작업으로 남겨, 리뷰에서 범위를 논의합니다.
- 롤백 방법: 본 커밋 revert

## 관련 이슈
Closes #346
