### PR TITLE
fix(ai): sort_by 채점 도입 (RANKING=metric_value, COMPARISON=delta) (#373)

### DIFF
--- a/apps/ai/eval/cases/question_analysis/amb/AMB-01.json
+++ b/apps/ai/eval/cases/question_analysis/amb/AMB-01.json
@@ -11,6 +11,7 @@
   "expected": {
     "analysis_criteria": {
       "analysis_type": "RANKING",
+      "sort_by": "metric_value",
       "metric_name": "signup_conversion_rate",
       "group_by": ["channel"],
       "limit_num": 5

--- a/apps/ai/eval/cases/question_analysis/amb/AMB-02.json
+++ b/apps/ai/eval/cases/question_analysis/amb/AMB-02.json
@@ -11,6 +11,7 @@
   "expected": {
     "analysis_criteria": {
       "analysis_type": "RANKING",
+      "sort_by": "metric_value",
       "metric_name": "signup_conversion_rate",
       "group_by": ["channel", "device"],
       "limit_num": 5

--- a/apps/ai/eval/cases/question_analysis/amb/AMB-03.json
+++ b/apps/ai/eval/cases/question_analysis/amb/AMB-03.json
@@ -15,6 +15,7 @@
   "expected": {
     "analysis_criteria": {
       "analysis_type": "RANKING",
+      "sort_by": "metric_value",
       "metric_name": "signup_conversion_rate",
       "base_date_column": "event_date",
       "standard_period": "1W",

--- a/apps/ai/eval/cases/question_analysis/amb/AMB-04.json
+++ b/apps/ai/eval/cases/question_analysis/amb/AMB-04.json
@@ -14,6 +14,7 @@
   "expected": {
     "analysis_criteria": {
       "analysis_type": "RANKING",
+      "sort_by": "metric_value",
       "metric_name": "signup_conversion_rate",
       "base_date_column": "event_date",
       "standard_period": "1W",

--- a/apps/ai/eval/cases/question_analysis/amb/AMB-05.json
+++ b/apps/ai/eval/cases/question_analysis/amb/AMB-05.json
@@ -11,6 +11,7 @@
   "expected": {
     "analysis_criteria": {
       "analysis_type": "RANKING",
+      "sort_by": "metric_value",
       "metric_name": "signup_conversion_rate",
       "group_by": ["channel"],
       "limit_num": 5

--- a/apps/ai/eval/cases/question_analysis/amb/AMB-06.json
+++ b/apps/ai/eval/cases/question_analysis/amb/AMB-06.json
@@ -11,6 +11,7 @@
   "expected": {
     "analysis_criteria": {
       "analysis_type": "RANKING",
+      "sort_by": "metric_value",
       "metric_name": "signup_conversion_rate",
       "base_date_column": "created_at",
       "standard_period": "1W",

--- a/apps/ai/eval/cases/question_analysis/amb/AMB-07.json
+++ b/apps/ai/eval/cases/question_analysis/amb/AMB-07.json
@@ -15,6 +15,7 @@
   "expected": {
     "analysis_criteria": {
       "analysis_type": "RANKING",
+      "sort_by": "metric_value",
       "metric_name": "signup_conversion_rate",
       "base_date_column": "event_date",
       "standard_period": "1W",

--- a/apps/ai/eval/cases/question_analysis/amb/AMB-08.json
+++ b/apps/ai/eval/cases/question_analysis/amb/AMB-08.json
@@ -11,6 +11,7 @@
   "expected": {
     "analysis_criteria": {
       "analysis_type": "RANKING",
+      "sort_by": "metric_value",
       "base_date_column": "event_date",
       "standard_period": "1W",
       "group_by": ["channel"],

--- a/apps/ai/eval/cases/question_analysis/amb/AMB-09.json
+++ b/apps/ai/eval/cases/question_analysis/amb/AMB-09.json
@@ -11,6 +11,7 @@
   "expected": {
     "analysis_criteria": {
       "analysis_type": "RANKING",
+      "sort_by": "metric_value",
       "metric_name": "signup_conversion_rate",
       "base_date_column": "event_date",
       "group_by": ["channel"],

--- a/apps/ai/eval/cases/question_analysis/cmp/CMP-01.json
+++ b/apps/ai/eval/cases/question_analysis/cmp/CMP-01.json
@@ -10,6 +10,7 @@
   "expected": {
     "analysis_criteria": {
       "analysis_type": "COMPARISON",
+      "sort_by": "delta",
       "metric_name": "signup_conversion_rate",
       "base_date_column": "event_date",
       "standard_period": "1W",

--- a/apps/ai/eval/cases/question_analysis/cmp/CMP-02.json
+++ b/apps/ai/eval/cases/question_analysis/cmp/CMP-02.json
@@ -10,6 +10,7 @@
   "expected": {
     "analysis_criteria": {
       "analysis_type": "COMPARISON",
+      "sort_by": "delta",
       "metric_name": "activation_rate",
       "base_date_column": "event_date",
       "standard_period": "1M",

--- a/apps/ai/eval/cases/question_analysis/cmp/CMP-03.json
+++ b/apps/ai/eval/cases/question_analysis/cmp/CMP-03.json
@@ -10,6 +10,7 @@
   "expected": {
     "analysis_criteria": {
       "analysis_type": "COMPARISON",
+      "sort_by": "delta",
       "metric_name": "trial_start_rate",
       "base_date_column": "event_date",
       "standard_period": "1W",

--- a/apps/ai/eval/cases/question_analysis/cmp/CMP-04.json
+++ b/apps/ai/eval/cases/question_analysis/cmp/CMP-04.json
@@ -10,6 +10,7 @@
   "expected": {
     "analysis_criteria": {
       "analysis_type": "COMPARISON",
+      "sort_by": "delta",
       "metric_name": "paid_conversion_rate",
       "base_date_column": "event_date",
       "standard_period": "3M",

--- a/apps/ai/eval/cases/question_analysis/cmp/CMP-05.json
+++ b/apps/ai/eval/cases/question_analysis/cmp/CMP-05.json
@@ -10,6 +10,7 @@
   "expected": {
     "analysis_criteria": {
       "analysis_type": "COMPARISON",
+      "sort_by": "delta",
       "metric_name": "signup_conversion_rate",
       "base_date_column": "event_date",
       "standard_period": "1W",

--- a/apps/ai/eval/cases/question_analysis/cmp/CMP-06.json
+++ b/apps/ai/eval/cases/question_analysis/cmp/CMP-06.json
@@ -10,6 +10,7 @@
   "expected": {
     "analysis_criteria": {
       "analysis_type": "COMPARISON",
+      "sort_by": "delta",
       "metric_name": "signup_conversion_rate",
       "base_date_column": "event_date",
       "standard_period": "1W",

--- a/apps/ai/eval/cases/question_analysis/cmp/CMP-07.json
+++ b/apps/ai/eval/cases/question_analysis/cmp/CMP-07.json
@@ -10,6 +10,7 @@
   "expected": {
     "analysis_criteria": {
       "analysis_type": "COMPARISON",
+      "sort_by": "delta",
       "metric_name": "signup_conversion_rate",
       "base_date_column": "event_date",
       "standard_period": "1W",

--- a/apps/ai/eval/cases/question_analysis/cmp/CMP-08.json
+++ b/apps/ai/eval/cases/question_analysis/cmp/CMP-08.json
@@ -10,6 +10,7 @@
   "expected": {
     "analysis_criteria": {
       "analysis_type": "COMPARISON",
+      "sort_by": "delta",
       "metric_name": "signup_conversion_rate",
       "base_date_column": "created_at",
       "standard_period": "1W",

--- a/apps/ai/eval/cases/question_analysis/cmp/CMP-09.json
+++ b/apps/ai/eval/cases/question_analysis/cmp/CMP-09.json
@@ -11,6 +11,7 @@
   "expected": {
     "analysis_criteria": {
       "analysis_type": "COMPARISON",
+      "sort_by": "delta",
       "metric_name": "signup_conversion_rate",
       "standard_period": "1W",
       "compare_period": "1W",

--- a/apps/ai/eval/cases/question_analysis/cmp/CMP-10.json
+++ b/apps/ai/eval/cases/question_analysis/cmp/CMP-10.json
@@ -10,6 +10,7 @@
   "expected": {
     "analysis_criteria": {
       "analysis_type": "COMPARISON",
+      "sort_by": "delta",
       "metric_name": "signup_conversion_rate",
       "base_date_column": "event_date",
       "standard_period": "1W",

--- a/apps/ai/eval/cases/question_analysis/flt/FLT-01.json
+++ b/apps/ai/eval/cases/question_analysis/flt/FLT-01.json
@@ -10,6 +10,7 @@
   "expected": {
     "analysis_criteria": {
       "analysis_type": "RANKING",
+      "sort_by": "metric_value",
       "metric_name": "signup_conversion_rate",
       "base_date_column": "event_date",
       "standard_period": "1W",

--- a/apps/ai/eval/cases/question_analysis/flt/FLT-02.json
+++ b/apps/ai/eval/cases/question_analysis/flt/FLT-02.json
@@ -10,6 +10,7 @@
   "expected": {
     "analysis_criteria": {
       "analysis_type": "COMPARISON",
+      "sort_by": "delta",
       "metric_name": "signup_conversion_rate",
       "base_date_column": "event_date",
       "standard_period": "1W",

--- a/apps/ai/eval/cases/question_analysis/flt/FLT-03.json
+++ b/apps/ai/eval/cases/question_analysis/flt/FLT-03.json
@@ -10,6 +10,7 @@
   "expected": {
     "analysis_criteria": {
       "analysis_type": "RANKING",
+      "sort_by": "metric_value",
       "metric_name": "signup_conversion_rate",
       "base_date_column": "created_at",
       "standard_period": "1W",

--- a/apps/ai/eval/cases/question_analysis/rnk/RNK-01.json
+++ b/apps/ai/eval/cases/question_analysis/rnk/RNK-01.json
@@ -10,6 +10,7 @@
   "expected": {
     "analysis_criteria": {
       "analysis_type": "RANKING",
+      "sort_by": "metric_value",
       "metric_name": "signup_conversion_rate",
       "base_date_column": "event_date",
       "standard_period": "1W",

--- a/apps/ai/eval/cases/question_analysis/rnk/RNK-02.json
+++ b/apps/ai/eval/cases/question_analysis/rnk/RNK-02.json
@@ -10,6 +10,7 @@
   "expected": {
     "analysis_criteria": {
       "analysis_type": "RANKING",
+      "sort_by": "metric_value",
       "metric_name": "signup_conversion_rate",
       "base_date_column": "event_date",
       "standard_period": "1W",

--- a/apps/ai/eval/cases/question_analysis/rnk/RNK-03.json
+++ b/apps/ai/eval/cases/question_analysis/rnk/RNK-03.json
@@ -10,6 +10,7 @@
   "expected": {
     "analysis_criteria": {
       "analysis_type": "RANKING",
+      "sort_by": "metric_value",
       "metric_name": "signup_conversion_rate",
       "base_date_column": "event_date",
       "standard_period": "1W",

--- a/apps/ai/eval/cases/question_analysis/rnk/RNK-04.json
+++ b/apps/ai/eval/cases/question_analysis/rnk/RNK-04.json
@@ -10,6 +10,7 @@
   "expected": {
     "analysis_criteria": {
       "analysis_type": "RANKING",
+      "sort_by": "metric_value",
       "metric_name": "signup_conversion_rate",
       "base_date_column": "event_date",
       "standard_period": "1W",

--- a/apps/ai/eval/cases/question_analysis/rnk/RNK-05.json
+++ b/apps/ai/eval/cases/question_analysis/rnk/RNK-05.json
@@ -10,6 +10,7 @@
   "expected": {
     "analysis_criteria": {
       "analysis_type": "RANKING",
+      "sort_by": "metric_value",
       "metric_name": "activation_rate",
       "base_date_column": "event_date",
       "standard_period": "1M",

--- a/apps/ai/eval/cases/question_analysis/rnk/RNK-06.json
+++ b/apps/ai/eval/cases/question_analysis/rnk/RNK-06.json
@@ -10,6 +10,7 @@
   "expected": {
     "analysis_criteria": {
       "analysis_type": "RANKING",
+      "sort_by": "metric_value",
       "metric_name": "paid_conversion_rate",
       "base_date_column": "event_date",
       "standard_period": "1M",

--- a/apps/ai/eval/cases/question_analysis/rnk/RNK-07.json
+++ b/apps/ai/eval/cases/question_analysis/rnk/RNK-07.json
@@ -10,6 +10,7 @@
   "expected": {
     "analysis_criteria": {
       "analysis_type": "RANKING",
+      "sort_by": "metric_value",
       "metric_name": "trial_start_rate",
       "base_date_column": "event_date",
       "standard_period": "1W",

--- a/apps/ai/eval/cases/question_analysis/rnk/RNK-08.json
+++ b/apps/ai/eval/cases/question_analysis/rnk/RNK-08.json
@@ -10,6 +10,7 @@
   "expected": {
     "analysis_criteria": {
       "analysis_type": "RANKING",
+      "sort_by": "metric_value",
       "metric_name": "signup_conversion_rate",
       "base_date_column": "created_at",
       "standard_period": "1W",

--- a/apps/ai/eval/cases/question_analysis/rnk/RNK-09.json
+++ b/apps/ai/eval/cases/question_analysis/rnk/RNK-09.json
@@ -11,6 +11,7 @@
   "expected": {
     "analysis_criteria": {
       "analysis_type": "RANKING",
+      "sort_by": "metric_value",
       "metric_name": "signup_conversion_rate",
       "standard_period": "1W",
       "group_by": ["channel"],

--- a/apps/ai/eval/cases/question_analysis/rnk/RNK-10.json
+++ b/apps/ai/eval/cases/question_analysis/rnk/RNK-10.json
@@ -10,6 +10,7 @@
   "expected": {
     "analysis_criteria": {
       "analysis_type": "RANKING",
+      "sort_by": "metric_value",
       "metric_name": "signup_conversion_rate",
       "base_date_column": "event_date",
       "standard_period": "1W",

--- a/apps/ai/eval/cases/question_analysis/wrn/WRN-01.json
+++ b/apps/ai/eval/cases/question_analysis/wrn/WRN-01.json
@@ -12,6 +12,7 @@
   "expected": {
     "analysis_criteria": {
       "analysis_type": "RANKING",
+      "sort_by": "metric_value",
       "metric_name": "signup_conversion_rate",
       "base_date_column": "event_date",
       "standard_period": "1W",

--- a/apps/ai/eval/cases/question_analysis/wrn/WRN-02.json
+++ b/apps/ai/eval/cases/question_analysis/wrn/WRN-02.json
@@ -11,6 +11,7 @@
   "expected": {
     "analysis_criteria": {
       "analysis_type": "RANKING",
+      "sort_by": "metric_value",
       "metric_name": "signup_conversion_rate",
       "base_date_column": "event_date",
       "standard_period": "1W"

--- a/apps/ai/eval/cases/question_analysis/wrn/WRN-03.json
+++ b/apps/ai/eval/cases/question_analysis/wrn/WRN-03.json
@@ -12,6 +12,7 @@
   "expected": {
     "analysis_criteria": {
       "analysis_type": "RANKING",
+      "sort_by": "metric_value",
       "metric_name": "signup_conversion_rate",
       "base_date_column": "event_date",
       "standard_period": "1W",

--- a/apps/ai/prompts/question_analysis_v1.system.md
+++ b/apps/ai/prompts/question_analysis_v1.system.md
@@ -169,6 +169,11 @@ Return a single JSON object. Do not include any explanation outside the JSON.
 - 비교/랭킹/현재 상태 질문이 **분해 기준 차원을 명시하지 않으면**(예: "전주 대비 어디서 제일 빠졌어", "크게 떨어진 구간 보여줘") `data_source` 의 **모든 `DIMENSION` 역할 컬럼**을 `group_by` 에 넣는다 (하나만 고르지 않는다).
 - 질문이 특정 차원을 명시하면(예: "채널별", "지역별") 그 차원에 해당하는 컬럼만 정확히 `group_by` 에 넣는다.
 
+## sort_by 결정
+
+- `analysis_type` 이 `RANKING` 이면 `sort_by` 는 `"metric_value"`.
+- `analysis_type` 이 `COMPARISON` 이면 `sort_by` 는 `"delta"`.
+
 ## warning 판단 기준
 
 | warning code | 발생 조건 |
@@ -304,7 +309,7 @@ Shape B(unsupported_question)를 반환할 때 `detected_intent` 는 **반드시
     "base_date_column": "order_date",
     "standard_period": "this_month",
     "compare_period": null,
-    "sort_by": "value",
+    "sort_by": "metric_value",
     "sort_direction": "desc",
     "group_by": ["region"],
     "limit_num": 5,

--- a/apps/ai/services/analysis_criteria_service.py
+++ b/apps/ai/services/analysis_criteria_service.py
@@ -118,7 +118,7 @@ def _build_mock_response(req: QuestionAnalysisRequest) -> QuestionAnalysisRespon
             "base_date_column": date_col.column_name,
             "standard_period": standard,
             "compare_period": None,
-            "sort_by": "value",
+            "sort_by": "metric_value",
             "sort_direction": "desc",
             "group_by": [dim_col.column_name],
             "limit_num": 5,


### PR DESCRIPTION
## 관련 이슈
Closes #373

## 변경 사항
- 프롬프트: Example 2(RANKING) sort_by value -> metric_value, Decision Guide 에 'sort_by 결정' 규칙 추가(RANKING=metric_value, COMPARISON=delta).
- mock(analysis_criteria_service) RANKING sort_by value -> metric_value.
- Shape-A eval 케이스 35종 expected.analysis_criteria 에 sort_by 주입(RANKING=metric_value, COMPARISON=delta). UNS 케이스는 미주입.

## 검증
sort_by 는 비-hard-fail 일반 필드. 전체 pytest 통과(181, dev 병합 후).