### PR TITLE
fix(ai): eval catalog dataset별 분리 및 formula 컬럼 부재 backstop 재도입 (#407)

### DIFF
--- a/apps/ai/eval/composers/question_analysis.py
+++ b/apps/ai/eval/composers/question_analysis.py
@@ -37,7 +37,12 @@ def compose_request(spec: dict[str, Any]) -> dict[str, Any]:
 
     columns = [_field_to_column(f) for f in dataset.get("fields", [])]
 
-    catalog = copy.deepcopy(load_fixture("catalog"))
+    suffix = dataset_id.rsplit("-", 1)[-1]
+    catalog_fixture = f"catalog-{suffix}"
+    try:
+        catalog = copy.deepcopy(load_fixture(catalog_fixture))
+    except FileNotFoundError:
+        catalog = copy.deepcopy(load_fixture("catalog"))
     for key, value in (spec.get("catalog_overrides") or {}).items():
         catalog[key] = value
 

--- a/apps/ai/eval/fixtures/catalog-b.json
+++ b/apps/ai/eval/fixtures/catalog-b.json
@@ -1,0 +1,16 @@
+{
+  "analysis_types": ["COMPARISON", "RANKING"],
+  "metric_types": ["RATIO"],
+  "predefined_metrics": [
+    {"metric_name": "signup_conversion_rate", "display_name": "가입 전환율", "metric_type": "RATIO", "formula_numerator": "signups", "formula_denominator": "visits"},
+    {"metric_name": "activation_rate", "display_name": "액티베이션율", "metric_type": "RATIO", "formula_numerator": "activated", "formula_denominator": "signups"},
+    {"metric_name": "trial_start_rate", "display_name": "트라이얼 시작율", "metric_type": "RATIO", "formula_numerator": "trial_starts", "formula_denominator": "activated"},
+    {"metric_name": "paid_conversion_rate", "display_name": "유료 전환율", "metric_type": "RATIO", "formula_numerator": "paid", "formula_denominator": "trial_starts"}
+  ],
+  "supported_periods": ["1W", "1M", "3M"],
+  "flow_warning_keys": [
+    {"code": "QUESTION_DATA_MISMATCH", "name": "질문/데이터 불일치", "comment": "질문에서 요구한 컬럼이 데이터에 없습니다."},
+    {"code": "CRITICAL_NULL_DETECTED", "name": "critical null", "comment": "분석 필요 컬럼의 null 비율이 임계값을 초과합니다."},
+    {"code": "DATE_FIELD_CONFLICT", "name": "기준 날짜 충돌", "comment": "DATE_CRITERIA 역할 컬럼이 둘 이상이라 기준 날짜가 결정되지 않습니다."}
+  ]
+}

--- a/apps/ai/rules/unsupported_backstop.py
+++ b/apps/ai/rules/unsupported_backstop.py
@@ -53,8 +53,9 @@ def detect_unsupported(
 
     reasons: list[str] = []
     # detected_intent 는 우선순위에 따라 첫 매칭 사유 1개만 채운다.
-    # (predefined-metric 의 formula 컬럼명은 카탈로그-전역 의미명이지 특정
-    # 데이터셋의 실제 컬럼명이 아니므로, formula 컬럼 존재 여부는 검사하지 않는다.)
+    # catalog 는 dataset-aware(dataset-b → catalog-b 등) 로 로드되므로
+    # formula 컬럼명은 해당 데이터셋의 실제 컬럼명과 일치한다. formula 컬럼
+    # 존재 여부를 검사해 missing_formula_column 을 결정론적으로 감지한다.
     detected_intent: str | None = None
 
     if c.metric_name not in metrics_by_name:
@@ -62,6 +63,15 @@ def detect_unsupported(
             f"metric_name '{c.metric_name}' 은 catalog.predefined_metrics 에 없습니다."
         )
         detected_intent = detected_intent or "unknown_metric"
+    else:
+        catalog_metric = metrics_by_name[c.metric_name]
+        ds_columns = {col.column_name for col in request.data_source.columns}
+        for formula_col in (catalog_metric.formula_numerator, catalog_metric.formula_denominator):
+            if formula_col is not None and formula_col not in ds_columns:
+                reasons.append(
+                    f"catalog formula 컬럼 '{formula_col}' 이 data_source.columns 에 없습니다."
+                )
+                detected_intent = detected_intent or "missing_formula_column"
     if c.standard_period not in periods:
         reasons.append(
             f"standard_period '{c.standard_period}' 은 catalog.supported_periods 에 없습니다."

--- a/apps/ai/tests/test_eval_harness.py
+++ b/apps/ai/tests/test_eval_harness.py
@@ -448,3 +448,38 @@ def test_runner_unknown_suite_returns_error() -> None:
     result = run_case("ghost_suite", {"id": "C1", "input": {}})  # type: ignore[arg-type]
     assert result.error is not None
     assert "ghost_suite" in result.error or "알 수 없는" in result.error
+
+
+# ---------- composer: dataset-aware catalog ----------
+
+
+def test_composer_dataset_b_uses_catalog_b_formula_columns() -> None:
+    """dataset-b spec 은 catalog-b 를 로드하므로 signup_conversion_rate formula 가
+    signups/visits 로 설정된다."""
+    from eval.composers import compose_question_analysis_request
+
+    payload = compose_question_analysis_request({
+        "id": "CMP-B",
+        "dataset": "dataset-b",
+        "question": "이번 주 가입 전환율 top 5",
+    })
+    metrics = {m["metric_name"]: m for m in payload["catalog"]["predefined_metrics"]}
+    scr = metrics["signup_conversion_rate"]
+    assert scr["formula_numerator"] == "signups"
+    assert scr["formula_denominator"] == "visits"
+
+
+def test_composer_dataset_a_uses_default_catalog_formula_columns() -> None:
+    """dataset-a spec 은 catalog-a fixture 가 없으므로 기본 catalog 를 폴백 로드한다.
+    signup_conversion_rate formula 는 signup_complete/landing_sessions 이다."""
+    from eval.composers import compose_question_analysis_request
+
+    payload = compose_question_analysis_request({
+        "id": "CMP-A",
+        "dataset": "dataset-a",
+        "question": "이번 주 가입 전환율 top 5",
+    })
+    metrics = {m["metric_name"]: m for m in payload["catalog"]["predefined_metrics"]}
+    scr = metrics["signup_conversion_rate"]
+    assert scr["formula_numerator"] == "signup_complete"
+    assert scr["formula_denominator"] == "landing_sessions"

--- a/apps/ai/tests/test_unsupported_backstop.py
+++ b/apps/ai/tests/test_unsupported_backstop.py
@@ -142,13 +142,12 @@ def test_unknown_compare_period_returns_unsupported() -> None:
     assert "this_year" in result.reason
 
 
-def test_metric_formula_column_absent_returns_none() -> None:
-    """카탈로그 지표의 formula 컬럼은 카탈로그-전역 의미명이지 특정 데이터셋의
-    실제 컬럼명이 아니다. data_source.columns 에 그 의미명이 없더라도(컬럼명이
-    rename 된 데이터셋) 동일 지표를 계산할 수 있으므로 unsupported 가 아니다.
+def test_metric_formula_column_absent_returns_missing_formula_column() -> None:
+    """catalog 가 dataset-aware 이므로 formula 컬럼은 해당 데이터셋의 실제 컬럼명이다.
+    catalog formula 컬럼이 data_source.columns 에 없으면 missing_formula_column 을 반환한다.
 
-    회귀 방지: formula = signup_complete/landing_sessions 인데 data_source 는
-    source/device_type/visits/signups + DATE_CRITERIA 만 가진 경우."""
+    UNS-04 재현: formula = signup_complete/landing_sessions 인데 data_source 에
+    signup_complete 가 없는 경우."""
     req = QuestionAnalysisRequest(
         request_id="req_X",
         conversation_id=1,
@@ -161,21 +160,14 @@ def test_metric_formula_column_absent_returns_none() -> None:
                     semantic_role="DATE_CRITERIA", null_ratio=0.0, sample_values=[],
                 ),
                 DataSourceColumn(
-                    column_name="source", data_type="string",
+                    column_name="channel", data_type="string",
                     semantic_role="DIMENSION", null_ratio=0.0, sample_values=[],
                 ),
                 DataSourceColumn(
-                    column_name="device_type", data_type="string",
-                    semantic_role="DIMENSION", null_ratio=0.0, sample_values=[],
-                ),
-                DataSourceColumn(
-                    column_name="visits", data_type="integer",
+                    column_name="landing_sessions", data_type="integer",
                     semantic_role="MEASURE", null_ratio=0.0, sample_values=[],
                 ),
-                DataSourceColumn(
-                    column_name="signups", data_type="integer",
-                    semantic_role="MEASURE", null_ratio=0.0, sample_values=[],
-                ),
+                # signup_complete 는 의도적으로 제거
             ],
         ),
         catalog=Catalog(
@@ -197,6 +189,58 @@ def test_metric_formula_column_absent_returns_none() -> None:
         ),
     )
     result = detect_unsupported(_response(_criteria()), req)
