### PR TITLE
feat(ai): result_summary eval 케이스 및 dual-track 채점 추가, 프롬프트 정합화 (#421)

### DIFF
--- a/apps/ai/eval/cases/result_summary/RS-01.json
+++ b/apps/ai/eval/cases/result_summary/RS-01.json
@@ -1,0 +1,34 @@
+{
+  "id": "RS-01",
+  "input": {
+    "request_id": "rs-01",
+    "analysis_criteria": {
+      "analysis_type": "COMPARISON",
+      "metric_name": "signup_conversion_rate",
+      "metric_display_name": "가입 전환율",
+      "standard_period": "1W",
+      "compare_period": "1W",
+      "group_by": ["channel", "device"],
+      "sort_by": "delta",
+      "sort_direction": "asc",
+      "limit_num": null
+    },
+    "chart_data": {
+      "columns": ["channel", "device", "current", "previous", "delta"],
+      "rows": [
+        ["paid_search", "mobile", 0.04, 0.09, -0.05],
+        ["organic", "desktop", 0.07, 0.08, -0.01]
+      ]
+    },
+    "locale": "ko-KR"
+  },
+  "expected": {
+    "hard": {
+      "plain_text_contains": ["paid_search", "mobile", "5%p", "하락"]
+    },
+    "soft": {
+      "emphasis_pattern": [false, true, false],
+      "emphasis_keywords": ["5%p 하락"]
+    }
+  }
+}

--- a/apps/ai/eval/cases/result_summary/RS-02.json
+++ b/apps/ai/eval/cases/result_summary/RS-02.json
@@ -1,0 +1,34 @@
+{
+  "id": "RS-02",
+  "input": {
+    "request_id": "rs-02",
+    "analysis_criteria": {
+      "analysis_type": "COMPARISON",
+      "metric_name": "activation_rate",
+      "metric_display_name": "액티베이션율",
+      "standard_period": "1M",
+      "compare_period": "1M",
+      "group_by": ["segment"],
+      "sort_by": "delta",
+      "sort_direction": "desc",
+      "limit_num": null
+    },
+    "chart_data": {
+      "columns": ["segment", "current", "previous", "delta"],
+      "rows": [
+        ["enterprise", 0.30, 0.22, 0.08],
+        ["smb", 0.18, 0.16, 0.02]
+      ]
+    },
+    "locale": "ko-KR"
+  },
+  "expected": {
+    "hard": {
+      "plain_text_contains": ["enterprise", "8%p", "상승"]
+    },
+    "soft": {
+      "emphasis_pattern": [false, true, false],
+      "emphasis_keywords": ["8%p 상승"]
+    }
+  }
+}

--- a/apps/ai/eval/cases/result_summary/RS-03.json
+++ b/apps/ai/eval/cases/result_summary/RS-03.json
@@ -1,0 +1,37 @@
+{
+  "id": "RS-03",
+  "input": {
+    "request_id": "rs-03",
+    "analysis_criteria": {
+      "analysis_type": "RANKING",
+      "metric_name": "purchase_conversion_rate",
+      "metric_display_name": "구매 전환율",
+      "standard_period": "1M",
+      "compare_period": null,
+      "group_by": ["category"],
+      "sort_by": "metric_value",
+      "sort_direction": "desc",
+      "limit_num": 5
+    },
+    "chart_data": {
+      "columns": ["category", "value"],
+      "rows": [
+        ["Electronics", 0.12],
+        ["Books", 0.09],
+        ["Toys", 0.07],
+        ["Apparel", 0.05],
+        ["Garden", 0.03]
+      ]
+    },
+    "locale": "ko-KR"
+  },
+  "expected": {
+    "hard": {
+      "plain_text_contains": ["Electronics", "12%", "가장 높은"]
+    },
+    "soft": {
+      "emphasis_pattern": [false, true, false],
+      "emphasis_keywords": ["가장 높은"]
+    }
+  }
+}

--- a/apps/ai/eval/cases/result_summary/RS-04.json
+++ b/apps/ai/eval/cases/result_summary/RS-04.json
@@ -1,0 +1,35 @@
+{
+  "id": "RS-04",
+  "input": {
+    "request_id": "rs-04",
+    "analysis_criteria": {
+      "analysis_type": "RANKING",
+      "metric_name": "resolution_rate",
+      "metric_display_name": "해결율",
+      "standard_period": "1W",
+      "compare_period": null,
+      "group_by": ["priority"],
+      "sort_by": "metric_value",
+      "sort_direction": "asc",
+      "limit_num": 3
+    },
+    "chart_data": {
+      "columns": ["priority", "value"],
+      "rows": [
+        ["urgent", 0.42],
+        ["high", 0.55],
+        ["low", 0.71]
+      ]
+    },
+    "locale": "ko-KR"
+  },
+  "expected": {
+    "hard": {
+      "plain_text_contains": ["urgent", "42%", "가장 낮은"]
+    },
+    "soft": {
+      "emphasis_pattern": [false, true, false],
+      "emphasis_keywords": ["가장 낮은"]
+    }
+  }
+}

--- a/apps/ai/eval/cases/result_summary/RS-05.json
+++ b/apps/ai/eval/cases/result_summary/RS-05.json
@@ -1,0 +1,30 @@
+{
+  "id": "RS-05",
+  "input": {
+    "request_id": "rs-05",
+    "analysis_criteria": {
+      "analysis_type": "RANKING",
+      "metric_name": "signup_conversion_rate",
+      "metric_display_name": "가입 전환율",
+      "standard_period": "1W",
+      "compare_period": null,
+      "group_by": ["channel"],
+      "sort_by": "metric_value",
+      "sort_direction": "desc",
+      "limit_num": 5
+    },
+    "chart_data": {
+      "columns": ["channel", "value"],
+      "rows": []
+    },
+    "locale": "ko-KR"
+  },
+  "expected": {
+    "hard": {
+      "plain_text_contains": ["데이터가 없습니다"]
+    },
+    "soft": {
+      "emphasis_pattern": [false]
+    }
+  }
+}

--- a/apps/ai/eval/cases/result_summary/RS-06.json
+++ b/apps/ai/eval/cases/result_summary/RS-06.json
@@ -1,0 +1,32 @@
+{
+  "id": "RS-06",
+  "input": {
+    "request_id": "rs-06",
+    "analysis_criteria": {
+      "analysis_type": "RANKING",
+      "metric_name": "open_rate",
+      "metric_display_name": "오픈율",
+      "standard_period": "1W",
+      "compare_period": null,
+      "group_by": ["channel"],
+      "sort_by": "metric_value",
+      "sort_direction": "desc",
+      "limit_num": 5
+    },
+    "chart_data": {
+      "columns": ["channel", "value"],
+      "rows": [
+        ["newsletter", 0.34]
+      ]
+    },
+    "locale": "ko-KR"
+  },
+  "expected": {
+    "hard": {
+      "plain_text_contains": ["newsletter", "34%"]
+    },
+    "soft": {
+      "emphasis_pattern": [false, true, false]
+    }
+  }
+}

--- a/apps/ai/eval/cases/result_summary/RS-07.json
+++ b/apps/ai/eval/cases/result_summary/RS-07.json
@@ -1,0 +1,34 @@
+{
+  "id": "RS-07",
+  "input": {
+    "request_id": "rs-07",
+    "analysis_criteria": {
+      "analysis_type": "RANKING",
+      "metric_name": "purchase_conversion_rate",
+      "metric_display_name": "구매 전환율",
+      "standard_period": "1M",
+      "compare_period": null,
+      "group_by": ["category"],
+      "sort_by": "metric_value",
+      "sort_direction": "desc",
+      "limit_num": 5
+    },
+    "chart_data": {
+      "columns": ["category", "value"],
+      "rows": [
+        ["Mystery", null],
+        ["Books", 0.30],
+        ["Toys", 0.18]
+      ]
+    },
+    "locale": "ko-KR"
+  },
+  "expected": {
+    "hard": {
+      "plain_text_contains": ["Books", "30%"]
+    },
+    "soft": {
+      "emphasis_pattern": [false, true, false]
+    }
+  }
+}

--- a/apps/ai/eval/cases/result_summary/RS-08.json
+++ b/apps/ai/eval/cases/result_summary/RS-08.json
@@ -1,0 +1,33 @@
+{
+  "id": "RS-08",
+  "input": {
+    "request_id": "rs-08",
+    "analysis_criteria": {
+      "analysis_type": "COMPARISON",
+      "metric_name": "signup_conversion_rate",
+      "metric_display_name": "가입 전환율",
+      "standard_period": "1W",
+      "compare_period": "1W",
+      "group_by": ["channel"],
+      "sort_by": "delta",
+      "sort_direction": "asc",
+      "limit_num": null
+    },
+    "chart_data": {
+      "columns": ["channel", "current", "previous", "delta"],
+      "rows": [
+        ["organic", 0.10, 0.10, 0.0]
+      ]
+    },
+    "locale": "ko-KR"
+  },
+  "expected": {
+    "hard": {
+      "plain_text_contains": ["변동이 없"]
+    },
+    "soft": {
+      "emphasis_pattern": [false, true, false],
+      "emphasis_keywords": ["변동이 없"]
+    }
+  }
+}

--- a/apps/ai/eval/cases/result_summary/RS-09.json
+++ b/apps/ai/eval/cases/result_summary/RS-09.json
@@ -1,0 +1,34 @@
+{
+  "id": "RS-09",
+  "input": {
+    "request_id": "rs-09",
+    "analysis_criteria": {
+      "analysis_type": "RANKING",
+      "metric_name": "visits",
+      "metric_display_name": "방문 수",
+      "standard_period": "1W",
+      "compare_period": null,
+      "group_by": ["channel"],
+      "sort_by": "metric_value",
+      "sort_direction": "desc",
+      "limit_num": 5
+    },
+    "chart_data": {
+      "columns": ["channel", "value"],
+      "rows": [
+        ["paid_search", 120000],
+        ["organic", 100000],
+        ["referral", 64000]
+      ]
+    },
+    "locale": "ko-KR"
+  },
+  "expected": {
+    "hard": {
+      "plain_text_contains": ["120,000", "100,000"]
+    },
+    "soft": {
+      "emphasis_pattern": [false, true, false]
+    }
+  }
+}

--- a/apps/ai/eval/cases/result_summary/RS-10.json
+++ b/apps/ai/eval/cases/result_summary/RS-10.json
@@ -1,0 +1,32 @@
+{
+  "id": "RS-10",
+  "input": {
+    "request_id": "rs-10",
+    "analysis_criteria": {
+      "analysis_type": "COMPARISON",
+      "metric_name": "signup_conversion_rate",
+      "metric_display_name": "가입 전환율",
+      "standard_period": "1W",
+      "compare_period": "1W",
+      "group_by": ["channel"],
+      "sort_by": "delta",
+      "sort_direction": "desc",
+      "limit_num": null
+    },
+    "chart_data": {
+      "columns": ["channel", "current", "previous", "delta"],
+      "rows": [
+        ["organic", 0.0623, 0.05, 0.0123]
+      ]
+    },
+    "locale": "ko-KR"
+  },
+  "expected": {
+    "hard": {
+      "plain_text_contains": ["1.23%"]
+    },
+    "soft": {
+      "emphasis_pattern": [false, true, false]
+    }
+  }
+}

--- a/apps/ai/eval/cases/result_summary/RS-11.json
+++ b/apps/ai/eval/cases/result_summary/RS-11.json
@@ -1,0 +1,33 @@
+{
+  "id": "RS-11",
+  "input": {
+    "request_id": "rs-11",
+    "analysis_criteria": {
+      "analysis_type": "COMPARISON",
+      "metric_name": "signup_conversion_rate",
+      "metric_display_name": "Signup conversion rate",
+      "standard_period": "1W",
+      "compare_period": "1W",
+      "group_by": ["channel"],
+      "sort_by": "delta",
+      "sort_direction": "asc",
+      "limit_num": null
+    },
+    "chart_data": {
+      "columns": ["channel", "current", "previous", "delta"],
+      "rows": [
+        ["paid_search", 0.04, 0.09, -0.05]
+      ]
+    },
+    "locale": "en-US"
+  },
+  "expected": {
+    "hard": {
+      "plain_text_contains": ["dropped", "5%p"]
+    },
+    "soft": {
+      "emphasis_pattern": [false, true, false],
+      "emphasis_keywords": ["dropped by 5%p"]
+    }
+  }
+}

--- a/apps/ai/eval/cases/result_summary/RS-12.json
+++ b/apps/ai/eval/cases/result_summary/RS-12.json
@@ -1,0 +1,33 @@
+{
+  "id": "RS-12",
+  "input": {
+    "request_id": "rs-12",
+    "analysis_criteria": {
+      "analysis_type": "COMPARISON",
+      "metric_name": "signup_conversion_rate",
+      "metric_display_name": "가입 전환율",
+      "standard_period": "1W",
+      "compare_period": "1W",
+      "group_by": ["channel", "device", "region"],
+      "sort_by": "delta",
+      "sort_direction": "asc",
+      "limit_num": null
+    },
+    "chart_data": {
+      "columns": ["channel", "device", "region", "current", "previous", "delta"],
+      "rows": [
+        ["channel", "device", "region", 0.05, 0.12, -0.07],
+        ["organic", "desktop", "us", 0.08, 0.09, -0.01]
+      ]
+    },
+    "locale": "ko-KR"
+  },
+  "expected": {
+    "hard": {
+      "plain_text_contains": ["channel", "device", "region"]
+    },
+    "soft": {
+      "emphasis_pattern": [false, true, false]
+    }
+  }
+}

--- a/apps/ai/eval/cases/result_summary/RS-13.json
+++ b/apps/ai/eval/cases/result_summary/RS-13.json
@@ -1,0 +1,34 @@
+{
+  "id": "RS-13",
+  "input": {
+    "request_id": "rs-13",
+    "analysis_criteria": {
+      "analysis_type": "RANKING",
+      "metric_name": "monthly_active_signup_conversion_rate",
+      "metric_display_name": "월간 활성 가입 전환율",
+      "standard_period": "1M",
+      "compare_period": null,
+      "group_by": ["channel"],
+      "sort_by": "metric_value",
+      "sort_direction": "desc",
+      "limit_num": 5
+    },
+    "chart_data": {
+      "columns": ["channel", "value"],
+      "rows": [
+        ["paid_search", 0.21],
+        ["organic", 0.17],
+        ["referral", 0.11]
+      ]
+    },
+    "locale": "ko-KR"
+  },
+  "expected": {
+    "hard": {
+      "plain_text_contains": ["월간 활성 가입 전환율"]
+    },
+    "soft": {
+      "emphasis_pattern": [false, true, false]
+    }
+  }
+}

--- a/apps/ai/eval/scoring.py
+++ b/apps/ai/eval/scoring.py
@@ -102,6 +102,9 @@ def score_case(
             latency_ms=latency_ms,
         )
 
+    if suite == "result_summary":
+        return _score_result_summary_case(case_id, suite, expected, actual, latency_ms)
+
     actual = _normalize_actual(suite, actual)
 
     comparisons: list[FieldComparison] = []
@@ -125,6 +128,54 @@ def score_case(
         field_comparisons=comparisons,
         error=None,
         latency_ms=latency_ms,
+    )
+
+
+def _score_result_summary_case(
+    case_id: str,
+    suite: str,
+    expected: dict[str, Any],
+    actual: dict[str, Any],
+    latency_ms: int,
+) -> CaseScore:
+    """RS dual-track 채점. hard: plain_text 키워드 포함 + segments-plain_text 무결성. soft: emphasis 패턴/키워드."""
+    description = (actual.get("description") if isinstance(actual, dict) else None) or {}
+    plain_text = description.get("plain_text") or ""
+    segments = description.get("segments") or []
+    comparisons: list[FieldComparison] = []
+
+    hard = expected.get("hard") or {}
+    for kw in hard.get("plain_text_contains", []):
+        comparisons.append(FieldComparison(
+            path=f"hard.plain_text_contains[{kw}]",
+            expected=kw, actual=plain_text, match=(kw in plain_text),
+        ))
+    joined = "".join(str(s.get("text", "")) for s in segments)
+    comparisons.append(FieldComparison(
+        path="hard.plain_text_integrity",
+        expected=plain_text, actual=joined, match=(joined == plain_text),
+    ))
+
+    soft = expected.get("soft") or {}
+    if "emphasis_pattern" in soft:
+        actual_pattern = [bool(s.get("emphasis")) for s in segments]
+        comparisons.append(FieldComparison(
+            path="soft.emphasis_pattern",
+            expected=soft["emphasis_pattern"], actual=actual_pattern,
+            match=(actual_pattern == soft["emphasis_pattern"]),
+        ))
+    emphasized_text = "".join(str(s.get("text", "")) for s in segments if s.get("emphasis"))
+    for kw in soft.get("emphasis_keywords", []):
+        comparisons.append(FieldComparison(
+            path=f"soft.emphasis_keywords[{kw}]",
+            expected=kw, actual=emphasized_text, match=(kw in emphasized_text),
+        ))
+
+    passed = all(c.match for c in comparisons)
+    hard_fail = any((not c.match) and c.path.startswith("hard.") for c in comparisons)
+    return CaseScore(
+        case_id=case_id, suite=suite, passed=passed, hard_fail=hard_fail,
+        field_comparisons=comparisons, error=None, latency_ms=latency_ms,
     )
 
 

--- a/apps/ai/prompts/result_summary_v1.system.md
+++ b/apps/ai/prompts/result_summary_v1.system.md
@@ -1,4 +1,4 @@
-# Result Summary — System Prompt v1
+# Result Summary - System Prompt v1
 
 > 03 결과 요약 API (`POST /v1/llm/analysis-results/describe`) 의 system message.
 > response schema: `schemas.api.result_summary.AnalysisSummaryResponse` (Structured Outputs 로 강제됨)
@@ -7,7 +7,7 @@
 # Role
 
 You are a data analysis assistant for Logue, a Question-first analytics service.
-Your job is to convert structured analysis results into a single natural language summary sentence in Korean.
+Your job is to convert structured analysis results into a single natural language summary sentence.
 You summarize an analysis result (`analysis_criteria` + `chart_data`) into a single natural-language sentence with emphasis segments.
 
 ---
@@ -21,7 +21,7 @@ You will receive a JSON object with the following structure:
   "analysis_criteria": {
     "analysis_type":      "COMPARISON | RANKING",
     "metric_name":        "<지표 식별자>",
-    "metric_display_name":"<지표 표시명 (한국어)>",
+    "metric_display_name":"<지표 표시명>",
     "standard_period":    "<기준 기간>",
     "compare_period":     "<비교 기간 | null>",
     "group_by":           ["<그룹 기준 컬럼명>", "..."],
@@ -32,7 +32,8 @@ You will receive a JSON object with the following structure:
   "chart_data": {
     "columns": ["<컬럼명>", "..."],
     "rows":    [["<값>", "..."], "..."]
-  }
+  },
+  "locale": "ko-KR | en-US"
 }
 ```
 
@@ -57,60 +58,74 @@ Return a single JSON object. Do not include any explanation outside the JSON.
 
 # Rules
 
-1. 반드시 한국어로 작성한다.
-2. 전체 요약은 **한 문장**으로 작성한다. 여러 문장 금지.
-3. `plain_text` 는 `segments[].text` 를 순서대로 이어붙인 결과와 정확히 일치해야 한다.
-4. `emphasis: true` 는 핵심 수치, 기간, 순위처럼 사용자가 한눈에 봐야 할 정보에만 사용한다. 과도한 강조 금지.
-5. `chart_data.rows` 가 비어있으면 "분석 결과 데이터가 없습니다." 를 단일 segment로 반환한다.
-6. 수치는 `chart_data` 에서 읽은 값만 사용한다. 임의로 수치를 생성하거나 추론하지 않는다.
-7. `analysis_criteria` 의 `metric_display_name` 을 지표 표시명으로 사용한다. 임의로 바꾸지 않는다.
+1. 전체 요약은 **한 문장**으로 작성한다. 여러 문장 금지.
+2. `plain_text` 는 `segments[].text` 를 순서대로 이어붙인 결과와 정확히 일치해야 한다.
+3. 기본 언어는 한국어(`ko-KR`)다. `locale` 이 `"en-US"` 이면 영어로 작성한다.
+4. 문장은 보통 3개 segment 로 구성한다: 앞부분(`emphasis: false`) + 핵심 강조 구간(`emphasis: true`) + 뒷부분(`emphasis: false`). 강조는 핵심 수치/방향 표현 한 곳에만 사용한다.
+5. 수치는 `chart_data` 에서 읽은 값만 사용한다. 임의로 수치를 생성하거나 추론하지 않는다.
+6. `analysis_criteria` 의 `metric_display_name` 을 지표 표시명으로 사용한다. 임의로 바꾸지 않으며 길어도 그대로 보존한다.
+7. `chart_data.rows` 가 비어있으면 `"분석 결과 데이터가 없습니다."` 를 단일 segment(`emphasis: false`)로 반환한다.
+8. metric value 가 `null` 인 row 는 top 결과 선택에서 제외한다.
 
 ---
 
 # Decision Guide
 
+## 공통 - top row 선택
+
+- `rows` 는 이미 `sort_by` / `sort_direction` 기준으로 정렬되어 전달된다. metric value 가 `null` 인 row 를 제외한 뒤 **첫 번째 row** 가 top 결과다.
+- top row 의 `group_by` 컬럼 값들을 라벨로 사용한다. group_by 가 여러 개면 모든 라벨을 가운뎃점(·) 으로 결합한다.
+
+## 수치 포맷
+
+- 비율(0~1 사이 소수) 은 백분율로 변환한다: `0.12` -> `12%`, `0.0123` -> `1.23%` (소수점은 최대 2자리까지, 뒤따르는 0 은 제거).
+- 큰 정수 값은 천 단위 구분자를 넣는다: `120000` -> `120,000`.
+
 ## COMPARISON 요약 패턴
 
-- 핵심: 어떤 기준으로 비교했는지 + 가장 두드러진 변화
-- `sort_direction: asc` → 하락폭이 큰 순서로 나열한 결과
-- `sort_direction: desc` → 상승폭이 큰 순서로 나열한 결과
-- `compare_period` 를 자연스러운 한국어로 표현 (예: `last_week` → "지난주 대비")
+- 핵심: 가장 두드러진 변화를 보인 group 라벨 + 변화량.
+- `sort_direction: asc` -> 하락폭이 가장 큰 row 가 top. `sort_direction: desc` -> 상승폭이 가장 큰 row 가 top.
+- 변화량은 top row 의 delta 값으로 `{X}%p {상승|하락}` 형태로 표현한다. `X = round(abs(delta) * 100, 2)` (뒤따르는 0 제거). delta 가 음수면 `하락`, 양수면 `상승`.
+- 강조 segment 는 정확히 `{X}%p {상승|하락}` 구간이다.
+- delta 가 `0` 이면 변화량 대신 `변동이 없어요` 로 표현하고 그 구간을 강조한다.
 
 ## RANKING 요약 패턴
 
-- 핵심: 상위/하위 N개 + 기준 지표
-- `sort_direction: desc` → 상위 N개
-- `sort_direction: asc` → 하위 N개
-- `limit_num` 을 그대로 사용 (예: 5 → "상위 5개")
+- 핵심: top group 라벨 + 그 metric 값 + 방향 표현.
+- `sort_direction: desc` -> top 은 가장 큰 값. 방향 표현은 `가장 높은`.
+- `sort_direction: asc` -> top 은 가장 작은 값. 방향 표현은 `가장 낮은`.
+- 강조 segment 는 `가장 높은` / `가장 낮은` 구간이다.
+- row 가 1개뿐이면 `상위 N` / `top N` 같은 순위 표현을 쓰지 않고 단일 결과만 서술한다.
+
+## locale: en-US
+
+- 영어로 한 문장을 작성한다. COMPARISON 하락 예시: top 라벨 + `dropped by {X}%p` + 마무리. 강조 segment 는 `dropped by {X}%p` 구간이다.
 
 ---
 
 # Examples
 
-## Example 1 — COMPARISON, 하락폭 순
+## Example 1 - COMPARISON, 하락 (asc, ko-KR)
 
 **Input**
 ```json
 {
   "analysis_criteria": {
     "analysis_type": "COMPARISON",
-    "metric_name": "conversion_rate",
+    "metric_name": "signup_conversion_rate",
     "metric_display_name": "가입 전환율",
-    "standard_period": "this_week",
-    "compare_period": "last_week",
-    "group_by": ["channel", "device_type"],
-    "sort_by": "delta_conversion_rate",
+    "standard_period": "1W",
+    "compare_period": "1W",
+    "group_by": ["channel", "device"],
+    "sort_by": "delta",
     "sort_direction": "asc",
     "limit_num": null
   },
   "chart_data": {
-    "columns": ["channel", "device_type", "conversion_rate_standard", "conversion_rate_compare", "delta"],
-    "rows": [
-      ["cold_email", "ios", 0.03, 0.05, -0.02],
-      ["direct", "android", 0.06, 0.065, -0.005],
-      ["crm", "ios", 0.08, 0.08, 0.0]
-    ]
-  }
+    "columns": ["channel", "device", "current", "previous", "delta"],
+    "rows": [["paid_search", "mobile", 0.04, 0.09, -0.05]]
+  },
+  "locale": "ko-KR"
 }
 ```
 
@@ -118,40 +133,35 @@ Return a single JSON object. Do not include any explanation outside the JSON.
 ```json
 {
   "segments": [
-    { "text": "가입 전환율이 ", "emphasis": false },
-    { "text": "지난주 대비 낮은 순", "emphasis": true },
-    { "text": "으로 채널·디바이스를 나열했어요.", "emphasis": false }
+    { "text": "paid_search·mobile에서 가입 전환율이 ", "emphasis": false },
+    { "text": "5%p 하락", "emphasis": true },
+    { "text": "했어요.", "emphasis": false }
   ],
-  "plain_text": "가입 전환율이 지난주 대비 낮은 순으로 채널·디바이스를 나열했어요."
+  "plain_text": "paid_search·mobile에서 가입 전환율이 5%p 하락했어요."
 }
 ```
 
-## Example 2 — RANKING, 상위 5개
+## Example 2 - COMPARISON, 상승 (desc, ko-KR)
 
 **Input**
 ```json
 {
   "analysis_criteria": {
-    "analysis_type": "RANKING",
-    "metric_name": "total_revenue",
-    "metric_display_name": "매출",
-    "standard_period": "this_month",
-    "compare_period": null,
-    "group_by": ["region"],
-    "sort_by": "value",
+    "analysis_type": "COMPARISON",
+    "metric_name": "activation_rate",
+    "metric_display_name": "액티베이션율",
+    "standard_period": "1M",
+    "compare_period": "1M",
+    "group_by": ["segment"],
+    "sort_by": "delta",
     "sort_direction": "desc",
-    "limit_num": 5
+    "limit_num": null
   },
   "chart_data": {
-    "columns": ["region", "total_revenue"],
-    "rows": [
-      ["seoul", 4200000],
-      ["busan", 3100000],
-      ["incheon", 2800000],
-      ["daegu", 2400000],
-      ["daejeon", 1900000]
-    ]
-  }
+    "columns": ["segment", "current", "previous", "delta"],
+    "rows": [["enterprise", 0.30, 0.22, 0.08]]
+  },
+  "locale": "ko-KR"
 }
 ```
 
@@ -159,34 +169,143 @@ Return a single JSON object. Do not include any explanation outside the JSON.
 ```json
 {
   "segments": [
-    { "text": "이번 달 매출 ", "emphasis": false },
-    { "text": "상위 5개 지역", "emphasis": true },
-    { "text": "을 나열했어요.", "emphasis": false }
+    { "text": "enterprise에서 액티베이션율이 ", "emphasis": false },
+    { "text": "8%p 상승", "emphasis": true },
+    { "text": "했어요.", "emphasis": false }
   ],
-  "plain_text": "이번 달 매출 상위 5개 지역을 나열했어요."
+  "plain_text": "enterprise에서 액티베이션율이 8%p 상승했어요."
 }
 ```
 
-## Example 3 — 빈 데이터
+## Example 3 - COMPARISON, 변동 없음 (delta=0, ko-KR)
+
+**Input**
+```json
+{
+  "analysis_criteria": {
+    "analysis_type": "COMPARISON",
+    "metric_name": "signup_conversion_rate",
+    "metric_display_name": "가입 전환율",
+    "standard_period": "1W",
+    "compare_period": "1W",
+    "group_by": ["channel"],
+    "sort_by": "delta",
+    "sort_direction": "asc",
+    "limit_num": null
+  },
+  "chart_data": {
+    "columns": ["channel", "current", "previous", "delta"],
+    "rows": [["organic", 0.10, 0.10, 0.0]]
+  },
+  "locale": "ko-KR"
+}
+```
+
+**Output**
+```json
+{
+  "segments": [
+    { "text": "organic에서 가입 전환율은 지난 기간 대비 ", "emphasis": false },
+    { "text": "변동이 없어요", "emphasis": true },
+    { "text": ".", "emphasis": false }
+  ],
+  "plain_text": "organic에서 가입 전환율은 지난 기간 대비 변동이 없어요."
+}
+```
+
+## Example 4 - RANKING, 가장 높은 (desc, ko-KR)
 
 **Input**
 ```json
 {
   "analysis_criteria": {
     "analysis_type": "RANKING",
-    "metric_name": "total_revenue",
-    "metric_display_name": "매출",
-    "standard_period": "this_month",
+    "metric_name": "purchase_conversion_rate",
+    "metric_display_name": "구매 전환율",
+    "standard_period": "1M",
     "compare_period": null,
-    "group_by": ["region"],
-    "sort_by": "value",
+    "group_by": ["category"],
+    "sort_by": "metric_value",
     "sort_direction": "desc",
     "limit_num": 5
   },
   "chart_data": {
-    "columns": ["region", "total_revenue"],
+    "columns": ["category", "value"],
+    "rows": [["Electronics", 0.12], ["Books", 0.09], ["Toys", 0.07]]
+  },
+  "locale": "ko-KR"
+}
+```
+
+**Output**
+```json
+{
+  "segments": [
+    { "text": "구매 전환율이 ", "emphasis": false },
+    { "text": "가장 높은", "emphasis": true },
+    { "text": " 카테고리는 Electronics로 12%예요.", "emphasis": false }
+  ],
+  "plain_text": "구매 전환율이 가장 높은 카테고리는 Electronics로 12%예요."
+}
+```
+
+## Example 5 - RANKING, 가장 낮은 (asc, ko-KR)
+
+**Input**
+```json
+{
+  "analysis_criteria": {
+    "analysis_type": "RANKING",
+    "metric_name": "resolution_rate",
+    "metric_display_name": "해결율",
+    "standard_period": "1W",
+    "compare_period": null,
+    "group_by": ["priority"],
+    "sort_by": "metric_value",
+    "sort_direction": "asc",
+    "limit_num": 3
+  },
+  "chart_data": {
+    "columns": ["priority", "value"],
+    "rows": [["urgent", 0.42], ["high", 0.55], ["low", 0.71]]
+  },
+  "locale": "ko-KR"
+}
+```
+
+**Output**
+```json
+{
+  "segments": [
+    { "text": "해결율이 ", "emphasis": false },
+    { "text": "가장 낮은", "emphasis": true },
+    { "text": " 우선순위는 urgent로 42%예요.", "emphasis": false }
+  ],
+  "plain_text": "해결율이 가장 낮은 우선순위는 urgent로 42%예요."
+}
+```
+
+## Example 6 - 빈 데이터
+
+**Input**
+```json
+{
+  "analysis_criteria": {
+    "analysis_type": "RANKING",
+    "metric_name": "signup_conversion_rate",
+    "metric_display_name": "가입 전환율",
+    "standard_period": "1W",
+    "compare_period": null,
+    "group_by": ["channel"],
+    "sort_by": "metric_value",
+    "sort_direction": "desc",
+    "limit_num": 5
+  },
+  "chart_data": {
+    "columns": ["channel", "value"],
     "rows": []
-  }
+  },
+  "locale": "ko-KR"
 }
 ```
 
@@ -197,5 +316,41 @@ Return a single JSON object. Do not include any explanation outside the JSON.
     { "text": "분석 결과 데이터가 없습니다.", "emphasis": false }
   ],
   "plain_text": "분석 결과 데이터가 없습니다."
+}
+```
+
+## Example 7 - COMPARISON, 하락 (en-US)
+
+**Input**
+```json
+{
+  "analysis_criteria": {
+    "analysis_type": "COMPARISON",
+    "metric_name": "signup_conversion_rate",
+    "metric_display_name": "Signup conversion rate",
+    "standard_period": "1W",
+    "compare_period": "1W",
+    "group_by": ["channel"],
+    "sort_by": "delta",
+    "sort_direction": "asc",
+    "limit_num": null
+  },
+  "chart_data": {
+    "columns": ["channel", "current", "previous", "delta"],
+    "rows": [["paid_search", 0.04, 0.09, -0.05]]
+  },
+  "locale": "en-US"
+}
+```
+
+**Output**
+```json
+{
+  "segments": [
+    { "text": "Signup conversion rate for paid_search ", "emphasis": false },
+    { "text": "dropped by 5%p", "emphasis": true },
+    { "text": " versus the previous period.", "emphasis": false }
+  ],
+  "plain_text": "Signup conversion rate for paid_search dropped by 5%p versus the previous period."
 }
 ```

