### PR TITLE
fix(ai): 동일 role(FLAG/STATUS_CONDITION) 중복 시 QUESTION_DATA_MISMATCH 결정론 추론 (#406)

### DIFF
--- a/apps/ai/rules/warning_rules.py
+++ b/apps/ai/rules/warning_rules.py
@@ -119,6 +119,52 @@ def infer_date_conflict_warning(
     ]
 
 
+def infer_qdm_warning(
+    response: QuestionAnalysisResponse,
+    request: QuestionAnalysisRequest,
+) -> list[FlowWarning]:
+    """데이터 기반으로 QUESTION_DATA_MISMATCH warning 을 결정론적으로 추론한다.
+
+    FLAG 또는 STATUS_CONDITION role 의 컬럼이 동일 role 에서 2개 이상이면
+    질문-데이터 매핑이 모호하므로 QUESTION_DATA_MISMATCH 를 반환한다.
+    DIMENSION/MEASURE 는 정상 데이터셋에서도 복수 존재하므로 제외한다.
+    catalog.flow_warning_keys 에 QUESTION_DATA_MISMATCH 가 정의돼 있지 않으면
+    추론하지 않는다.
+    """
+    if response.analysis_criteria is None:
+        return []
+
+    catalog_codes = {w.code for w in request.catalog.flow_warning_keys}
+    if FlowWarningKey.QUESTION_DATA_MISMATCH not in catalog_codes:
+        return []
+
+    target_roles = {SemanticRoleType.FLAG, SemanticRoleType.STATUS_CONDITION}
+
+    role_to_columns: dict[SemanticRoleType, list[str]] = {}
+    for col in request.data_source.columns:
+        if col.semantic_role in target_roles:
+            role_to_columns.setdefault(col.semantic_role, []).append(col.column_name)
+
+    related_fields: list[str] = []
+    for role in (SemanticRoleType.FLAG, SemanticRoleType.STATUS_CONDITION):
+        cols = role_to_columns.get(role, [])
+        if len(cols) >= 2:
+            for c in cols:
+                if c not in related_fields:
+                    related_fields.append(c)
+
+    if not related_fields:
+        return []
+
+    return [
+        FlowWarning(
+            code=FlowWarningKey.QUESTION_DATA_MISMATCH,
+            related_fields=related_fields,
+            detail="동일 의미 컬럼이 둘 이상이라 질문과 데이터 매핑이 모호합니다.",
+        )
+    ]
+
+
 def apply_inferred_warnings(
     response: QuestionAnalysisResponse,
     request: QuestionAnalysisRequest,
@@ -128,8 +174,10 @@ def apply_inferred_warnings(
     동일 code 가 이미 LLM 응답에 존재하면 기존 것을 유지하고 추가하지 않는다.
     """
     existing_codes = {w.code for w in response.warnings}
-    inferred = infer_data_warnings(response, request) + infer_date_conflict_warning(
-        response, request
+    inferred = (
+        infer_data_warnings(response, request)
+        + infer_date_conflict_warning(response, request)
+        + infer_qdm_warning(response, request)
     )
     for warning in inferred:
         if warning.code not in existing_codes:

--- a/apps/ai/tests/test_warning_inference.py
+++ b/apps/ai/tests/test_warning_inference.py
@@ -11,6 +11,7 @@ from rules.warning_rules import (
     apply_inferred_warnings,
     infer_data_warnings,
     infer_date_conflict_warning,
+    infer_qdm_warning,
 )
 from schemas.api.question_analysis import (
     AnalysisCriteria,
@@ -241,4 +242,141 @@ def test_apply_adds_date_conflict_warning() -> None:
     apply_inferred_warnings(response, _request_with_dates(date_count=2))
     assert any(
         w.code == FlowWarningKey.DATE_FIELD_CONFLICT for w in response.warnings
+    )
+
+
+# ---------- QUESTION_DATA_MISMATCH 추론 ----------
+
+
+def _request_with_roles(
+    *,
+    flag_count: int = 0,
+    status_count: int = 0,
+    with_qdm_key: bool = True,
+) -> QuestionAnalysisRequest:
+    """FLAG/STATUS_CONDITION 컬럼 수와 catalog 의 QUESTION_DATA_MISMATCH 정의 여부를 제어한다."""
+    columns: list[DataSourceColumn] = [
+        DataSourceColumn(
+            column_name="signed_at",
+            data_type="datetime",
+            semantic_role="DATE_CRITERIA",
+            null_ratio=0.0,
+            sample_values=[],
+        ),
+        DataSourceColumn(
+            column_name="channel",
+            data_type="string",
+            semantic_role="DIMENSION",
+            null_ratio=0.0,
+            sample_values=[],
+        ),
+        DataSourceColumn(
+            column_name="device",
+            data_type="string",
+            semantic_role="DIMENSION",
+            null_ratio=0.0,
+            sample_values=[],
+        ),
+    ]
+    for i in range(flag_count):
+        columns.append(
+            DataSourceColumn(
+                column_name=f"flag_{i}",
+                data_type="boolean",
+                semantic_role="FLAG",
+                null_ratio=0.0,
+                sample_values=[],
+            )
+        )
+    for i in range(status_count):
+        columns.append(
+            DataSourceColumn(
+                column_name=f"status_{i}",
+                data_type="string",
+                semantic_role="STATUS_CONDITION",
+                null_ratio=0.0,
+                sample_values=[],
+            )
+        )
+    for name in ("amount", "count", "revenue", "users", "orders"):
+        columns.append(
+            DataSourceColumn(
+                column_name=name,
+                data_type="double",
+                semantic_role="MEASURE",
+                null_ratio=0.0,
+                sample_values=[],
+            )
+        )
+    flow_warning_keys: list[FlowWarningKeyCatalog] = []
+    if with_qdm_key:
+        flow_warning_keys.append(
+            FlowWarningKeyCatalog(
+                code="QUESTION_DATA_MISMATCH", name="...", comment="...",
+            ),
+        )
+    return QuestionAnalysisRequest(
+        request_id="req_X",
+        conversation_id=1,
+        question=Question(content="?"),
+        data_source=DataSource(id=1, columns=columns),
+        catalog=Catalog(
+            analysis_types=["COMPARISON", "RANKING"],
+            metric_types=["RATIO"],
+            predefined_metrics=[
+                PredefinedMetric(
+                    metric_name="cr", display_name="전환율", metric_type="RATIO",
+                    formula_numerator="amount", formula_denominator="users",
+                ),
+            ],
+            supported_periods=["this_week", "last_week"],
+            flow_warning_keys=flow_warning_keys,
+        ),
+    )
+
+
+def test_two_flag_columns_infers_qdm() -> None:
+    warnings = infer_qdm_warning(
+        _response(_criteria()),
+        _request_with_roles(flag_count=2),
+    )
+    assert len(warnings) == 1
+    assert warnings[0].code == FlowWarningKey.QUESTION_DATA_MISMATCH
+    assert "flag_0" in (warnings[0].related_fields or [])
+    assert "flag_1" in (warnings[0].related_fields or [])
+
+
+def test_two_status_condition_columns_infers_qdm() -> None:
+    warnings = infer_qdm_warning(
+        _response(_criteria()),
+        _request_with_roles(status_count=2),
+    )
+    assert len(warnings) == 1
+    assert warnings[0].code == FlowWarningKey.QUESTION_DATA_MISMATCH
+    assert "status_0" in (warnings[0].related_fields or [])
+    assert "status_1" in (warnings[0].related_fields or [])
+
+
+def test_normal_request_no_qdm() -> None:
+    # 1 FLAG, 2 DIMENSION, 5 MEASURE: QDM 기준 미달, warning 없어야 함.
+    warnings = infer_qdm_warning(
+        _response(_criteria()),
+        _request_with_roles(flag_count=1),
+    )
+    assert warnings == []
+
+
+def test_catalog_without_qdm_key_returns_empty() -> None:
+    warnings = infer_qdm_warning(
+        _response(_criteria()),
+        _request_with_roles(flag_count=2, with_qdm_key=False),
+    )
+    assert warnings == []
+
+
+def test_apply_adds_qdm_warning() -> None:
+    response = _response(_criteria())
+    apply_inferred_warnings(response, _request_with_roles(flag_count=2))
+    assert any(
+        w.code == FlowWarningKey.QUESTION_DATA_MISMATCH for w in response.warnings
     )


### PR DESCRIPTION
## 요약
- 동일 의미 컬럼(FLAG 또는 STATUS_CONDITION)이 둘 이상일 때 QUESTION_DATA_MISMATCH 를 결정론적으로 추론하도록 후처리 규칙 추가

## 변경 사항
- [x] 버그 수정

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - cd apps/ai && python -m pytest tests/test_warning_inference.py -q

## 롤백/리스크
- 리스크 포인트: DIMENSION/MEASURE 중복은 정상 데이터셋에서 흔하므로 의도적으로 제외함
- 롤백 방법: 본 커밋 revert

## 관련 이슈
Closes #406