+    assert isinstance(result, UnsupportedQuestion)
+    assert "signup_complete" in result.reason
+    assert result.detected_intent == "missing_formula_column"
+
+
+def test_metric_formula_columns_present_no_formula_reason() -> None:
+    """catalog formula 컬럼이 data_source.columns 에 모두 있으면 formula 관련 reason 이 없다."""
+    req = QuestionAnalysisRequest(
+        request_id="req_X",
+        conversation_id=1,
+        question=Question(content="?"),
+        data_source=DataSource(
+            id=1,
+            columns=[
+                DataSourceColumn(
+                    column_name="signed_at", data_type="datetime",
+                    semantic_role="DATE_CRITERIA", null_ratio=0.0, sample_values=[],
+                ),
+                DataSourceColumn(
+                    column_name="channel", data_type="string",
+                    semantic_role="DIMENSION", null_ratio=0.0, sample_values=[],
+                ),
+                DataSourceColumn(
+                    column_name="a", data_type="integer",
+                    semantic_role="MEASURE", null_ratio=0.0, sample_values=[],
+                ),
+                DataSourceColumn(
+                    column_name="b", data_type="integer",
+                    semantic_role="MEASURE", null_ratio=0.0, sample_values=[],
+                ),
+            ],
+        ),
+        catalog=Catalog(
+            analysis_types=["COMPARISON", "RANKING"],
+            metric_types=["RATIO"],
+            predefined_metrics=[
+                PredefinedMetric(
+                    metric_name="cr", display_name="전환율", metric_type="RATIO",
+                    formula_numerator="a",
+                    formula_denominator="b",
+                ),
+            ],
+            supported_periods=["this_week", "last_week"],
+            flow_warning_keys=[
+                FlowWarningKeyCatalog(
+                    code="QUESTION_DATA_MISMATCH", name="...", comment="...",
+                ),
+            ],
+        ),
+    )
+    result = detect_unsupported(_response(_criteria()), req)
+    # formula 컬럼이 모두 있으므로 formula 관련 reason 이 없다(다른 위반도 없으므로 None).
     assert result is None
 
 


### PR DESCRIPTION
## 요약
- eval catalog 를 데이터소스별로 분리(dataset-b 전용 catalog-b)하고, 그 위에서 formula 컬럼 부재 backstop 을 재도입하여 UNS-04 를 missing_formula_column 으로 분기

## 변경 사항
- [x] 버그 수정

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - cd apps/ai && python -m pytest tests/test_unsupported_backstop.py tests/test_eval_harness.py tests/test_analysis_criteria_resolve.py tests/test_business_validation.py -q (67 passed)
  - cd apps/ai && python -m eval --suite question_analysis --category uns --mock (UNS-04 통과 확인)
  - cd apps/ai && python -m eval --suite question_analysis --category cmp --mock (CMP-08 이 unsupported 오탐되지 않고 criteria 유지 확인, dev 와 동일)

## 롤백/리스크
- 리스크 포인트: catalog 분리와 backstop 재도입은 원자적으로 함께 반영해야 하며, 분리 없이 backstop 만 들어가면 dataset-b 가 회귀
- 롤백 방법: 본 커밋 revert

## 관련 이슈
Closes #407