--- a/apps/ai/tests/test_result_summary_scoring.py
+++ b/apps/ai/tests/test_result_summary_scoring.py
@@ -1,0 +1,142 @@
+"""eval/scoring.py 의 result_summary dual-track 채점 (`_score_result_summary_case`) 단위 테스트.
+
+score_case(suite="result_summary", ...) 경로를 통해:
+  - hard: plain_text 키워드 포함 + segments↔plain_text 무결성
+  - soft: emphasis_pattern (segment 별 강조 위치) + emphasis_keywords (강조 텍스트 포함)
+의 채점 동작을 통과/실패 두 케이스로 검증한다.
+"""
+
+from __future__ import annotations
+
+from eval.scoring import score_case
+
+
+def _actual(segments: list[dict], plain_text: str) -> dict:
+    """result_summary 응답 dict (description.segments / description.plain_text) 를 만든다."""
+    return {
+        "request_id": "rs-test",
+        "description": {
+            "segments": segments,
+            "plain_text": plain_text,
+        },
+    }
+
+
+def _passing_actual() -> dict:
+    return _actual(
+        segments=[
+            {"text": "paid_search·mobile에서 가입 전환율이 ", "emphasis": False},
+            {"text": "5%p 하락", "emphasis": True},
+            {"text": "했어요.", "emphasis": False},
+        ],
+        plain_text="paid_search·mobile에서 가입 전환율이 5%p 하락했어요.",
+    )
+
+
+_EXPECTED = {
+    "hard": {"plain_text_contains": ["paid_search", "mobile", "5%p", "하락"]},
+    "soft": {
+        "emphasis_pattern": [False, True, False],
+        "emphasis_keywords": ["5%p 하락"],
+    },
+}
+
+
+# ────────────────────────────────────────────────────────────────
+# 통과 케이스 (모든 hard/soft 항목 충족)
+# ────────────────────────────────────────────────────────────────
+
+def test_score_result_summary_passing_case() -> None:
+    score = score_case(
+        case_id="RS-01", suite="result_summary",
+        expected=_EXPECTED, actual=_passing_actual(),
+        error=None, latency_ms=42,
+    )
+    assert score.passed is True
+    assert score.hard_fail is False
+    paths = {c.path for c in score.field_comparisons}
+    # hard: 키워드 4개 + 무결성, soft: 패턴 + 키워드 1개
+    assert "hard.plain_text_contains[paid_search]" in paths
+    assert "hard.plain_text_integrity" in paths
+    assert "soft.emphasis_pattern" in paths
+    assert "soft.emphasis_keywords[5%p 하락]" in paths
+    assert all(c.match for c in score.field_comparisons)
+
+
+# ────────────────────────────────────────────────────────────────
+# 실패 케이스 (hard 키워드 누락 시 hard_fail)
+# ────────────────────────────────────────────────────────────────
+
+def test_score_result_summary_hard_keyword_missing_marks_hard_fail() -> None:
+    actual = _actual(
+        segments=[
+            {"text": "organic에서 가입 전환율이 ", "emphasis": False},
+            {"text": "5%p 하락", "emphasis": True},
+            {"text": "했어요.", "emphasis": False},
+        ],
+        plain_text="organic에서 가입 전환율이 5%p 하락했어요.",
+    )
+    score = score_case(
+        case_id="RS-01", suite="result_summary",
+        expected=_EXPECTED, actual=actual,
+        error=None, latency_ms=42,
+    )
+    assert score.passed is False
+    assert score.hard_fail is True
+    failed = {c.path for c in score.field_comparisons if not c.match}
+    # "paid_search" / "mobile" 키워드 미포함
+    assert "hard.plain_text_contains[paid_search]" in failed
+    assert "hard.plain_text_contains[mobile]" in failed
+
+
+# ────────────────────────────────────────────────────────────────
+# segments↔plain_text 무결성 위반 → hard_fail
+# ────────────────────────────────────────────────────────────────
+
+def test_score_result_summary_integrity_violation_marks_hard_fail() -> None:
+    actual = _actual(
+        segments=[
+            {"text": "paid_search·mobile에서 가입 전환율이 ", "emphasis": False},
+            {"text": "5%p 하락", "emphasis": True},
+            {"text": "했어요.", "emphasis": False},
+        ],
+        # join 결과와 다른 plain_text (무결성 위반)
+        plain_text="paid_search·mobile에서 가입 전환율이 10%p 하락했어요.",
+    )
+    score = score_case(
+        case_id="RS-01", suite="result_summary",
+        expected=_EXPECTED, actual=actual,
+        error=None, latency_ms=42,
+    )
+    assert score.passed is False
+    assert score.hard_fail is True
+    integrity = next(c for c in score.field_comparisons if c.path == "hard.plain_text_integrity")
+    assert integrity.match is False
+
+
+# ────────────────────────────────────────────────────────────────
+# soft 항목만 어긋남 → passed=False 이지만 hard_fail=False
+# ────────────────────────────────────────────────────────────────
+
+def test_score_result_summary_soft_only_mismatch_is_not_hard_fail() -> None:
+    actual = _actual(
+        segments=[
+            # 강조 위치가 기대 패턴([F,T,F])과 다름: 첫 segment 를 강조
+            {"text": "paid_search·mobile에서 가입 전환율이 ", "emphasis": True},
+            {"text": "5%p 하락", "emphasis": False},
+            {"text": "했어요.", "emphasis": False},
+        ],
+        plain_text="paid_search·mobile에서 가입 전환율이 5%p 하락했어요.",
+    )
+    score = score_case(
+        case_id="RS-01", suite="result_summary",
+        expected=_EXPECTED, actual=actual,
+        error=None, latency_ms=42,
+    )
+    assert score.passed is False
+    assert score.hard_fail is False
+    pattern = next(c for c in score.field_comparisons if c.path == "soft.emphasis_pattern")
+    assert pattern.match is False
+    # 강조 텍스트가 "5%p 하락" 을 포함하지 않으므로 emphasis_keywords 도 실패
+    kw = next(c for c in score.field_comparisons if c.path == "soft.emphasis_keywords[5%p 하락]")
+    assert kw.match is False


