### PR TITLE
fix(ai): unsupported 백스톱에 formula 컬럼·DATE_CRITERIA 부재 감지 추가 (#353)

### DIFF
--- a/apps/ai/rules/unsupported_backstop.py
+++ b/apps/ai/rules/unsupported_backstop.py
@@ -16,6 +16,7 @@ from schemas.api.question_analysis import (
     QuestionAnalysisResponse,
     UnsupportedQuestion,
 )
+from schemas.enums import SemanticRoleType
 
 
 def detect_unsupported(
@@ -33,16 +34,28 @@ def detect_unsupported(
     c = response.analysis_criteria
     catalog = request.catalog
 
-    metric_names = {m.metric_name for m in catalog.predefined_metrics}
+    metrics_by_name = {m.metric_name: m for m in catalog.predefined_metrics}
     periods = set(catalog.supported_periods)
     analysis_types = set(catalog.analysis_types)
+    column_names = {col.column_name for col in request.data_source.columns}
 
     reasons: list[str] = []
 
-    if c.metric_name not in metric_names:
+    if c.metric_name not in metrics_by_name:
         reasons.append(
             f"metric_name '{c.metric_name}' 은 catalog.predefined_metrics 에 없습니다."
         )
+    else:
+        # 멤버십은 통과하지만 카탈로그 지표의 formula 컬럼이 data_source 에
+        # 존재하지 않으면 답변 불가. (criteria 가 아닌 카탈로그 지표의 formula 를
+        # 사용해 LLM 이 되돌려준 formula 를 신뢰하지 않는다.)
+        metric = metrics_by_name[c.metric_name]
+        for formula_column in (metric.formula_numerator, metric.formula_denominator):
+            if formula_column is not None and formula_column not in column_names:
+                reasons.append(
+                    f"metric '{c.metric_name}' 의 formula 컬럼 '{formula_column}' "
+                    "은 data_source.columns 에 없습니다."
+                )
     if c.standard_period not in periods:
         reasons.append(
             f"standard_period '{c.standard_period}' 은 catalog.supported_periods 에 없습니다."
@@ -54,6 +67,16 @@ def detect_unsupported(
     if c.analysis_type not in analysis_types:
         reasons.append(
             f"analysis_type '{c.analysis_type}' 은 catalog.analysis_types 에 없습니다."
+        )
+
+    has_date_criteria = any(
+        col.semantic_role == SemanticRoleType.DATE_CRITERIA
+        for col in request.data_source.columns
+    )
+    if not has_date_criteria:
+        reasons.append(
+            "data_source.columns 에 DATE_CRITERIA 컬럼이 없어 base_date_column 을 "
+            "정할 수 없습니다."
         )
 
     if not reasons:

--- a/apps/ai/tests/test_analysis_criteria_resolve.py
+++ b/apps/ai/tests/test_analysis_criteria_resolve.py
@@ -40,6 +40,16 @@ def _valid_request_payload() -> dict:
                     "semantic_role": "DIMENSION",
                     "null_ratio": 0.0, "sample_values": [],
                 },
+                {
+                    "column_name": "a", "data_type": "integer",
+                    "semantic_role": "MEASURE",
+                    "null_ratio": 0.0, "sample_values": [],
+                },
+                {
+                    "column_name": "b", "data_type": "integer",
+                    "semantic_role": "MEASURE",
+                    "null_ratio": 0.0, "sample_values": [],
+                },
             ],
         },
         "catalog": {

--- a/apps/ai/tests/test_unsupported_backstop.py
+++ b/apps/ai/tests/test_unsupported_backstop.py
@@ -46,6 +46,20 @@ def _request() -> QuestionAnalysisRequest:
                     null_ratio=0.0,
                     sample_values=[],
                 ),
+                DataSourceColumn(
+                    column_name="a",
+                    data_type="integer",
+                    semantic_role="MEASURE",
+                    null_ratio=0.0,
+                    sample_values=[],
+                ),
+                DataSourceColumn(
+                    column_name="b",
+                    data_type="integer",
+                    semantic_role="MEASURE",
+                    null_ratio=0.0,
+                    sample_values=[],
+                ),
             ],
         ),
         catalog=Catalog(
@@ -125,6 +139,27 @@ def test_unknown_compare_period_returns_unsupported() -> None:
     )
     assert isinstance(result, UnsupportedQuestion)
     assert "this_year" in result.reason
+
+
+def test_metric_formula_column_absent_returns_unsupported() -> None:
+    """metric_name 은 catalog 에 있으나 그 카탈로그 지표의 formula 컬럼이
+    data_source.columns 에 없으면 unsupported."""
+    req = _request()
+    req.catalog.predefined_metrics[0].formula_numerator = "ghost_col"
+    result = detect_unsupported(_response(_criteria()), req)
+    assert isinstance(result, UnsupportedQuestion)
+    assert "ghost_col" in result.reason
+
+
+def test_no_date_criteria_column_returns_unsupported() -> None:
+    """data_source 에 DATE_CRITERIA 컬럼이 하나도 없으면 unsupported."""
+    req = _request()
+    for col in req.data_source.columns:
+        if col.semantic_role == "DATE_CRITERIA":
+            col.semantic_role = "DIMENSION"
+    result = detect_unsupported(_response(_criteria()), req)
+    assert isinstance(result, UnsupportedQuestion)
+    assert "DATE_CRITERIA" in result.reason
 
 
 def test_fully_valid_criteria_returns_none() -> None:


### PR DESCRIPTION
## 요약
- unsupported 백스톱(#348)에 결정적 감지 두 가지를 추가합니다. 카탈로그에는 있으나 그 지표의 formula 컬럼이 데이터에 없는 경우, 그리고 DATE_CRITERIA 컬럼이 하나도 없는 경우를 unsupported 로 분기합니다.

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `cd apps/ai && uv run pytest` (전체 161 passed)

## 스크린샷/로그 (선택)
- 해당 없음

## 롤백/리스크
- 리스크 포인트: formula 컬럼 검사는 LLM 이 돌려준 formula 가 아니라 카탈로그 지표의 formula 를 기준으로 합니다. 멤버십을 통과한 경우에만 동작하므로 정상 요청에 false unsupported 가 나지 않습니다(테스트로 검증).
- 롤백 방법: 본 커밋 revert

## 관련 이슈
Closes #353

> 참고: 본 PR 은 #348(`fix/ai/#344-unsupported-backstop`) 위에 stacked 입니다. base 를 #344 브랜치로 잡았으며, #348 머지 후 자동으로 dev 로 retarget 됩니다.
