### PR TITLE
fix(ai): UNS-03/04 듀얼브랜치 채점(502 LLM_REFERENCE_VIOLATION 허용) (#374)

### DIFF
--- a/apps/ai/eval/__main__.py
+++ b/apps/ai/eval/__main__.py
@@ -60,6 +60,8 @@ def main(argv: list[str] | None = None) -> int:
             actual=result.response,
             error=result.error,
             latency_ms=result.latency_ms,
+            error_code=result.error_code,
+            accept_error_codes=case.get("accept_error_codes"),
         )
         scores.append(score)
         status = "✅" if score.passed else ("🔥" if score.hard_fail else "❌")

--- a/apps/ai/eval/cases/question_analysis/uns/UNS-03.json
+++ b/apps/ai/eval/cases/question_analysis/uns/UNS-03.json
@@ -8,6 +8,7 @@
     "dataset": "dataset-a",
     "question": "최근 6개월 채널별 가입 전환율 top 5"
   },
+  "accept_error_codes": ["LLM_REFERENCE_VIOLATION"],
   "expected": {
     "analysis_criteria": null,
     "unsupported_question": {"detected_intent": "unsupported_period"}

--- a/apps/ai/eval/cases/question_analysis/uns/UNS-04.json
+++ b/apps/ai/eval/cases/question_analysis/uns/UNS-04.json
@@ -9,6 +9,7 @@
     "override_columns": {"signup_complete": {"remove": true}},
     "question": "이번 주 채널별 가입 전환율 top 5"
   },
