### PR TITLE
refactor: dataSource API 경계 정리

### DIFF
--- a/apps/fe/src/apis/datasource.ts
+++ b/apps/fe/src/apis/datasource.ts
@@ -1,44 +1,11 @@
 import instance from '@/lib/axios';
 import { unwrapApiResponse, type ApiResponse } from './types';
-
-export type DataSourceSort = 'LATEST' | 'MOST_USED';
-
-export type DataSourceSummary = {
-  dataSourceId: number;
-  fileName: string;
-  fileSize: number;
-  uploadedAt: string;
-};
-
-export type GetDataSourceListParams = {
-  sort: DataSourceSort;
-  page: number;
-  size: number;
-};
-
-export type GetDataSourceListResponse = {
-  sort: DataSourceSort;
-  page: number;
-  size: number;
-  totalPages: number;
-  dataSources: DataSourceSummary[];
-};
-
-export type FilePreview = {
-  headers: string[];
-  rows: string[][];
-};
-
-export type GetFileResponse = {
-  fileName: string;
-  fileSize: number;
-  uploadedAt: string;
-  preview: FilePreview | null;
-};
-
-export type UploadFileResponse = {
-  dataSourceId: number;
-};
+import type {
+  GetDataSourceListParams,
+  GetDataSourceListResponse,
+  GetFileResponse,
+  UploadFileResponse,
+} from '@/features/dataSource/types';
 
 function serializeDataSourceIds(dataSourceIds: number[]) {
   return `id=${dataSourceIds.join(',')}`;
@@ -47,16 +14,6 @@ function serializeDataSourceIds(dataSourceIds: number[]) {
 function getDeleteDataSourcesPath(dataSourceIds: number[]) {
   return `/api/datasources?${serializeDataSourceIds(dataSourceIds)}`;
 }
-
-export const dataSourceKeys = {
-  all: ['dataSources'] as const,
-  lists: () => [...dataSourceKeys.all, 'list'] as const,
-  list: (params: GetDataSourceListParams) =>
-    [...dataSourceKeys.lists(), params] as const,
-  details: () => [...dataSourceKeys.all, 'detail'] as const,
-  detail: (dataSourceId: number) =>
-    [...dataSourceKeys.details(), dataSourceId] as const,
-};
 
 export async function getDataSources(params: GetDataSourceListParams) {
   const { data } = await instance.get<ApiResponse<GetDataSourceListResponse>>(

--- a/apps/fe/src/app/(main)/analysis/[id]/_hooks/useAnalysisDataPreview.ts
+++ b/apps/fe/src/app/(main)/analysis/[id]/_hooks/useAnalysisDataPreview.ts
@@ -1,9 +1,12 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { dataSourceKeys, getDataSource } from '@/apis/datasource';
 import { getApiErrorMessage } from '@/apis/errors';
-import { createDataSourcePreviewTableModel } from '@/features/dataSource';
+import {
+  createDataSourcePreviewTableModel,
+  dataSourceKeys,
+  getDataSource,
+} from '@/features/dataSource';
 
 type UseAnalysisDataPreviewParams = {
   dataSourceId: number | null;

--- a/apps/fe/src/app/(main)/data/[id]/_components/DataDetailView.tsx
+++ b/apps/fe/src/app/(main)/data/[id]/_components/DataDetailView.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import type { GetFileResponse } from '@/apis/datasource';
 import { ConfirmModal } from '@/components';
+import type { GetFileResponse } from '@/features/dataSource';
 import { formatDateTime } from '@/lib/dateTime';
 import { formatFileSize } from '@/lib/fileValidation';
 import DataChartCard from '../../_components/DataChartCard';

--- a/apps/fe/src/app/(main)/data/[id]/_hooks/useDataDetail.ts
+++ b/apps/fe/src/app/(main)/data/[id]/_hooks/useDataDetail.ts
@@ -1,8 +1,7 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { dataSourceKeys } from '@/apis/datasource';
-import { getDataSource } from '@/features/dataSource';
+import { dataSourceKeys, getDataSource } from '@/features/dataSource';
 
 type UseDataDetailParams = {
   dataSourceId: number;

--- a/apps/fe/src/app/(main)/data/_components/DataChartCard.tsx
+++ b/apps/fe/src/app/(main)/data/_components/DataChartCard.tsx
@@ -1,9 +1,11 @@
 'use client';
 
-import type { FilePreview } from '@/apis/datasource';
 import ChatIcon from '@/assets/icons/chat.svg';
 import TrashIcon from '@/assets/icons/trash.svg';
-import { DataSourcePreviewTable } from '@/features/dataSource';
+import {
+  DataSourcePreviewTable,
+  type FilePreview,
+} from '@/features/dataSource';
 
 export type DataChartCardProps = {
   fileName: string;

--- a/apps/fe/src/app/(main)/data/_components/DataSourceRow.tsx
+++ b/apps/fe/src/app/(main)/data/_components/DataSourceRow.tsx
@@ -1,4 +1,4 @@
-import { type DataSourceSummary } from '@/apis/datasource';
+import { type DataSourceSummary } from '@/features/dataSource';
 import ChatIcon from '@/assets/icons/chat.svg';
 import { Checkbox } from '@/components';
 import { formatDateTime } from '@/lib/dateTime';

--- a/apps/fe/src/app/(main)/data/_components/DataSourceTable.tsx
+++ b/apps/fe/src/app/(main)/data/_components/DataSourceTable.tsx
@@ -1,4 +1,4 @@
-import type { DataSourceSummary } from '@/apis/datasource';
+import type { DataSourceSummary } from '@/features/dataSource';
 import { Checkbox } from '@/components';
 import DataSourceRow from './DataSourceRow';
 

--- a/apps/fe/src/app/(main)/data/_components/DataSourceToolbar.tsx
+++ b/apps/fe/src/app/(main)/data/_components/DataSourceToolbar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { DataSourceSort } from '@/apis/datasource';
+import type { DataSourceSort } from '@/features/dataSource';
 import SortDropdown, { type SortOption } from './SortDropdown';
 
 type DataSourceToolbarProps = {

--- a/apps/fe/src/app/(main)/data/_hooks/useDataSourceList.ts
+++ b/apps/fe/src/app/(main)/data/_hooks/useDataSourceList.ts
@@ -2,8 +2,11 @@
 
 import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { dataSourceKeys, type DataSourceSort } from '@/apis/datasource';
-import { getDataSources } from '@/features/dataSource';
+import {
+  dataSourceKeys,
+  getDataSources,
+  type DataSourceSort,
+} from '@/features/dataSource';
 import type { MockDataSourceManager } from '@/features/mockDataSource';
 import { getDataSourceErrorMessage } from '../_utils/dataSourceErrorMessage';
 

--- a/apps/fe/src/app/(main)/data/_hooks/useDataSourceSelection.ts
+++ b/apps/fe/src/app/(main)/data/_hooks/useDataSourceSelection.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useMemo, useState } from 'react';
-import type { DataSourceSummary } from '@/apis/datasource';
+import type { DataSourceSummary } from '@/features/dataSource';
 
 export function useDataSourceSelection(
   dataSources: readonly DataSourceSummary[],

--- a/apps/fe/src/app/(main)/data/_hooks/useDeleteDataSources.ts
+++ b/apps/fe/src/app/(main)/data/_hooks/useDeleteDataSources.ts
@@ -2,9 +2,8 @@
 
 import { useCallback } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { dataSourceKeys } from '@/apis/datasource';
 import { AUTH_MESSAGES } from '@/constants/messages';
-import { deleteDataSources } from '@/features/dataSource';
+import { dataSourceKeys, deleteDataSources } from '@/features/dataSource';
 import type { MockDataSourceManager } from '@/features/mockDataSource';
 import { getDataSourceDeleteErrorMessage } from '../_utils/dataSourceErrorMessage';
 

--- a/apps/fe/src/app/(main)/data/_hooks/useUploadDataSource.ts
+++ b/apps/fe/src/app/(main)/data/_hooks/useUploadDataSource.ts
@@ -2,7 +2,7 @@
 
 import { useCallback } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { dataSourceKeys, uploadDataSource } from '@/apis/datasource';
+import { dataSourceKeys, uploadDataSource } from '@/features/dataSource';
 import { getDataSourceErrorMessage } from '../_utils/dataSourceErrorMessage';
 
 type UseUploadDataSourceOptions = {

--- a/apps/fe/src/app/(main)/data/page.tsx
+++ b/apps/fe/src/app/(main)/data/page.tsx
@@ -2,9 +2,9 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { type DataSourceSummary, type DataSourceSort } from '@/apis/datasource';
 import { ConfirmModal, FileUploadModal, ToastPortal } from '@/components';
 import { AUTH_MESSAGES, DATA_SOURCE_MESSAGES } from '@/constants/messages';
+import type { DataSourceSummary, DataSourceSort } from '@/features/dataSource';
 import { useStartAnalysis } from '@/hooks/useStartAnalysis';
 import { useToast } from '@/hooks/useToast';
 import { validateCsvFile } from '@/lib/fileValidation';

--- a/apps/fe/src/features/dataSource/DataSourcePreviewTable.tsx
+++ b/apps/fe/src/features/dataSource/DataSourcePreviewTable.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import type { FilePreview } from '@/apis/datasource';
 import {
   createDataSourcePreviewTableModel,
   type DataSourcePreviewTableModel,
 } from './previewTable';
+import type { FilePreview } from './types';
 
 type DataSourcePreviewTableVariant = 'detail' | 'analysis';
 

--- a/apps/fe/src/features/dataSource/dataSourceRepository.test.ts
+++ b/apps/fe/src/features/dataSource/dataSourceRepository.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as dataSourceApi from '@/apis/datasource';
 import { MOCK_MARKETING_CVR_DATA_SOURCE_ID } from '@/features/mockDataSource';
 import {
@@ -21,6 +21,10 @@ beforeEach(() => {
     'fetch',
     vi.fn(async () => new Response('name,value\nemail,12', { status: 200 })),
   );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
 });
 
 describe('dataSourceRepository', () => {

--- a/apps/fe/src/features/dataSource/dataSourceRepository.test.ts
+++ b/apps/fe/src/features/dataSource/dataSourceRepository.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as dataSourceApi from '@/apis/datasource';
+import { MOCK_MARKETING_CVR_DATA_SOURCE_ID } from '@/features/mockDataSource';
+import {
+  deleteDataSources,
+  getDataSource,
+  uploadDataSource,
+} from './dataSourceRepository';
+
+vi.mock('@/apis/datasource', () => ({
+  deleteDataSource: vi.fn(),
+  deleteDataSources: vi.fn(),
+  getDataSource: vi.fn(),
+  getDataSources: vi.fn(),
+  uploadDataSource: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => new Response('name,value\nemail,12', { status: 200 })),
+  );
+});
+
+describe('dataSourceRepository', () => {
+  it('serves mock data source details without calling the raw API', async () => {
+    const detail = await getDataSource(MOCK_MARKETING_CVR_DATA_SOURCE_ID);
+
+    expect(dataSourceApi.getDataSource).not.toHaveBeenCalled();
+    expect(detail.fileName).toBe('marketing-cvr-mock-data.csv');
+    expect(detail.preview).toEqual({
+      headers: ['name', 'value'],
+      rows: [['email', '12']],
+    });
+  });
+
+  it('passes only server data source ids to the raw multi-delete API', async () => {
+    vi.mocked(dataSourceApi.deleteDataSources).mockResolvedValue(undefined);
+
+    await deleteDataSources([1, MOCK_MARKETING_CVR_DATA_SOURCE_ID, 2]);
+
+    expect(dataSourceApi.deleteDataSources).toHaveBeenCalledWith([1, 2]);
+  });
+
+  it('delegates uploads through the raw upload API', async () => {
+    const file = new File(['a,b'], 'sample.csv', { type: 'text/csv' });
+    vi.mocked(dataSourceApi.uploadDataSource).mockResolvedValue({
+      dataSourceId: 42,
+    });
+
+    await expect(uploadDataSource(file)).resolves.toEqual({
+      dataSourceId: 42,
+    });
+    expect(dataSourceApi.uploadDataSource).toHaveBeenCalledWith(file);
+  });
+});

--- a/apps/fe/src/features/dataSource/dataSourceRepository.ts
+++ b/apps/fe/src/features/dataSource/dataSourceRepository.ts
@@ -3,8 +3,7 @@ import {
   deleteDataSources as deleteDataSourcesRequest,
   getDataSource as getDataSourceRequest,
   getDataSources as getDataSourcesRequest,
-  type GetDataSourceListParams,
-  type GetFileResponse,
+  uploadDataSource as uploadDataSourceRequest,
 } from '@/apis/datasource';
 import {
   getMockDataSource,
@@ -13,6 +12,7 @@ import {
   isMockDataSourceId,
   withMockDataSource,
 } from '@/features/mockDataSource';
+import type { GetDataSourceListParams, GetFileResponse } from './types';
 
 type DataSourceDetailReader = (
   dataSourceId: number,
@@ -68,4 +68,8 @@ export async function deleteDataSources(dataSourceIds: number[]) {
 
 export async function deleteDataSource(dataSourceId: number) {
   return deleteMockAwareDataSource(dataSourceId, deleteDataSourceRequest);
+}
+
+export async function uploadDataSource(file: File) {
+  return uploadDataSourceRequest(file);
 }

--- a/apps/fe/src/features/dataSource/index.ts
+++ b/apps/fe/src/features/dataSource/index.ts
@@ -4,6 +4,7 @@ export {
   deleteDataSources,
   getDataSource,
   getDataSources,
+  uploadDataSource,
 } from './dataSourceRepository';
 export {
   createDataSourcePreviewTableModel,
@@ -11,3 +12,13 @@ export {
   type DataSourcePreviewRow,
   type DataSourcePreviewTableModel,
 } from './previewTable';
+export { dataSourceKeys } from './queryKeys';
+export type {
+  DataSourceSort,
+  DataSourceSummary,
+  FilePreview,
+  GetDataSourceListParams,
+  GetDataSourceListResponse,
+  GetFileResponse,
+  UploadFileResponse,
+} from './types';

--- a/apps/fe/src/features/dataSource/previewTable.ts
+++ b/apps/fe/src/features/dataSource/previewTable.ts
@@ -1,4 +1,4 @@
-import type { FilePreview } from '@/apis/datasource';
+import type { FilePreview } from './types';
 
 export type DataSourcePreviewColumn = {
   key: string;

--- a/apps/fe/src/features/dataSource/queryKeys.ts
+++ b/apps/fe/src/features/dataSource/queryKeys.ts
@@ -1,0 +1,11 @@
+import type { GetDataSourceListParams } from './types';
+
+export const dataSourceKeys = {
+  all: ['dataSources'] as const,
+  lists: () => [...dataSourceKeys.all, 'list'] as const,
+  list: (params: GetDataSourceListParams) =>
+    [...dataSourceKeys.lists(), params] as const,
+  details: () => [...dataSourceKeys.all, 'detail'] as const,
+  detail: (dataSourceId: number) =>
+    [...dataSourceKeys.details(), dataSourceId] as const,
+};

--- a/apps/fe/src/features/dataSource/types.ts
+++ b/apps/fe/src/features/dataSource/types.ts
@@ -1,0 +1,38 @@
+export type DataSourceSort = 'LATEST' | 'MOST_USED';
+
+export type DataSourceSummary = {
+  dataSourceId: number;
+  fileName: string;
+  fileSize: number;
+  uploadedAt: string;
+};
+
+export type GetDataSourceListParams = {
+  sort: DataSourceSort;
+  page: number;
+  size: number;
+};
+
+export type GetDataSourceListResponse = {
+  sort: DataSourceSort;
+  page: number;
+  size: number;
+  totalPages: number;
+  dataSources: DataSourceSummary[];
+};
+
+export type FilePreview = {
+  headers: string[];
+  rows: string[][];
+};
+
+export type GetFileResponse = {
+  fileName: string;
+  fileSize: number;
+  uploadedAt: string;
+  preview: FilePreview | null;
+};
+
+export type UploadFileResponse = {
+  dataSourceId: number;
+};

--- a/apps/fe/src/features/mockDataSource/mockDataSource.ts
+++ b/apps/fe/src/features/mockDataSource/mockDataSource.ts
@@ -4,7 +4,7 @@ import type {
   GetDataSourceListParams,
   GetDataSourceListResponse,
   GetFileResponse,
-} from '@/apis/datasource';
+} from '@/features/dataSource/types';
 
 export const MOCK_MARKETING_CVR_DATA_SOURCE_ID = 900001;
 

--- a/apps/fe/src/features/mockDataSource/useMockDataSourceManager.ts
+++ b/apps/fe/src/features/mockDataSource/useMockDataSourceManager.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useMemo, useState } from 'react';
-import type { DataSourceSummary } from '@/apis/datasource';
+import type { DataSourceSummary } from '@/features/dataSource/types';
 import {
   filterVisibleMockDataSources,
   getMockDataSourceIds,

--- a/apps/fe/src/hooks/useStartAnalysis.ts
+++ b/apps/fe/src/hooks/useStartAnalysis.ts
@@ -3,8 +3,8 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { startAnalysisFlowFromDataSource } from '@/apis/analysis';
-import { dataSourceKeys, uploadDataSource } from '@/apis/datasource';
 import { getApiErrorMessage } from '@/apis/errors';
+import { dataSourceKeys, uploadDataSource } from '@/features/dataSource';
 import { writeAnalysisStartPayload } from '@/lib/analysisStartPayload';
 import { useAuthSession } from '@/providers/AuthProvider';
 


### PR DESCRIPTION
## 요약
- dataSource API 경계를 feature public interface 중심으로 정리합니다.

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `yarn test`
  - `yarn lint`
  - `NEXT_PUBLIC_API_URL=https://api-stg.asklogue.co yarn build`

## 스크린샷/로그 (선택)
- 해당 없음

## 롤백/리스크
- 리스크 요인: dataSource import 경계 변경으로 인한 import path 충돌 가능성
- 롤백 방법: 본 PR revert

## 관련 이슈
Closes #386

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 데이터 소스 관련 타입 정의 및 유틸리티 위치를 재구성하여 모듈 구조를 개선했습니다.
  * 다양한 파일의 임포트 경로를 통합하여 의존성 구조를 단순화했습니다.

* **Tests**
  * 데이터 소스 저장소의 주요 동작을 검증하는 테스트를 추가했습니다.

* **Chores**
  * 데이터 소스 타입 정의 파일을 신규 생성하고 쿼리 캐시 키 정의를 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->