### PR DESCRIPTION
## 요약

03 결과 요약(result_summary) API의 출력 품질을 검증하기 위한 eval 케이스(RS-01~RS-13)와 전용 dual-track 채점 경로를 추가하고, 프롬프트를 골든 셋에 맞춰 정합화했습니다.

## 변경 사항

- [x] `eval/scoring.py`: `score_case`에 result_summary 분기 추가 및 `_score_result_summary_case` 구현 (hard: plain_text 키워드 포함 + segments-plain_text 무결성, soft: emphasis 패턴/키워드)
- [x] `eval/cases/result_summary/RS-01.json ~ RS-13.json`: 케이스별 input(AnalysisSummaryRequest payload) + expected(hard/soft) 추가
- [x] `prompts/result_summary_v1.system.md`: COMPARISON(상승/하락/변동없음), RANKING(가장 높은/가장 낮은, 단일 row, 천 단위, null row 제외), 빈 결과, en-US locale 규칙과 예시를 골든 셋에 맞춰 재작성
- [x] `tests/test_result_summary_scoring.py`: dual-track 채점 단위 테스트 (통과/실패 케이스, 무결성 위반, soft-only 불일치)

## 테스트

- 전체 단위 테스트: `env -u PYTHONPATH PYTHONNOUSERSITE=1 .venv/bin/python -m pytest -q` (apps/ai), 193 passed
- mock eval 하네스 동작 확인: `env -u PYTHONPATH PYTHONNOUSERSITE=1 .venv/bin/python -m eval --suite result_summary --mock` (apps/ai), total=13 passed=0 failed=13 (mock 더미 응답이므로 키워드 미충족은 정상, 채점 경로/하네스 실행과 결과 기록을 확인)

## 롤백·리스크

- 프롬프트 출력 형태(단일 문장 + 3 segment + 강조 규칙)를 변경했습니다. 실제 LLM 통과 여부는 사용자 실행으로 확인이 필요합니다.
- 채점/케이스 추가는 기존 question_analysis / file_analysis 채점 경로에 영향을 주지 않습니다.

## 관련 이슈

Closes #421