### PR TITLE
fix(ai): 채점 hard-fail 에 compare_period 추가 (COMPARISON 한정) (#369)

### DIFF
--- a/apps/ai/eval/scoring.py
+++ b/apps/ai/eval/scoring.py
@@ -20,6 +20,8 @@ _HARD_FAIL_FIELDS: dict[str, list[str]] = {
         "analysis_criteria.analysis_type",
         "analysis_criteria.metric_name",
         "analysis_criteria.base_date_column",
+        # compare_period 는 COMPARISON 분석에서만 hard-fail (아래 _is_hard_fail 참고).
+        "analysis_criteria.compare_period",
     ],
     "file_analysis": [
         # 01 FA 케이스는 column_roles 가 핵심. expected.column_roles 가 dict 형태라 별도 처리.
@@ -209,9 +211,25 @@ def _field_match(expected: Any, actual: Any) -> bool:
     return expected == actual
 
 
+_COMPARE_PERIOD_PATH = "analysis_criteria.compare_period"
+
+
 def _is_hard_fail(suite: str, comparisons: list[FieldComparison]) -> bool:
     hard_paths = set(_HARD_FAIL_FIELDS.get(suite, []))
     if not hard_paths:
         return False
+    # compare_period 는 COMPARISON 분석에서만 hard-fail 이다. expected 의 analysis_type 이
+    # COMPARISON 이 아니면 hard 셋에서 제외한다 (RANKING expected 에 compare_period 비교가
+    # 생기더라도 오탐으로 케이스를 죽이지 않도록).
+    if _COMPARE_PERIOD_PATH in hard_paths and not _expected_is_comparison(comparisons):
+        hard_paths.discard(_COMPARE_PERIOD_PATH)
     failed_hard_paths = {c.path for c in comparisons if not c.match} & hard_paths
     return bool(failed_hard_paths)
+
+
+def _expected_is_comparison(comparisons: list[FieldComparison]) -> bool:
+    """expected 의 analysis_type 이 COMPARISON 인지 (없으면 False)."""
+    for c in comparisons:
+        if c.path == "analysis_criteria.analysis_type":
+            return c.expected == "COMPARISON"
+    return False

--- a/apps/ai/tests/test_eval_harness.py
+++ b/apps/ai/tests/test_eval_harness.py
@@ -136,6 +136,51 @@ def test_score_case_non_hard_fail_field_mismatch_fails_but_not_hard() -> None:
     assert score.hard_fail is False  # sort_direction 은 hard-fail 아님
 
 
+def test_score_case_hard_fail_on_compare_period_mismatch_for_comparison() -> None:
+    score = score_case(
+        case_id="CMP-X", suite="question_analysis",
+        expected={"analysis_criteria": {"analysis_type": "COMPARISON", "compare_period": "1W"}},
+        actual={"analysis_criteria": {"analysis_type": "COMPARISON", "compare_period": "1M"}},
+        error=None, latency_ms=100,
+    )
+    assert score.passed is False
+    assert score.hard_fail is True  # COMPARISON 의 compare_period 는 hard-fail
+
+
+def test_score_case_compare_period_mismatch_not_hard_for_ranking() -> None:
+    score = score_case(
+        case_id="RNK-X", suite="question_analysis",
+        expected={"analysis_criteria": {"analysis_type": "RANKING", "compare_period": None}},
+        actual={"analysis_criteria": {"analysis_type": "RANKING", "compare_period": "1W"}},
+        error=None, latency_ms=100,
+    )
+    assert score.passed is False
+    assert score.hard_fail is False  # RANKING 에서는 compare_period 가 hard-fail 아님
+
+
+def test_score_case_compare_period_match_for_comparison_passes() -> None:
+    score = score_case(
+        case_id="CMP-Y", suite="question_analysis",
+        expected={"analysis_criteria": {"analysis_type": "COMPARISON", "compare_period": "1W"}},
+        actual={"analysis_criteria": {"analysis_type": "COMPARISON", "compare_period": "1W"}},
+        error=None, latency_ms=100,
+    )
+    assert score.passed is True
+    assert score.hard_fail is False
+
+
+def test_score_case_compare_period_mismatch_without_analysis_type_not_hard() -> None:
+    # analysis_type 부재 시 COMPARISON 확신 불가 -> compare_period 를 hard-fail 로 안 본다(방어적 기본값).
+    score = score_case(
+        case_id="EDGE-1", suite="question_analysis",
+        expected={"analysis_criteria": {"compare_period": "1W", "metric_name": "cr"}},
+        actual={"analysis_criteria": {"compare_period": "1M", "metric_name": "cr"}},
+        error=None, latency_ms=100,
+    )
+    assert score.passed is False
+    assert score.hard_fail is False
+
+
 def test_score_case_error_marks_hard_fail() -> None:
     score = score_case(
         case_id="C1", suite="question_analysis",


### PR DESCRIPTION
## 관련 이슈
Closes #369

## 변경 사항
- `eval/scoring.py` `_HARD_FAIL_FIELDS['question_analysis']` 에 `analysis_criteria.compare_period` 추가.
- `_is_hard_fail` 이 expected `analysis_type == COMPARISON` 일 때만 compare_period 를 hard-fail 로 취급(헬퍼 `_expected_is_comparison`). analysis_type 부재 시 방어적으로 제외.
- file_analysis/result_summary 는 hard 셋에 compare_period 가 없어 영향 없음.

## 검증
- COMPARISON 불일치 hard-fail, RANKING 불일치 비-hard-fail, analysis_type 부재 방어 케이스 테스트 추가.
- 전체 pytest 통과.