### PR TITLE
refactor: auth lifecycle 정책 응집

### DIFF
--- a/apps/fe/src/hooks/useAuthLifecycle.ts
+++ b/apps/fe/src/hooks/useAuthLifecycle.ts
@@ -19,15 +19,12 @@ import {
   isAllowedOAuthPopupOrigin,
   readOAuthPopupCallbackMessage,
 } from '@/lib/authRedirect';
-import {
-  AUTH_REDIRECT_PATH,
-  getLoginRedirectPath,
-  getPostAuthRedirectPath,
-  shouldRedirectAuthenticatedUser,
-  shouldRedirectPrivatePath,
-  type AuthStatus,
-} from '@/lib/authSession';
+import { getPostAuthRedirectPath, type AuthStatus } from '@/lib/authSession';
 import { restoreAuthSession } from '@/lib/authSessionRestore';
+import {
+  getAuthRouteBypassRequirements,
+  getAuthRouteDecision,
+} from '@/lib/authSessionService';
 
 type SetAuthStatus = (status: AuthStatus) => void;
 
@@ -65,28 +62,26 @@ function useAuthStatusApplier({
 
       if (nextStatus === 'anonymous') {
         queryClient.clear();
-
-        if (
-          shouldRedirectPrivatePath(nextStatus, pathname) &&
-          !consumePrivatePathRedirectBypass()
-        ) {
-          replaceLocation(getLoginRedirectPath(new URL(window.location.href)));
-        }
-
-        return;
       }
 
-      const shouldBypassAuthEntryRedirect =
-        shouldCheckAuthEntryRedirect &&
-        shouldRedirectAuthenticatedUser(pathname) &&
-        consumeAuthEntryRedirectBypass();
+      const bypassRequirements = getAuthRouteBypassRequirements({
+        pathname,
+        shouldCheckAuthEntryRedirect,
+        status: nextStatus,
+      });
+      const routeDecision = getAuthRouteDecision({
+        currentUrl: new URL(window.location.href),
+        pathname,
+        shouldBypassAuthEntryRedirect:
+          bypassRequirements.authEntry && consumeAuthEntryRedirectBypass(),
+        shouldBypassPrivatePathRedirect:
+          bypassRequirements.privatePath && consumePrivatePathRedirectBypass(),
+        shouldCheckAuthEntryRedirect,
+        status: nextStatus,
+      });
 
-      if (
-        shouldCheckAuthEntryRedirect &&
-        shouldRedirectAuthenticatedUser(pathname) &&
-        !shouldBypassAuthEntryRedirect
-      ) {
-        replaceLocation(AUTH_REDIRECT_PATH);
+      if (routeDecision.type === 'replace') {
+        replaceLocation(routeDecision.path);
       }
     },
     [pathname, queryClient, setStatus],

--- a/apps/fe/src/lib/authSessionRestore.test.ts
+++ b/apps/fe/src/lib/authSessionRestore.test.ts
@@ -68,6 +68,32 @@ describe('restoreAuthSession', () => {
     );
   });
 
+  it('shares in-flight token reissue while restoring concurrent sessions', async () => {
+    installWindowStorage();
+    const nextAccessToken = createJwt(Date.now() + 120_000);
+    const reissueAuthTokens = vi.fn<ReissueAuthTokens>().mockResolvedValue({
+      accessToken: nextAccessToken,
+      refreshToken: 'next-refresh-token',
+    });
+
+    setAuthTokens({
+      accessToken: createJwt(Date.now() - 1_000),
+      refreshToken: 'refresh-token',
+    });
+
+    await expect(
+      Promise.all([
+        restoreAuthSession(reissueAuthTokens),
+        restoreAuthSession(reissueAuthTokens),
+      ]),
+    ).resolves.toEqual(['authenticated', 'authenticated']);
+
+    expect(reissueAuthTokens).toHaveBeenCalledTimes(1);
+    expect(reissueAuthTokens).toHaveBeenCalledWith('refresh-token');
+    expect(getAccessToken()).toBe(nextAccessToken);
+    expect(getRefreshToken()).toBe('next-refresh-token');
+  });
+
   it('clears tokens and returns anonymous when reissue fails', async () => {
     installWindowStorage();
     const reissueAuthTokens = vi

--- a/apps/fe/src/lib/authSessionRestore.ts
+++ b/apps/fe/src/lib/authSessionRestore.ts
@@ -7,20 +7,9 @@ import {
   type AuthTokens,
 } from './auth';
 import type { AuthStatus } from './authSession';
+import { hasUsableRotatedTokens } from './authTokenRefresh';
 
 export type ReissueAuthTokens = (refreshToken: string) => Promise<AuthTokens>;
-
-function hasUsableRotatedTokens(previousRefreshToken: string) {
-  const latestAccessToken = getAccessToken();
-  const latestRefreshToken = getRefreshToken();
-
-  return (
-    !!latestAccessToken &&
-    !!latestRefreshToken &&
-    latestRefreshToken !== previousRefreshToken &&
-    !shouldRefreshAccessToken(latestAccessToken)
-  );
-}
 
 export async function restoreAuthSession(
   reissueAuthTokens: ReissueAuthTokens,

--- a/apps/fe/src/lib/authSessionRestore.ts
+++ b/apps/fe/src/lib/authSessionRestore.ts
@@ -7,7 +7,10 @@ import {
   type AuthTokens,
 } from './auth';
 import type { AuthStatus } from './authSession';
-import { hasUsableRotatedTokens } from './authTokenRefresh';
+import {
+  getSharedReissuedAuthTokens,
+  hasUsableRotatedTokens,
+} from './authTokenRefresh';
 
 export type ReissueAuthTokens = (refreshToken: string) => Promise<AuthTokens>;
 
@@ -31,7 +34,10 @@ export async function restoreAuthSession(
   }
 
   try {
-    const nextTokens = await reissueAuthTokens(refreshToken);
+    const nextTokens = await getSharedReissuedAuthTokens(
+      refreshToken,
+      reissueAuthTokens,
+    );
     setAuthTokens(nextTokens);
     return 'authenticated';
   } catch {

--- a/apps/fe/src/lib/authSessionService.test.ts
+++ b/apps/fe/src/lib/authSessionService.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getAuthRouteBypassRequirements,
+  getAuthRouteDecision,
+} from './authSessionService';
+
+const CURRENT_URL = new URL('https://www.asklogue.co/data/12?q=csv#preview');
+
+describe('auth session route decision service', () => {
+  it('redirects anonymous private route visits to login with the current path', () => {
+    expect(
+      getAuthRouteDecision({
+        currentUrl: CURRENT_URL,
+        pathname: '/data/12',
+        shouldBypassAuthEntryRedirect: false,
+        shouldBypassPrivatePathRedirect: false,
+        shouldCheckAuthEntryRedirect: true,
+        status: 'anonymous',
+      }),
+    ).toEqual({
+      type: 'replace',
+      path: '/login?next=%2Fdata%2F12%3Fq%3Dcsv%23preview',
+    });
+  });
+
+  it('allows anonymous private route visits when the private redirect is bypassed', () => {
+    expect(
+      getAuthRouteDecision({
+        currentUrl: CURRENT_URL,
+        pathname: '/data/12',
+        shouldBypassAuthEntryRedirect: false,
+        shouldBypassPrivatePathRedirect: true,
+        shouldCheckAuthEntryRedirect: true,
+        status: 'anonymous',
+      }),
+    ).toEqual({ type: 'none' });
+  });
+
+  it('redirects authenticated auth entry visits unless the auth entry redirect is bypassed', () => {
+    expect(
+      getAuthRouteDecision({
+        currentUrl: new URL('https://www.asklogue.co/'),
+        pathname: '/',
+        shouldBypassAuthEntryRedirect: false,
+        shouldBypassPrivatePathRedirect: false,
+        shouldCheckAuthEntryRedirect: true,
+        status: 'authenticated',
+      }),
+    ).toEqual({ type: 'replace', path: '/analysis' });
+
+    expect(
+      getAuthRouteDecision({
+        currentUrl: new URL('https://www.asklogue.co/'),
+        pathname: '/',
+        shouldBypassAuthEntryRedirect: true,
+        shouldBypassPrivatePathRedirect: false,
+        shouldCheckAuthEntryRedirect: true,
+        status: 'authenticated',
+      }),
+    ).toEqual({ type: 'none' });
+  });
+
+  it('reports only the bypasses that can affect the current decision', () => {
+    expect(
+      getAuthRouteBypassRequirements({
+        pathname: '/data',
+        shouldCheckAuthEntryRedirect: true,
+        status: 'anonymous',
+      }),
+    ).toEqual({ authEntry: false, privatePath: true });
+
+    expect(
+      getAuthRouteBypassRequirements({
+        pathname: '/',
+        shouldCheckAuthEntryRedirect: true,
+        status: 'authenticated',
+      }),
+    ).toEqual({ authEntry: true, privatePath: false });
+  });
+});

--- a/apps/fe/src/lib/authSessionService.ts
+++ b/apps/fe/src/lib/authSessionService.ts
@@ -1,0 +1,75 @@
+import {
+  AUTH_REDIRECT_PATH,
+  getLoginRedirectPath,
+  shouldRedirectAuthenticatedUser,
+  shouldRedirectPrivatePath,
+  type AuthStatus,
+} from './authSession';
+
+export type AuthRouteDecision =
+  | { type: 'none' }
+  | { type: 'replace'; path: string };
+
+export type AuthRouteBypassRequirements = {
+  authEntry: boolean;
+  privatePath: boolean;
+};
+
+type GetAuthRouteDecisionParams = {
+  currentUrl: URL;
+  pathname: string;
+  shouldBypassAuthEntryRedirect: boolean;
+  shouldBypassPrivatePathRedirect: boolean;
+  shouldCheckAuthEntryRedirect: boolean;
+  status: AuthStatus;
+};
+
+export function getAuthRouteBypassRequirements({
+  pathname,
+  shouldCheckAuthEntryRedirect,
+  status,
+}: Pick<
+  GetAuthRouteDecisionParams,
+  'pathname' | 'shouldCheckAuthEntryRedirect' | 'status'
+>): AuthRouteBypassRequirements {
+  return {
+    authEntry:
+      status === 'authenticated' &&
+      shouldCheckAuthEntryRedirect &&
+      shouldRedirectAuthenticatedUser(pathname),
+    privatePath: shouldRedirectPrivatePath(status, pathname),
+  };
+}
+
+export function getAuthRouteDecision({
+  currentUrl,
+  pathname,
+  shouldBypassAuthEntryRedirect,
+  shouldBypassPrivatePathRedirect,
+  shouldCheckAuthEntryRedirect,
+  status,
+}: GetAuthRouteDecisionParams): AuthRouteDecision {
+  if (
+    shouldRedirectPrivatePath(status, pathname) &&
+    !shouldBypassPrivatePathRedirect
+  ) {
+    return {
+      type: 'replace',
+      path: getLoginRedirectPath(currentUrl),
+    };
+  }
+
+  if (
+    status === 'authenticated' &&
+    shouldCheckAuthEntryRedirect &&
+    shouldRedirectAuthenticatedUser(pathname) &&
+    !shouldBypassAuthEntryRedirect
+  ) {
+    return {
+      type: 'replace',
+      path: AUTH_REDIRECT_PATH,
+    };
+  }
+
+  return { type: 'none' };
+}

--- a/apps/fe/src/lib/authTokenRefresh.test.ts
+++ b/apps/fe/src/lib/authTokenRefresh.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createJwt } from '../test-utils/jwt';
+import { installWindowStorage } from '../test-utils/storage';
+import { setAuthTokens } from './auth';
+import {
+  getSharedReissuedAuthTokens,
+  getUsableRotatedAccessToken,
+  hasUsableRotatedTokens,
+} from './authTokenRefresh';
+
+afterEach(() => {
+  Reflect.deleteProperty(globalThis, 'window');
+  vi.restoreAllMocks();
+});
+
+describe('auth token refresh helpers', () => {
+  it('shares an in-flight token reissue request', async () => {
+    const nextTokens = {
+      accessToken: 'next-access-token',
+      refreshToken: 'next-refresh-token',
+    };
+    const reissueAuthTokens = vi.fn(async () => nextTokens);
+
+    const first = getSharedReissuedAuthTokens(
+      'refresh-token',
+      reissueAuthTokens,
+    );
+    const second = getSharedReissuedAuthTokens(
+      'refresh-token',
+      reissueAuthTokens,
+    );
+
+    expect(first).toBe(second);
+    await expect(first).resolves.toEqual(nextTokens);
+    expect(reissueAuthTokens).toHaveBeenCalledOnce();
+  });
+
+  it('detects usable tokens rotated by another refresh request', () => {
+    installWindowStorage();
+    const accessToken = createJwt({ exp: 1_800_000_120 });
+    vi.spyOn(Date, 'now').mockReturnValue(1_800_000_000_000);
+
+    setAuthTokens({
+      accessToken,
+      refreshToken: 'rotated-refresh-token',
+    });
+
+    expect(getUsableRotatedAccessToken('previous-refresh-token')).toBe(
+      accessToken,
+    );
+    expect(hasUsableRotatedTokens('previous-refresh-token')).toBe(true);
+    expect(getUsableRotatedAccessToken('rotated-refresh-token')).toBeNull();
+  });
+});

--- a/apps/fe/src/lib/authTokenRefresh.ts
+++ b/apps/fe/src/lib/authTokenRefresh.ts
@@ -1,0 +1,41 @@
+import {
+  getAccessToken,
+  getRefreshToken,
+  shouldRefreshAccessToken,
+  type AuthTokens,
+} from './auth';
+
+export type ReissueAuthTokens = (refreshToken: string) => Promise<AuthTokens>;
+
+let reissueTokensRequest: Promise<AuthTokens> | null = null;
+
+export function getSharedReissuedAuthTokens(
+  refreshToken: string,
+  reissueAuthTokens: ReissueAuthTokens,
+) {
+  reissueTokensRequest ??= reissueAuthTokens(refreshToken).finally(() => {
+    reissueTokensRequest = null;
+  });
+
+  return reissueTokensRequest;
+}
+
+export function getUsableRotatedAccessToken(previousRefreshToken: string) {
+  const latestAccessToken = getAccessToken();
+  const latestRefreshToken = getRefreshToken();
+
+  if (
+    latestAccessToken &&
+    latestRefreshToken &&
+    latestRefreshToken !== previousRefreshToken &&
+    !shouldRefreshAccessToken(latestAccessToken)
+  ) {
+    return latestAccessToken;
+  }
+
+  return null;
+}
+
+export function hasUsableRotatedTokens(previousRefreshToken: string) {
+  return !!getUsableRotatedAccessToken(previousRefreshToken);
+}

--- a/apps/fe/src/lib/axios.ts
+++ b/apps/fe/src/lib/axios.ts
@@ -5,18 +5,18 @@ import {
   getAccessToken,
   getRefreshToken,
   setAuthTokens,
-  shouldRefreshAccessToken,
-  type AuthTokens,
 } from './auth';
 import { getApiBaseUrl } from './apiBaseUrl';
+import {
+  getSharedReissuedAuthTokens,
+  getUsableRotatedAccessToken,
+} from './authTokenRefresh';
 
 const API_BASE_URL = getApiBaseUrl();
 
 type AuthRetryRequestConfig = InternalAxiosRequestConfig & {
   _authRetry?: boolean;
 };
-
-let reissueTokensRequest: Promise<AuthTokens> | null = null;
 
 const instance = axios.create({
   baseURL: API_BASE_URL,
@@ -35,30 +35,6 @@ instance.interceptors.request.use((config) => {
 
   return config;
 });
-
-function getReissuedAuthTokens(refreshToken: string) {
-  reissueTokensRequest ??= reissueAuthTokens(refreshToken).finally(() => {
-    reissueTokensRequest = null;
-  });
-
-  return reissueTokensRequest;
-}
-
-function getUsableRotatedAccessToken(previousRefreshToken: string) {
-  const latestAccessToken = getAccessToken();
-  const latestRefreshToken = getRefreshToken();
-
-  if (
-    latestAccessToken &&
-    latestRefreshToken &&
-    latestRefreshToken !== previousRefreshToken &&
-    !shouldRefreshAccessToken(latestAccessToken)
-  ) {
-    return latestAccessToken;
-  }
-
-  return null;
-}
 
 instance.interceptors.response.use(
   (response) => response,
@@ -83,7 +59,10 @@ instance.interceptors.response.use(
     originalRequest._authRetry = true;
 
     try {
-      const nextTokens = await getReissuedAuthTokens(refreshToken);
+      const nextTokens = await getSharedReissuedAuthTokens(
+        refreshToken,
+        reissueAuthTokens,
+      );
       setAuthTokens(nextTokens);
       originalRequest.headers.Authorization = `Bearer ${nextTokens.accessToken}`;
       return instance(originalRequest);


### PR DESCRIPTION
## 요약
- auth lifecycle 정책과 token refresh helper를 순수 모듈 중심으로 응집합니다.

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `yarn test`
  - `yarn lint`
  - `NEXT_PUBLIC_API_URL=https://api-stg.asklogue.co yarn build`

## 스크린샷/로그 (선택)
- 해당 없음

## 롤백/리스크
- 리스크 요인: 로그인/토큰 복원/redirect 경로의 회귀 가능성
- 롤백 방법: 본 PR revert

## 관련 이슈
Closes #390

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * 인증 토큰 재발급 시 중복 요청 방지 및 회전된 토큰 재사용 로직 개선으로 안정성 향상

* **Refactor**
  * 인증 라우팅 결정 로직을 새로운 유틸리티 기반으로 정리하여 유지보수성 개선

* **Tests**
  * 인증 세션 관리 및 토큰 갱신 기능에 대한 테스트 커버리지 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->