### PR TITLE
refactor: 데이터 소스 리팩토링 백로그 정리

### DIFF
--- a/apps/fe/src/app/(main)/analysis/[id]/_components/DataPreviewPanel.tsx
+++ b/apps/fe/src/app/(main)/analysis/[id]/_components/DataPreviewPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import {
-  DataSourcePreviewTable,
+  DataSourceAnalysisPreviewTable,
   type DataSourcePreviewTableModel,
 } from '@/features/dataSource';
 import LoadingDataPreview from './LoadingDataPreview';
@@ -20,7 +20,7 @@ export default function DataPreviewPanel({
   table,
 }: DataPreviewPanelProps) {
   if (table) {
-    return <DataSourcePreviewTable table={table} variant="analysis" />;
+    return <DataSourceAnalysisPreviewTable table={table} />;
   }
 
   if (isLoading) {

--- a/apps/fe/src/app/(main)/data/[id]/_components/DataDetailView.tsx
+++ b/apps/fe/src/app/(main)/data/[id]/_components/DataDetailView.tsx
@@ -1,7 +1,10 @@
 'use client';
 
-import { ConfirmModal } from '@/components';
-import type { GetFileResponse } from '@/features/dataSource';
+import {
+  DeleteConfirmModal,
+  type GetFileResponse,
+} from '@/features/dataSource';
+import { DATA_SOURCE_MESSAGES } from '@/constants/messages';
 import { formatDateTime } from '@/lib/dateTime';
 import { formatFileSize } from '@/lib/fileValidation';
 import DataChartCard from '../../_components/DataChartCard';
@@ -15,8 +18,6 @@ type DataDetailViewProps = {
   onDeleteClose: () => void;
   onDeleteConfirm: () => void;
 };
-
-const DELETE_ILLUST_SRC = '/illusts/delete.svg';
 
 export default function DataDetailView({
   deleteOpen,
@@ -38,27 +39,13 @@ export default function DataDetailView({
         onDelete={onDelete}
       />
 
-      <ConfirmModal
+      <DeleteConfirmModal
         open={deleteOpen}
         onClose={onDeleteClose}
         onConfirm={onDeleteConfirm}
-        title="파일을 삭제하시겠어요?"
-        description="삭제 후에는 복구할 수 없어요."
-        confirmLabel={deletePending ? '삭제 중' : '삭제하기'}
-        cancelLabel="취소하기"
-        confirmDisabled={deletePending}
-        cancelDisabled={deletePending}
-        icon={
-          <>
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src={DELETE_ILLUST_SRC}
-              alt=""
-              aria-hidden
-              className="h-[8rem] w-auto"
-            />
-          </>
-        }
+        isPending={deletePending}
+        pendingConfirmLabel={DATA_SOURCE_MESSAGES.deletePendingLabel}
+        cancelDisabledOnPending
       />
     </main>
   );

--- a/apps/fe/src/app/(main)/data/[id]/page.tsx
+++ b/apps/fe/src/app/(main)/data/[id]/page.tsx
@@ -31,7 +31,7 @@ export default function DataDetailPage({
   const isDeletedMockDataSource =
     mockDataSource.isDeletedDataSource(dataSourceId);
   const dataDetail = useDataDetail({
-    dataSourceId: isValidDataSourceId ? dataSourceId : 0,
+    dataSourceId: isValidDataSourceId ? dataSourceId : null,
     enabled: isAuthenticated && isValidDataSourceId && !isDeletedMockDataSource,
   });
   const deleteDataSourcesMutation = useDeleteDataSources({

--- a/apps/fe/src/app/(main)/data/_components/DataChartCard.tsx
+++ b/apps/fe/src/app/(main)/data/_components/DataChartCard.tsx
@@ -3,7 +3,7 @@
 import ChatIcon from '@/assets/icons/chat.svg';
 import TrashIcon from '@/assets/icons/trash.svg';
 import {
-  DataSourcePreviewTable,
+  DataSourceDetailPreviewTable,
   type FilePreview,
 } from '@/features/dataSource';
 
@@ -61,7 +61,7 @@ export default function DataChartCard({
         </div>
       </div>
 
-      <DataSourcePreviewTable preview={preview} />
+      <DataSourceDetailPreviewTable preview={preview} />
     </div>
   );
 }

--- a/apps/fe/src/app/(main)/data/page.tsx
+++ b/apps/fe/src/app/(main)/data/page.tsx
@@ -2,9 +2,13 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { ConfirmModal, FileUploadModal, ToastPortal } from '@/components';
+import { FileUploadModal, ToastPortal } from '@/components';
 import { AUTH_MESSAGES, DATA_SOURCE_MESSAGES } from '@/constants/messages';
-import type { DataSourceSummary, DataSourceSort } from '@/features/dataSource';
+import {
+  DeleteConfirmModal,
+  type DataSourceSummary,
+  type DataSourceSort,
+} from '@/features/dataSource';
 import { useStartAnalysis } from '@/hooks/useStartAnalysis';
 import { useToast } from '@/hooks/useToast';
 import { validateCsvFile } from '@/lib/fileValidation';
@@ -16,8 +20,6 @@ import { useDataSourceUserContext } from '@/features/dataSource/hooks/useDataSou
 import { useDeleteDataSources } from '@/features/dataSource/hooks/useDeleteDataSources';
 import { useUploadDataSource } from '@/features/dataSource/hooks/useUploadDataSource';
 import { getTableMessage } from '@/features/dataSource/utils/tableMessage';
-
-const DELETE_ILLUST_SRC = '/illusts/delete.svg';
 
 const SORT_OPTIONS = [
   { value: 'MOST_USED', label: '사용량 많은 순' },
@@ -176,26 +178,11 @@ export default function DataPage() {
         onUpload={uploadDataSourceMutation.upload}
       />
 
-      <ConfirmModal
+      <DeleteConfirmModal
         open={deleteOpen}
         onClose={() => setDeleteOpen(false)}
         onConfirm={() => void handleDeleteConfirm()}
-        title={DATA_SOURCE_MESSAGES.deleteTitle}
-        description={DATA_SOURCE_MESSAGES.deleteDescription}
-        confirmLabel={DATA_SOURCE_MESSAGES.deleteConfirmLabel}
-        cancelLabel={DATA_SOURCE_MESSAGES.deleteCancelLabel}
-        confirmDisabled={deleteDataSourcesMutation.isPending}
-        icon={
-          <>
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src={DELETE_ILLUST_SRC}
-              alt=""
-              aria-hidden
-              className="h-[8rem] w-auto"
-            />
-          </>
-        }
+        isPending={deleteDataSourcesMutation.isPending}
       />
 
       <ToastPortal toast={toast} />

--- a/apps/fe/src/constants/messages.ts
+++ b/apps/fe/src/constants/messages.ts
@@ -18,6 +18,7 @@ export const DATA_SOURCE_MESSAGES = {
   deleteTitle: '파일을 삭제하시겠어요?',
   deleteDescription: '삭제 후엔 복구할 수 없어요.',
   deleteConfirmLabel: '삭제하기',
+  deletePendingLabel: '삭제 중',
   deleteCancelLabel: '취소하기',
   fileValidation: {
     invalidType: '파일 형식이 맞지 않습니다.',

--- a/apps/fe/src/features/analysis/hooks/useAnalysisDataPreview.ts
+++ b/apps/fe/src/features/analysis/hooks/useAnalysisDataPreview.ts
@@ -1,34 +1,21 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
 import { getApiErrorMessage } from '@/apis/errors';
-import {
-  createDataSourcePreviewTableModel,
-  dataSourceKeys,
-  getDataSource,
-} from '@/features/dataSource';
+import { createDataSourcePreviewTableModel } from '@/features/dataSource';
+import { useDataSourceDetail } from '@/features/dataSource/hooks/useDataSourceDetail';
 
 type UseAnalysisDataPreviewParams = {
   dataSourceId: number | null;
   enabled: boolean;
   errorMessage: string;
-  invalidRouteMessage: string;
 };
 
 export function useAnalysisDataPreview({
   dataSourceId,
   enabled,
   errorMessage,
-  invalidRouteMessage,
 }: UseAnalysisDataPreviewParams) {
-  const dataSourceQuery = useQuery({
-    queryKey: dataSourceKeys.detail(dataSourceId ?? 0),
-    queryFn: () => {
-      if (dataSourceId === null) throw new Error(invalidRouteMessage);
-      return getDataSource(dataSourceId);
-    },
-    enabled: enabled && dataSourceId !== null,
-  });
+  const dataSourceQuery = useDataSourceDetail(dataSourceId, { enabled });
   const previewTable = createDataSourcePreviewTableModel(
     dataSourceQuery.data?.preview,
   );

--- a/apps/fe/src/features/analysis/hooks/useAnalysisPageData.ts
+++ b/apps/fe/src/features/analysis/hooks/useAnalysisPageData.ts
@@ -71,7 +71,6 @@ export function useAnalysisPageData({
     dataSourceId,
     enabled: hasAccessToken,
     errorMessage: ANALYSIS_WORKFLOW_MESSAGES.dataSource.getError,
-    invalidRouteMessage: ANALYSIS_WORKFLOW_MESSAGES.invalidRoute,
   });
 
   return {

--- a/apps/fe/src/features/dataSource/DataSourcePreviewTable.tsx
+++ b/apps/fe/src/features/dataSource/DataSourcePreviewTable.tsx
@@ -6,15 +6,31 @@ import {
 } from './previewTable';
 import type { FilePreview } from './types';
 
-type DataSourcePreviewTableVariant = 'detail' | 'analysis';
+type DataSourcePreviewTableBaseProps = {
+  bodyWrapperClassName?: string;
+  cellClassName: string;
+  headerClassName: string;
+  headerRowClassName?: string;
+  rowClassName: string;
+  rowEmptyMessage: string;
+  showCellTitle?: boolean;
+  table: DataSourcePreviewTableModel;
+  theadClassName?: string;
+};
 
-type DataSourcePreviewTableProps = {
+type DataSourceDetailPreviewTableProps = {
   emptyMessage?: string;
   preview?: FilePreview | null;
   rowEmptyMessage?: string;
   table?: DataSourcePreviewTableModel | null;
   title?: string;
-  variant?: DataSourcePreviewTableVariant;
+};
+
+type DataSourceAnalysisPreviewTableProps = {
+  emptyMessage?: string;
+  preview?: FilePreview | null;
+  rowEmptyMessage?: string;
+  table?: DataSourcePreviewTableModel | null;
 };
 
 const DEFAULT_EMPTY_MESSAGE =
@@ -23,109 +39,126 @@ const DEFAULT_ROW_EMPTY_MESSAGE =
   '\uD45C\uC2DC\uD560 \uD589\uC774 \uC5C6\uC2B5\uB2C8\uB2E4.';
 const DEFAULT_TITLE = 'CSV \uBBF8\uB9AC\uBCF4\uAE30';
 
-function getContainerClassName(variant: DataSourcePreviewTableVariant) {
-  return variant === 'analysis'
-    ? 'scrollbar-hide h-full overflow-auto'
-    : 'min-h-0 flex-1 overflow-hidden rounded-8 border border-gray-300 bg-white';
+function DataSourcePreviewTableBase({
+  bodyWrapperClassName,
+  cellClassName,
+  headerClassName,
+  headerRowClassName,
+  rowClassName,
+  rowEmptyMessage,
+  showCellTitle = false,
+  table,
+  theadClassName,
+}: DataSourcePreviewTableBaseProps) {
+  return (
+    <div className={bodyWrapperClassName}>
+      <table className="min-w-full border-collapse text-body4">
+        <thead className={theadClassName}>
+          <tr className={headerRowClassName}>
+            {table.columns.map((column) => (
+              <th key={column.key} className={headerClassName}>
+                {column.label}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {table.rows.length === 0 ? (
+            <tr>
+              <td
+                colSpan={table.columns.length}
+                className="px-16 py-32 text-center text-gray-600"
+              >
+                {rowEmptyMessage}
+              </td>
+            </tr>
+          ) : (
+            table.rows.map((row, rowIndex) => (
+              <tr key={rowIndex} className={rowClassName}>
+                {table.columns.map((column) => {
+                  const cell = row[column.key] || '-';
+
+                  return (
+                    <td
+                      key={column.key}
+                      className={cellClassName}
+                      title={showCellTitle ? cell : undefined}
+                    >
+                      {cell}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
 }
 
-function getHeaderClassName(variant: DataSourcePreviewTableVariant) {
-  return variant === 'analysis'
-    ? 'border-b border-gray-300 bg-orange-100 px-16 py-12 text-left font-medium whitespace-nowrap text-gray-900'
-    : 'whitespace-nowrap border-b border-gray-200 px-16 py-12 text-left font-semibold';
-}
-
-function getCellClassName(variant: DataSourcePreviewTableVariant) {
-  return variant === 'analysis'
-    ? 'px-16 py-12 whitespace-nowrap text-gray-800'
-    : 'max-w-[24rem] truncate whitespace-nowrap px-16 py-12 text-gray-800';
-}
-
-function getBodyWrapperClassName(variant: DataSourcePreviewTableVariant) {
-  return variant === 'analysis' ? '' : 'max-h-[42rem] overflow-auto';
-}
-
-function getEmptyClassName(variant: DataSourcePreviewTableVariant) {
-  return variant === 'analysis'
-    ? 'flex h-full items-center justify-center text-body3 text-gray-600'
-    : 'flex min-h-[28rem] flex-1 items-center justify-center rounded-8 border border-gray-300 bg-white text-body3 text-gray-600';
-}
-
-export default function DataSourcePreviewTable({
+export function DataSourceDetailPreviewTable({
   emptyMessage = DEFAULT_EMPTY_MESSAGE,
   preview,
   rowEmptyMessage = DEFAULT_ROW_EMPTY_MESSAGE,
   table,
   title = DEFAULT_TITLE,
-  variant = 'detail',
-}: DataSourcePreviewTableProps) {
+}: DataSourceDetailPreviewTableProps) {
   const tableModel = table ?? createDataSourcePreviewTableModel(preview);
 
   if (!tableModel) {
-    return <div className={getEmptyClassName(variant)}>{emptyMessage}</div>;
+    return (
+      <div className="flex min-h-[28rem] flex-1 items-center justify-center rounded-8 border border-gray-300 bg-white text-body3 text-gray-600">
+        {emptyMessage}
+      </div>
+    );
   }
 
   return (
-    <div className={getContainerClassName(variant)}>
-      {variant === 'detail' && (
-        <div className="border-b border-gray-200 bg-gray-100 px-16 py-12">
-          <p className="text-body3 font-semibold text-gray-900">{title}</p>
-        </div>
-      )}
-      <div className={getBodyWrapperClassName(variant)}>
-        <table className="min-w-full border-collapse text-body4">
-          <thead className={variant === 'analysis' ? 'sticky top-0 z-10' : ''}>
-            <tr
-              className={
-                variant === 'analysis' ? undefined : 'bg-white text-gray-900'
-              }
-            >
-              {tableModel.columns.map((column) => (
-                <th key={column.key} className={getHeaderClassName(variant)}>
-                  {column.label}
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {tableModel.rows.length === 0 ? (
-              <tr>
-                <td
-                  colSpan={tableModel.columns.length}
-                  className="px-16 py-32 text-center text-gray-600"
-                >
-                  {rowEmptyMessage}
-                </td>
-              </tr>
-            ) : (
-              tableModel.rows.map((row, rowIndex) => (
-                <tr
-                  key={rowIndex}
-                  className={
-                    variant === 'analysis'
-                      ? 'border-b border-gray-200 transition-colors hover:bg-orange-50'
-                      : 'border-b border-gray-100'
-                  }
-                >
-                  {tableModel.columns.map((column) => {
-                    const cell = row[column.key] || '-';
-
-                    return (
-                      <td
-                        key={column.key}
-                        className={getCellClassName(variant)}
-                        title={variant === 'detail' ? cell : undefined}
-                      >
-                        {cell}
-                      </td>
-                    );
-                  })}
-                </tr>
-              ))
-            )}
-          </tbody>
-        </table>
+    <div className="min-h-0 flex-1 overflow-hidden rounded-8 border border-gray-300 bg-white">
+      <div className="border-b border-gray-200 bg-gray-100 px-16 py-12">
+        <p className="text-body3 font-semibold text-gray-900">{title}</p>
       </div>
+      <DataSourcePreviewTableBase
+        table={tableModel}
+        bodyWrapperClassName="max-h-[42rem] overflow-auto"
+        headerClassName="whitespace-nowrap border-b border-gray-200 px-16 py-12 text-left font-semibold"
+        headerRowClassName="bg-white text-gray-900"
+        cellClassName="max-w-[24rem] truncate whitespace-nowrap px-16 py-12 text-gray-800"
+        rowClassName="border-b border-gray-100"
+        rowEmptyMessage={rowEmptyMessage}
+        showCellTitle
+      />
+    </div>
+  );
+}
+
+export function DataSourceAnalysisPreviewTable({
+  emptyMessage = DEFAULT_EMPTY_MESSAGE,
+  preview,
+  rowEmptyMessage = DEFAULT_ROW_EMPTY_MESSAGE,
+  table,
+}: DataSourceAnalysisPreviewTableProps) {
+  const tableModel = table ?? createDataSourcePreviewTableModel(preview);
+
+  if (!tableModel) {
+    return (
+      <div className="flex h-full items-center justify-center text-body3 text-gray-600">
+        {emptyMessage}
+      </div>
+    );
+  }
+
+  return (
+    <div className="scrollbar-hide h-full overflow-auto">
+      <DataSourcePreviewTableBase
+        table={tableModel}
+        theadClassName="sticky top-0 z-10"
+        headerClassName="border-b border-gray-300 bg-orange-100 px-16 py-12 text-left font-medium whitespace-nowrap text-gray-900"
+        cellClassName="px-16 py-12 whitespace-nowrap text-gray-800"
+        rowClassName="border-b border-gray-200 transition-colors hover:bg-orange-50"
+        rowEmptyMessage={rowEmptyMessage}
+      />
     </div>
   );
 }

--- a/apps/fe/src/features/dataSource/DeleteConfirmModal.tsx
+++ b/apps/fe/src/features/dataSource/DeleteConfirmModal.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { ConfirmModal } from '@/components';
+import { DATA_SOURCE_MESSAGES } from '@/constants/messages';
+
+const DELETE_ILLUST_SRC = '/illusts/delete.svg';
+
+export type DeleteConfirmModalProps = {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  isPending: boolean;
+  cancelDisabledOnPending?: boolean;
+  title?: string;
+  description?: string;
+  confirmLabel?: string;
+  pendingConfirmLabel?: string;
+  cancelLabel?: string;
+};
+
+export default function DeleteConfirmModal({
+  open,
+  onClose,
+  onConfirm,
+  isPending,
+  cancelDisabledOnPending = false,
+  title = DATA_SOURCE_MESSAGES.deleteTitle,
+  description = DATA_SOURCE_MESSAGES.deleteDescription,
+  confirmLabel = DATA_SOURCE_MESSAGES.deleteConfirmLabel,
+  pendingConfirmLabel = confirmLabel,
+  cancelLabel = DATA_SOURCE_MESSAGES.deleteCancelLabel,
+}: DeleteConfirmModalProps) {
+  return (
+    <ConfirmModal
+      open={open}
+      onClose={onClose}
+      onConfirm={onConfirm}
+      title={title}
+      description={description}
+      confirmLabel={isPending ? pendingConfirmLabel : confirmLabel}
+      cancelLabel={cancelLabel}
+      confirmDisabled={isPending}
+      cancelDisabled={cancelDisabledOnPending && isPending}
+      icon={
+        <>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={DELETE_ILLUST_SRC}
+            alt=""
+            aria-hidden
+            className="h-[8rem] w-auto"
+          />
+        </>
+      }
+    />
+  );
+}

--- a/apps/fe/src/features/dataSource/DeleteConfirmModal.tsx
+++ b/apps/fe/src/features/dataSource/DeleteConfirmModal.tsx
@@ -27,7 +27,7 @@ export default function DeleteConfirmModal({
   title = DATA_SOURCE_MESSAGES.deleteTitle,
   description = DATA_SOURCE_MESSAGES.deleteDescription,
   confirmLabel = DATA_SOURCE_MESSAGES.deleteConfirmLabel,
-  pendingConfirmLabel = confirmLabel,
+  pendingConfirmLabel = DATA_SOURCE_MESSAGES.deletePendingLabel,
   cancelLabel = DATA_SOURCE_MESSAGES.deleteCancelLabel,
 }: DeleteConfirmModalProps) {
   return (

--- a/apps/fe/src/features/dataSource/dataSourceRepository.test.ts
+++ b/apps/fe/src/features/dataSource/dataSourceRepository.test.ts
@@ -39,10 +39,37 @@ describe('dataSourceRepository', () => {
     });
   });
 
-  it('passes only server data source ids to the raw multi-delete API', async () => {
+  it('deletes server data source ids through the raw multi-delete API', async () => {
     vi.mocked(dataSourceApi.deleteDataSources).mockResolvedValue(undefined);
 
-    await deleteDataSources([1, MOCK_MARKETING_CVR_DATA_SOURCE_ID, 2]);
+    await expect(deleteDataSources([1, 2])).resolves.toEqual({
+      deletedMockDataSourceIds: [],
+      deletedServerDataSourceIds: [1, 2],
+    });
+
+    expect(dataSourceApi.deleteDataSources).toHaveBeenCalledWith([1, 2]);
+  });
+
+  it('deletes mock data source ids without calling the raw multi-delete API', async () => {
+    await expect(
+      deleteDataSources([MOCK_MARKETING_CVR_DATA_SOURCE_ID]),
+    ).resolves.toEqual({
+      deletedMockDataSourceIds: [MOCK_MARKETING_CVR_DATA_SOURCE_ID],
+      deletedServerDataSourceIds: [],
+    });
+
+    expect(dataSourceApi.deleteDataSources).not.toHaveBeenCalled();
+  });
+
+  it('returns server and mock data source ids after a mixed delete', async () => {
+    vi.mocked(dataSourceApi.deleteDataSources).mockResolvedValue(undefined);
+
+    await expect(
+      deleteDataSources([1, MOCK_MARKETING_CVR_DATA_SOURCE_ID, 2]),
+    ).resolves.toEqual({
+      deletedMockDataSourceIds: [MOCK_MARKETING_CVR_DATA_SOURCE_ID],
+      deletedServerDataSourceIds: [1, 2],
+    });
 
     expect(dataSourceApi.deleteDataSources).toHaveBeenCalledWith([1, 2]);
   });

--- a/apps/fe/src/features/dataSource/dataSourceRepository.ts
+++ b/apps/fe/src/features/dataSource/dataSourceRepository.ts
@@ -7,12 +7,18 @@ import {
 } from '@/apis/datasource';
 import {
   getMockDataSource,
+  getMockDataSourceIds,
   getMockDataSourceListResponse,
   getServerDataSourceIds,
   isMockDataSourceId,
   withMockDataSource,
 } from '@/features/mockDataSource';
 import type { GetDataSourceListParams, GetFileResponse } from './types';
+
+export type DeleteDataSourcesResult = {
+  deletedMockDataSourceIds: number[];
+  deletedServerDataSourceIds: number[];
+};
 
 type DataSourceDetailReader = (
   dataSourceId: number,
@@ -34,10 +40,16 @@ async function deleteMockAwareDataSources(
   deleteDataSources: DataSourcesDeleteRequest,
 ) {
   const serverDataSourceIds = getServerDataSourceIds(dataSourceIds);
+  const mockDataSourceIds = getMockDataSourceIds(dataSourceIds);
 
-  if (serverDataSourceIds.length === 0) return;
+  if (serverDataSourceIds.length > 0) {
+    await deleteDataSources(serverDataSourceIds);
+  }
 
-  return deleteDataSources(serverDataSourceIds);
+  return {
+    deletedMockDataSourceIds: mockDataSourceIds,
+    deletedServerDataSourceIds: serverDataSourceIds,
+  } satisfies DeleteDataSourcesResult;
 }
 
 async function deleteMockAwareDataSource(

--- a/apps/fe/src/features/dataSource/hooks/useDataDetail.ts
+++ b/apps/fe/src/features/dataSource/hooks/useDataDetail.ts
@@ -1,19 +1,14 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
-import { dataSourceKeys, getDataSource } from '@/features/dataSource';
+import { useDataSourceDetail } from './useDataSourceDetail';
 
 type UseDataDetailParams = {
-  dataSourceId: number;
+  dataSourceId: number | null;
   enabled: boolean;
 };
 
 export function useDataDetail({ dataSourceId, enabled }: UseDataDetailParams) {
-  const detailQuery = useQuery({
-    queryKey: dataSourceKeys.detail(dataSourceId),
-    queryFn: () => getDataSource(dataSourceId),
-    enabled,
-  });
+  const detailQuery = useDataSourceDetail(dataSourceId, { enabled });
 
   return {
     detail: detailQuery.data,

--- a/apps/fe/src/features/dataSource/hooks/useDataSourceDetail.ts
+++ b/apps/fe/src/features/dataSource/hooks/useDataSourceDetail.ts
@@ -1,0 +1,25 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { dataSourceKeys, getDataSource } from '@/features/dataSource';
+
+type UseDataSourceDetailOptions = {
+  enabled?: boolean;
+};
+
+export function useDataSourceDetail(
+  dataSourceId: number | null,
+  { enabled = true }: UseDataSourceDetailOptions = {},
+) {
+  return useQuery({
+    queryKey: dataSourceKeys.detail(dataSourceId ?? 0),
+    queryFn: () => {
+      if (dataSourceId === null) {
+        throw new Error('Data source id is required.');
+      }
+
+      return getDataSource(dataSourceId);
+    },
+    enabled: enabled && dataSourceId !== null,
+  });
+}

--- a/apps/fe/src/features/dataSource/hooks/useDeleteDataSources.ts
+++ b/apps/fe/src/features/dataSource/hooks/useDeleteDataSources.ts
@@ -12,7 +12,7 @@ type UseDeleteDataSourcesOptions = {
   fallbackErrorMessage: string;
   mockDataSource: Pick<
     MockDataSourceManager,
-    'getDeletionPlan' | 'markDeletedDataSources'
+    'canPersistDeletedDataSources' | 'markDeletedDataSources'
   >;
   onError: (message: string) => void;
   onSuccess: () => void;
@@ -34,20 +34,18 @@ export function useDeleteDataSources({
     async (dataSourceIds: number[]) => {
       if (dataSourceIds.length === 0) return;
 
-      const deletionPlan = mockDataSource.getDeletionPlan(dataSourceIds);
-
-      if (deletionPlan.requiresUser) {
+      if (!mockDataSource.canPersistDeletedDataSources(dataSourceIds)) {
         onError(AUTH_MESSAGES.userInfoRequired);
         return;
       }
 
       try {
-        if (deletionPlan.serverDataSourceIds.length > 0) {
-          await mutation.mutateAsync(deletionPlan.serverDataSourceIds);
-        }
+        const result = await mutation.mutateAsync(dataSourceIds);
 
-        if (deletionPlan.mockDataSourceIds.length > 0) {
-          mockDataSource.markDeletedDataSources(deletionPlan.mockDataSourceIds);
+        if (result.deletedMockDataSourceIds.length > 0) {
+          mockDataSource.markDeletedDataSources(
+            result.deletedMockDataSourceIds,
+          );
         }
 
         await queryClient.invalidateQueries({

--- a/apps/fe/src/features/dataSource/index.ts
+++ b/apps/fe/src/features/dataSource/index.ts
@@ -1,4 +1,9 @@
-export { default as DataSourcePreviewTable } from './DataSourcePreviewTable';
+export { default as DeleteConfirmModal } from './DeleteConfirmModal';
+export type { DeleteConfirmModalProps } from './DeleteConfirmModal';
+export {
+  DataSourceAnalysisPreviewTable,
+  DataSourceDetailPreviewTable,
+} from './DataSourcePreviewTable';
 export {
   deleteDataSource,
   deleteDataSources,
@@ -6,6 +11,8 @@ export {
   getDataSources,
   uploadDataSource,
 } from './dataSourceRepository';
+export type { DeleteDataSourcesResult } from './dataSourceRepository';
+export { useDataSourceDetail } from './hooks/useDataSourceDetail';
 export {
   createDataSourcePreviewTableModel,
   type DataSourcePreviewColumn,

--- a/apps/fe/src/features/mockDataSource/index.ts
+++ b/apps/fe/src/features/mockDataSource/index.ts
@@ -2,6 +2,7 @@ export {
   MOCK_MARKETING_CVR_DATA_SOURCE_ID,
   getDeletedMockDataSourceStorageKey,
   getMockDataSource,
+  getMockDataSourceIds,
   getMockDataSourceListResponse,
   getServerDataSourceIds,
   isMockDataSourceId,
@@ -11,6 +12,5 @@ export {
 } from './mockDataSource';
 export {
   useMockDataSourceManager,
-  type MockDataSourceDeletionPlan,
   type MockDataSourceManager,
 } from './useMockDataSourceManager';

--- a/apps/fe/src/features/mockDataSource/useMockDataSourceManager.ts
+++ b/apps/fe/src/features/mockDataSource/useMockDataSourceManager.ts
@@ -6,19 +6,12 @@ import {
   filterVisibleMockDataSources,
   getMockDataSourceIds,
   getMockDataSourceListResponse,
-  getServerDataSourceIds,
   isMockDataSourceId,
   markMockDataSourcesDeleted,
   readDeletedMockDataSourceIds,
 } from './mockDataSource';
 
 const EMPTY_DELETED_IDS = new Set<number>();
-
-export type MockDataSourceDeletionPlan = {
-  mockDataSourceIds: number[];
-  requiresUser: boolean;
-  serverDataSourceIds: number[];
-};
 
 export function useMockDataSourceManager(userId: number | null | undefined) {
   const [sessionDeletedIdsByUser, setSessionDeletedIdsByUser] = useState(
@@ -46,16 +39,9 @@ export function useMockDataSourceManager(userId: number | null | undefined) {
     return deletedIds;
   }, [sessionDeletedIds, storageDeletedIds]);
 
-  const getDeletionPlan = useCallback(
-    (dataSourceIds: number[]): MockDataSourceDeletionPlan => {
-      const mockDataSourceIds = getMockDataSourceIds(dataSourceIds);
-
-      return {
-        mockDataSourceIds,
-        requiresUser: mockDataSourceIds.length > 0 && userId == null,
-        serverDataSourceIds: getServerDataSourceIds(dataSourceIds),
-      };
-    },
+  const canPersistDeletedDataSources = useCallback(
+    (dataSourceIds: number[]) =>
+      getMockDataSourceIds(dataSourceIds).length === 0 || userId != null,
     [userId],
   );
 
@@ -99,16 +85,16 @@ export function useMockDataSourceManager(userId: number | null | undefined) {
 
   return useMemo(
     () => ({
+      canPersistDeletedDataSources,
       deletedDataSourceIds,
-      getDeletionPlan,
       getFallbackListResponse: getMockDataSourceListResponse,
       getVisibleDataSources,
       isDeletedDataSource,
       markDeletedDataSources,
     }),
     [
+      canPersistDeletedDataSources,
       deletedDataSourceIds,
-      getDeletionPlan,
       getVisibleDataSources,
       isDeletedDataSource,
       markDeletedDataSources,


### PR DESCRIPTION
## 작업 내용
- 데이터 소스 삭제 확인 모달을 도메인 합성 컴포넌트로 분리했습니다.
- mock/server 데이터소스 삭제 분기 책임을 repository 결과 중심으로 정리했습니다.
- 데이터소스 상세 쿼리 공통 훅을 추가하고 화면별 파생 상태만 각 훅에서 계산하도록 변경했습니다.
- preview table의 variant 분기를 detail/analysis 전용 컴포넌트로 분리했습니다.

## 검증
- vitest run --project unit (Codex bundled Node로 실행): 20 files, 105 tests passed
- eslint . (Codex bundled Node로 실행): passed

Closes #397

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * 삭제 확인 모달의 대기 상태 처리 개선

* **개선 사항**
  * 데이터 미리보기 테이블 컴포넌트 구조 최적화
  * 모의 데이터 소스와 서버 데이터 소스의 삭제 처리 개선
  * 데이터 상세 조회 시 null 값 처리 강화

* **테스트**
  * 데이터 소스 삭제 기능 테스트 케이스 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->