+  "accept_error_codes": ["LLM_REFERENCE_VIOLATION"],
   "expected": {
     "analysis_criteria": null,
     "unsupported_question": {"detected_intent": "missing_formula_column"}

--- a/apps/ai/eval/runner.py
+++ b/apps/ai/eval/runner.py
@@ -11,6 +11,8 @@ import time
 from dataclasses import dataclass
 from typing import Any, Literal
 
+from core.errors import AppError
+
 
 SuiteName = Literal["question_analysis", "file_analysis", "result_summary"]
 
@@ -21,6 +23,7 @@ class RunResult:
     suite: SuiteName
     response: dict[str, Any] | None
     error: str | None
+    error_code: str | None
     latency_ms: int
 
 
@@ -35,11 +38,13 @@ def run_case(suite: SuiteName, case: dict[str, Any]) -> RunResult:
         payload = _resolve_payload(suite, case)
         response = _dispatch(suite, payload)
     except Exception as exc:
+        error_code = exc.error_code.value if isinstance(exc, AppError) else None
         return RunResult(
             case_id=case_id,
             suite=suite,
             response=None,
             error=f"{type(exc).__name__}: {exc}",
+            error_code=error_code,
             latency_ms=int((time.monotonic() - start) * 1000),
         )
     return RunResult(
@@ -47,6 +52,7 @@ def run_case(suite: SuiteName, case: dict[str, Any]) -> RunResult:
         suite=suite,
         response=response,
         error=None,
+        error_code=None,
         latency_ms=int((time.monotonic() - start) * 1000),
     )
 

--- a/apps/ai/eval/scoring.py
+++ b/apps/ai/eval/scoring.py
@@ -72,12 +72,26 @@ def score_case(
     actual: dict[str, Any] | None,
     error: str | None,
     latency_ms: int,
+    error_code: str | None = None,
+    accept_error_codes: list[str] | None = None,
 ) -> CaseScore:
     """case 의 expected vs actual 을 비교해 CaseScore 반환.
 
     actual=None (error 발생) 인 경우 hard-fail FAIL.
+    단, accept_error_codes 에 error_code 가 포함된 경우 PASS 로 처리 (듀얼-브랜치 수용).
     """
     if error is not None or actual is None:
+        # accept_error_codes 에 해당하는 에러 코드면 PASS 로 허용 (LLM_REFERENCE_VIOLATION 등 듀얼-브랜치)
+        if error_code is not None and accept_error_codes and error_code in accept_error_codes:
+            return CaseScore(
+                case_id=case_id,
+                suite=suite,
+                passed=True,
+                hard_fail=False,
+                field_comparisons=[],
+                error=error,
+                latency_ms=latency_ms,
+            )
         return CaseScore(
             case_id=case_id,
             suite=suite,

--- a/apps/ai/tests/test_eval_harness.py
+++ b/apps/ai/tests/test_eval_harness.py
@@ -191,6 +191,63 @@ def test_score_case_error_marks_hard_fail() -> None:
     assert "TimeoutError" in (score.error or "")
 
 
+def test_score_case_accepts_listed_error_code_as_pass() -> None:
+    score = score_case(
+        case_id="UNS-X", suite="question_analysis",
+        expected={"analysis_criteria": None, "unsupported_question": {"detected_intent": "unsupported_period"}},
+        actual=None,
+        error="LLMReferenceViolationError: ref",
+        error_code="LLM_REFERENCE_VIOLATION",
+        accept_error_codes=["LLM_REFERENCE_VIOLATION"],
+        latency_ms=100,
+    )
+    assert score.passed is True
+    assert score.hard_fail is False
+
+
+def test_score_case_unlisted_error_code_still_hard_fails() -> None:
+    score = score_case(
+        case_id="UNS-X", suite="question_analysis",
+        expected={"analysis_criteria": None, "unsupported_question": {"detected_intent": "unsupported_period"}},
+        actual=None,
+        error="LLMCallFailedError: upstream",
+        error_code="LLM_CALL_FAILED",
+        accept_error_codes=["LLM_REFERENCE_VIOLATION"],
+        latency_ms=100,
+    )
+    assert score.passed is False
+    assert score.hard_fail is True
+
+
+def test_score_case_error_without_accept_list_hard_fails() -> None:
+    score = score_case(
+        case_id="UNS-X", suite="question_analysis",
+        expected={"analysis_criteria": None, "unsupported_question": {"detected_intent": "unsupported_period"}},
+        actual=None,
+        error="LLMReferenceViolationError: ref",
+        error_code="LLM_REFERENCE_VIOLATION",
+        accept_error_codes=None,
+        latency_ms=100,
+    )
+    assert score.passed is False
+    assert score.hard_fail is True
+
+
+def test_score_case_empty_accept_list_hard_fails() -> None:
+    # 빈 accept 리스트는 '수용 코드 없음' 이므로 None 과 동일하게 hard-fail.
+    score = score_case(
+        case_id="UNS-X", suite="question_analysis",
+        expected={"analysis_criteria": None, "unsupported_question": {"detected_intent": "unsupported_period"}},
+        actual=None,
+        error="LLMReferenceViolationError: ref",
+        error_code="LLM_REFERENCE_VIOLATION",
+        accept_error_codes=[],
+        latency_ms=100,
+    )
+    assert score.passed is False
+    assert score.hard_fail is True
+
+
 def test_score_case_list_compared_as_set() -> None:
     score = score_case(
         case_id="C1", suite="question_analysis",


### PR DESCRIPTION
## 관련 이슈
Closes #374

## 변경 사항
- runner 가 AppError 의 error_code 를 RunResult.error_code 에 보존.
- scoring.score_case 가 error_code/accept_error_codes 를 받아 허용 코드면 PASS 처리(듀얼브랜치). 미해당/미지정 시 기존 hard-fail 유지(back-compat).
- __main__ 이 result.error_code 와 case.accept_error_codes 를 score_case 로 전달.
- UNS-03/UNS-04 케이스에 accept_error_codes=[LLM_REFERENCE_VIOLATION] 추가(200-unsupported 또는 502 둘 다 정답).

## 검증
듀얼브랜치 채점 테스트 4종(허용 pass, 미허용 hard-fail, accept 리스트 없음, 빈 리스트) 추가. 전체 pytest 통과(181).