### PR TITLE
fix(ai): unsupported 백스톱 formula-컬럼 검사 제거 및 detected_intent 통제 어휘 적용 (#362)

### DIFF
--- a/apps/ai/rules/unsupported_backstop.py
+++ b/apps/ai/rules/unsupported_backstop.py
@@ -18,6 +18,19 @@ from schemas.api.question_analysis import (
 )
 from schemas.enums import SemanticRoleType
 
+# detected_intent 통제 어휘(controlled vocabulary). 프롬프트 PR 과 공유하며
+# 임의로 늘리지 않는다. backstop 이 결정론적으로 채우는 값은 아래 일부뿐이다.
+DETECTED_INTENT_CODES = (
+    "unknown_metric",
+    "unsupported_period",
+    "missing_formula_column",
+    "missing_date_criteria",
+    "mixed_intent",
+    "context_dependent",
+    "missing_metric_type",
+    "trend_request",
+)
+
 
 def detect_unsupported(
     response: QuestionAnalysisResponse,
@@ -37,37 +50,33 @@ def detect_unsupported(
     metrics_by_name = {m.metric_name: m for m in catalog.predefined_metrics}
     periods = set(catalog.supported_periods)
     analysis_types = set(catalog.analysis_types)
-    column_names = {col.column_name for col in request.data_source.columns}
 
     reasons: list[str] = []
+    # detected_intent 는 우선순위에 따라 첫 매칭 사유 1개만 채운다.
+    # (predefined-metric 의 formula 컬럼명은 카탈로그-전역 의미명이지 특정
+    # 데이터셋의 실제 컬럼명이 아니므로, formula 컬럼 존재 여부는 검사하지 않는다.)
+    detected_intent: str | None = None
 
     if c.metric_name not in metrics_by_name:
         reasons.append(
             f"metric_name '{c.metric_name}' 은 catalog.predefined_metrics 에 없습니다."
         )
-    else:
-        # 멤버십은 통과하지만 카탈로그 지표의 formula 컬럼이 data_source 에
-        # 존재하지 않으면 답변 불가. (criteria 가 아닌 카탈로그 지표의 formula 를
-        # 사용해 LLM 이 되돌려준 formula 를 신뢰하지 않는다.)
-        metric = metrics_by_name[c.metric_name]
-        for formula_column in (metric.formula_numerator, metric.formula_denominator):
-            if formula_column is not None and formula_column not in column_names:
-                reasons.append(
-                    f"metric '{c.metric_name}' 의 formula 컬럼 '{formula_column}' "
-                    "은 data_source.columns 에 없습니다."
-                )
+        detected_intent = detected_intent or "unknown_metric"
     if c.standard_period not in periods:
         reasons.append(
             f"standard_period '{c.standard_period}' 은 catalog.supported_periods 에 없습니다."
         )
+        detected_intent = detected_intent or "unsupported_period"
     if c.compare_period is not None and c.compare_period not in periods:
         reasons.append(
             f"compare_period '{c.compare_period}' 은 catalog.supported_periods 에 없습니다."
         )
+        detected_intent = detected_intent or "unsupported_period"
     if c.analysis_type not in analysis_types:
         reasons.append(
             f"analysis_type '{c.analysis_type}' 은 catalog.analysis_types 에 없습니다."
         )
+        # analysis_type 단독 위반은 통제 어휘에 대응되는 detected_intent 가 없다.
 
     has_date_criteria = any(
         col.semantic_role == SemanticRoleType.DATE_CRITERIA
@@ -78,8 +87,11 @@ def detect_unsupported(
             "data_source.columns 에 DATE_CRITERIA 컬럼이 없어 base_date_column 을 "
             "정할 수 없습니다."
         )
+        detected_intent = detected_intent or "missing_date_criteria"
 
     if not reasons:
         return None
 
-    return UnsupportedQuestion(reason="; ".join(reasons), detected_intent=None)
+    return UnsupportedQuestion(
+        reason="; ".join(reasons), detected_intent=detected_intent
+    )

--- a/apps/ai/tests/test_unsupported_backstop.py
+++ b/apps/ai/tests/test_unsupported_backstop.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import pytest
 
-from rules.unsupported_backstop import detect_unsupported
+from rules.unsupported_backstop import DETECTED_INTENT_CODES, detect_unsupported
 from schemas.api.question_analysis import (
     AnalysisCriteria,
     Catalog,
@@ -105,7 +105,7 @@ def test_unknown_metric_name_returns_unsupported() -> None:
     result = detect_unsupported(_response(_criteria(metric_name="ghost")), _request())
     assert isinstance(result, UnsupportedQuestion)
     assert "ghost" in result.reason
-    assert result.detected_intent is None
+    assert result.detected_intent == "unknown_metric"
 
 
 def test_unknown_standard_period_returns_unsupported() -> None:
@@ -114,6 +114,7 @@ def test_unknown_standard_period_returns_unsupported() -> None:
     )
     assert isinstance(result, UnsupportedQuestion)
     assert "this_year" in result.reason
+    assert result.detected_intent == "unsupported_period"
 
 
 def test_unknown_analysis_type_returns_unsupported() -> None:
@@ -141,14 +142,62 @@ def test_unknown_compare_period_returns_unsupported() -> None:
     assert "this_year" in result.reason
 
 
-def test_metric_formula_column_absent_returns_unsupported() -> None:
-    """metric_name 은 catalog 에 있으나 그 카탈로그 지표의 formula 컬럼이
-    data_source.columns 에 없으면 unsupported."""
-    req = _request()
-    req.catalog.predefined_metrics[0].formula_numerator = "ghost_col"
+def test_metric_formula_column_absent_returns_none() -> None:
+    """카탈로그 지표의 formula 컬럼은 카탈로그-전역 의미명이지 특정 데이터셋의
+    실제 컬럼명이 아니다. data_source.columns 에 그 의미명이 없더라도(컬럼명이
+    rename 된 데이터셋) 동일 지표를 계산할 수 있으므로 unsupported 가 아니다.
+
+    회귀 방지: formula = signup_complete/landing_sessions 인데 data_source 는
+    source/device_type/visits/signups + DATE_CRITERIA 만 가진 경우."""
+    req = QuestionAnalysisRequest(
+        request_id="req_X",
+        conversation_id=1,
+        question=Question(content="?"),
+        data_source=DataSource(
+            id=1,
+            columns=[
+                DataSourceColumn(
+                    column_name="signed_at", data_type="datetime",
+                    semantic_role="DATE_CRITERIA", null_ratio=0.0, sample_values=[],
+                ),
+                DataSourceColumn(
+                    column_name="source", data_type="string",
+                    semantic_role="DIMENSION", null_ratio=0.0, sample_values=[],
+                ),
+                DataSourceColumn(
+                    column_name="device_type", data_type="string",
+                    semantic_role="DIMENSION", null_ratio=0.0, sample_values=[],
+                ),
+                DataSourceColumn(
+                    column_name="visits", data_type="integer",
+                    semantic_role="MEASURE", null_ratio=0.0, sample_values=[],
+                ),
+                DataSourceColumn(
+                    column_name="signups", data_type="integer",
+                    semantic_role="MEASURE", null_ratio=0.0, sample_values=[],
+                ),
+            ],
+        ),
+        catalog=Catalog(
+            analysis_types=["COMPARISON", "RANKING"],
+            metric_types=["RATIO"],
+            predefined_metrics=[
+                PredefinedMetric(
+                    metric_name="cr", display_name="전환율", metric_type="RATIO",
+                    formula_numerator="signup_complete",
+                    formula_denominator="landing_sessions",
+                ),
+            ],
+            supported_periods=["this_week", "last_week"],
+            flow_warning_keys=[
+                FlowWarningKeyCatalog(
+                    code="QUESTION_DATA_MISMATCH", name="...", comment="...",
+                ),
+            ],
+        ),
+    )
     result = detect_unsupported(_response(_criteria()), req)
-    assert isinstance(result, UnsupportedQuestion)
-    assert "ghost_col" in result.reason
+    assert result is None
 
 
 def test_no_date_criteria_column_returns_unsupported() -> None:
@@ -160,6 +209,7 @@ def test_no_date_criteria_column_returns_unsupported() -> None:
     result = detect_unsupported(_response(_criteria()), req)
     assert isinstance(result, UnsupportedQuestion)
     assert "DATE_CRITERIA" in result.reason
+    assert result.detected_intent == "missing_date_criteria"
 
 
 def test_fully_valid_criteria_returns_none() -> None:
@@ -194,3 +244,20 @@ def test_resolve_out_of_catalog_metric_yields_unsupported(
     assert result.unsupported_question is not None
     assert "ghost_metric" in result.unsupported_question.reason
     assert result.request_id == "req_X"
+
+
+def test_detected_intent_codes_vocabulary_locked() -> None:
+    # 통제 어휘는 프롬프트(Shape B)와 공유되므로 drift 를 막는다.
+    assert set(DETECTED_INTENT_CODES) == {
+        "unknown_metric",
+        "unsupported_period",
+        "missing_formula_column",
+        "missing_date_criteria",
+        "mixed_intent",
+        "context_dependent",
+        "missing_metric_type",
+        "trend_request",
+    }
+    # 백스톱이 결정적으로 emit 하는 코드는 통제 어휘의 부분집합이어야 한다.
+    for code in ("unknown_metric", "unsupported_period", "missing_date_criteria"):
+        assert code in DETECTED_INTENT_CODES


### PR DESCRIPTION
## 요약
- unsupported 백스톱에서 "카탈로그 지표 formula 컬럼 부재" 검사를 제거합니다(컬럼명이 다른 데이터셋을 오판하던 회귀). 동시에 백스톱이 결정적으로 감지하는 경우 `detected_intent` 를 통제 어휘로 설정합니다.

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `cd apps/ai && uv run pytest tests/test_unsupported_backstop.py` (10 passed), 전체 168 passed
  - 리네임 컬럼 데이터셋이 unsupported 로 오판되지 않음을 잠그는 회귀 테스트 추가

## 스크린샷/로그 (선택)
- 실측에서 dataset-b 케이스(CMP-08·FLT-03·RNK-08)가 formula 검사로 전멸하던 것을 해소

## 롤백/리스크
- 리스크 포인트: formula 컬럼 존재 여부 판단은 컬럼 매핑이 일어나는 이후 단계 책임이라 본 레이어에서 제거합니다. DATE_CRITERIA 부재 검사와 카탈로그 멤버십 검사는 유지합니다. `detected_intent` 통제 어휘는 프롬프트(#363)와 동일한 8개 코드이며 drift 방지 테스트로 고정했습니다.
- 롤백 방법: 본 커밋 revert

## 관련 이슈
Closes #362
