### PR TITLE
fix: 로그아웃 시 기존 token 삭제+SSO 세션 무효화

### DIFF
--- a/apps/be/src/main/java/com/capstone/logue/auth/handler/OAuth2LoginSuccessHandler.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/handler/OAuth2LoginSuccessHandler.java
@@ -1,6 +1,7 @@
 package com.capstone.logue.auth.handler;
 
 import com.capstone.logue.auth.provider.JWTProvider;
+import com.capstone.logue.auth.repository.GoogleTokenRepository;
 import com.capstone.logue.auth.service.AuthService;
 import com.capstone.logue.auth.service.RefreshTokenService;
 import com.capstone.logue.global.entity.User;
@@ -15,6 +16,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -68,6 +71,8 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
     private final UserRepository userRepository;
 
     private final RefreshTokenService refreshTokenService;
+    private final OAuth2AuthorizedClientService authorizedClientService;
+    private final GoogleTokenRepository googleTokenRepository;
 
 
     /**
@@ -120,6 +125,19 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         });
 
         log.info("OAuth 로그인 성공. providerUserId = {}, isNewUser = {}", providerUserId, isNewUser);
+
+        // Google access token을 Redis에 저장 (로그아웃 시 revoke에 사용)
+        OAuth2AuthorizedClient authorizedClient = authorizedClientService.loadAuthorizedClient(provider, token.getName());
+        if (authorizedClient != null && authorizedClient.getAccessToken() != null) {
+            googleTokenRepository.save(
+                    user.getId(),
+                    authorizedClient.getAccessToken().getTokenValue(),
+                    authorizedClient.getAccessToken().getExpiresAt()
+            );
+        } else {
+            log.warn("Google access token을 가져오지 못했습니다. userId={}", user.getId());
+        }
+
         String accessToken = jwtProvider.generateToken(user.getId(), user.getEmail(), ACCESS_TOKEN_EXPIRATION_TIME);
         String refreshToken = jwtProvider.generateToken(user.getId(), user.getEmail(), REFRESH_TOKEN_EXPIRATION_TIME);
 

--- a/apps/be/src/main/java/com/capstone/logue/auth/repository/GoogleTokenRepository.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/repository/GoogleTokenRepository.java
@@ -1,0 +1,38 @@
+package com.capstone.logue.auth.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class GoogleTokenRepository {
+
+    private static final Duration FALLBACK_TTL = Duration.ofHours(1);
+
+    private final StringRedisTemplate redisTemplate;
+
+    public void save(Long userId, String googleAccessToken, Instant expiresAt) {
+        Duration ttl = (expiresAt != null) ? Duration.between(Instant.now(), expiresAt) : FALLBACK_TTL;
+        if (ttl.isNegative() || ttl.isZero()) {
+            ttl = FALLBACK_TTL;
+        }
+        redisTemplate.opsForValue().set(buildKey(userId), googleAccessToken, ttl);
+    }
+
+    public Optional<String> findByUserId(Long userId) {
+        return Optional.ofNullable(redisTemplate.opsForValue().get(buildKey(userId)));
+    }
+
+    public void deleteByUserId(Long userId) {
+        redisTemplate.delete(buildKey(userId));
+    }
+
+    private String buildKey(Long userId) {
+        return "google_token:" + userId;
+    }
+}

--- a/apps/be/src/main/java/com/capstone/logue/auth/service/AuthService.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/service/AuthService.java
@@ -2,6 +2,7 @@ package com.capstone.logue.auth.service;
 
 import com.capstone.logue.auth.dto.ReIssueTokenResponse;
 import com.capstone.logue.auth.provider.JWTProvider;
+import com.capstone.logue.auth.repository.GoogleTokenRepository;
 import com.capstone.logue.auth.repository.RefreshTokenRepository;
 import com.capstone.logue.global.entity.RefreshToken;
 import com.capstone.logue.global.exception.ErrorCode;
@@ -12,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
 
 import java.time.LocalDateTime;
 
@@ -21,6 +23,8 @@ import java.time.LocalDateTime;
 public class AuthService {
     private final JWTProvider jwtProvider;
     private final RefreshTokenService refreshTokenService;
+    private final GoogleTokenRepository googleTokenRepository;
+    private final RestClient restClient = RestClient.create();
 
     @Value("${spring.jwt.access-token.expiration-time}")
     private long ACCESS_TOKEN_EXPIRATION_TIME;
@@ -51,6 +55,22 @@ public class AuthService {
     public void logout(String refreshToken) {
         Claims claims = jwtProvider.validateToken(refreshToken);
         Long userId = jwtProvider.getUserIdFromToken(claims);
+
+        // Google access token revoke (실패해도 로그아웃 계속 진행)
+        googleTokenRepository.findByUserId(userId).ifPresent(googleToken -> {
+            try {
+                restClient.post()
+                        .uri("https://oauth2.googleapis.com/revoke?token=" + googleToken)
+                        .retrieve()
+                        .toBodilessEntity();
+                log.info("Google token revoke 성공. userId={}", userId);
+            } catch (Exception e) {
+                log.warn("Google token revoke 실패 (로그아웃은 계속 진행). userId={}, reason={}", userId, e.getMessage());
+            } finally {
+                googleTokenRepository.deleteByUserId(userId);
+            }
+        });
+
         refreshTokenService.deleteByUserId(userId);
     }
 }


### PR DESCRIPTION
## 요약
- 로그아웃 시 서버 토큰 삭제에 그치지 않고 Google OAuth access token을 revoke하여 브라우저 SSO 세션까지 완전히 무효화

## 변경 사항
- [x] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [ ] 로컬 테스트 완료
- 테스트 방법:
  - Google 계정으로 로그인 후 `POST /api/auth/logout` 호출
  - 이후 `accounts.google.com` 등에서 해당 access token 유효성 확인 (401 응답이어야 함)
  - Google 서버 응답 실패 상황 시뮬레이션 시에도 로그아웃 200 OK 확인
  - Redis에서 `google_token:{userId}` 키가 삭제됐는지 확인

## 스크린샷/로그 (선택)
- 필요한 경우 첨부

## 롤백/리스크
- 리스크 포인트: 로그아웃 API에 Google 외부 HTTP 호출이 추가되어 Google 서버 지연 시 로그아웃 응답이 느려질 수 있음 (최대 수 초)
- 롤백 방법: `OAuth2LoginSuccessHandler`, `AuthService` 변경분 revert 및 `GoogleTokenRepository` 삭제

## 관련 이슈
Closes #379 
