### PR TITLE
fix: Google SSO 세션이 남아있어 자동 로그인되는 문제 해결

### DIFF
--- a/apps/be/src/main/java/com/capstone/logue/auth/security/CustomOAuth2AuthorizationRequestResolver.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/security/CustomOAuth2AuthorizationRequestResolver.java
@@ -1,0 +1,67 @@
+package com.capstone.logue.auth.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+/**
+ * Google OAuth2 인증 요청 시 {@code prompt=select_account} 파라미터를 주입하는 커스텀 Resolver.
+ *
+ * <p>Spring Security의 기본 {@link DefaultOAuth2AuthorizationRequestResolver}를 위임(delegate) 방식으로 감싸며,
+ * 인증 URL 생성 후 {@code additionalParameters}에 {@code prompt} 값을 추가한다.
+ *
+ * <p>이를 통해 브라우저에 Google SSO 세션이 잔류하더라도 재로그인 시 항상 계정 선택 화면이 노출된다.
+ *
+ * <p>사용 등록: {@code SecurityConfig} 의 {@code .oauth2Login()} 설정에서
+ * {@code authorizationEndpoint.authorizationRequestResolver}로 주입한다.
+ */
+public class CustomOAuth2AuthorizationRequestResolver implements OAuth2AuthorizationRequestResolver {
+
+    private final DefaultOAuth2AuthorizationRequestResolver delegate;
+
+    /**
+     * @param repository 등록된 OAuth2 클라이언트 정보를 제공하는 repository
+     */
+    public CustomOAuth2AuthorizationRequestResolver(ClientRegistrationRepository repository) {
+        this.delegate = new DefaultOAuth2AuthorizationRequestResolver(repository, "/oauth2/authorization");
+    }
+
+    /**
+     * 요청 URI에서 클라이언트 등록 ID를 추출하여 인증 요청을 생성한다.
+     *
+     * @param request 현재 HTTP 요청
+     * @return {@code prompt=select_account}가 포함된 인증 요청, 해당 없으면 {@code null}
+     */
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
+        return withPrompt(delegate.resolve(request));
+    }
+
+    /**
+     * 지정된 클라이언트 등록 ID로 인증 요청을 생성한다.
+     *
+     * @param request              현재 HTTP 요청
+     * @param clientRegistrationId 사용할 OAuth2 클라이언트 등록 ID
+     * @return {@code prompt=select_account}가 포함된 인증 요청, 해당 없으면 {@code null}
+     */
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request, String clientRegistrationId) {
+        return withPrompt(delegate.resolve(request, clientRegistrationId));
+    }
+
+    /**
+     * 인증 요청에 {@code prompt=select_account} 파라미터를 추가한다.
+     *
+     * @param authorizationRequest 원본 인증 요청, {@code null}이면 그대로 반환
+     * @return {@code prompt} 파라미터가 추가된 인증 요청
+     */
+    private OAuth2AuthorizationRequest withPrompt(OAuth2AuthorizationRequest authorizationRequest) {
+        if (authorizationRequest == null) return null;
+
+        return OAuth2AuthorizationRequest.from(authorizationRequest)
+                .additionalParameters(params -> params.put("prompt", "select_account"))
+                .build();
+    }
+}

--- a/apps/be/src/main/java/com/capstone/logue/auth/security/CustomOAuth2AuthorizationRequestResolver.java
+++ b/apps/be/src/main/java/com/capstone/logue/auth/security/CustomOAuth2AuthorizationRequestResolver.java
@@ -19,6 +19,8 @@ import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequ
  */
 public class CustomOAuth2AuthorizationRequestResolver implements OAuth2AuthorizationRequestResolver {
 
+    private static final String GOOGLE_REGISTRATION_ID = "google";
+
     private final DefaultOAuth2AuthorizationRequestResolver delegate;
 
     /**
@@ -48,7 +50,9 @@ public class CustomOAuth2AuthorizationRequestResolver implements OAuth2Authoriza
      */
     @Override
     public OAuth2AuthorizationRequest resolve(HttpServletRequest request, String clientRegistrationId) {
-        return withPrompt(delegate.resolve(request, clientRegistrationId));
+        OAuth2AuthorizationRequest authorizationRequest = delegate.resolve(request, clientRegistrationId);
+        if (!GOOGLE_REGISTRATION_ID.equals(clientRegistrationId)) return authorizationRequest;
+        return withPrompt(authorizationRequest);
     }
 
     /**

--- a/apps/be/src/main/java/com/capstone/logue/global/config/SecurityConfig.java
+++ b/apps/be/src/main/java/com/capstone/logue/global/config/SecurityConfig.java
@@ -6,6 +6,8 @@ import com.capstone.logue.auth.filter.JWTFilter;
 import com.capstone.logue.auth.handler.OAuth2LoginFailureHandler;
 import com.capstone.logue.auth.handler.OAuth2LoginSuccessHandler;
 import com.capstone.logue.auth.provider.JWTProvider;
+import com.capstone.logue.auth.security.CustomOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -38,6 +40,7 @@ public class SecurityConfig {
     private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
     private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
     private final JWTProvider jwtProvider;
+    private final ClientRegistrationRepository clientRegistrationRepository;
 
     @Bean
     public CorsFilter corsFilter() {
@@ -68,6 +71,9 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(HttpBasicConfigurer::disable)
                 .oauth2Login((oauth2) -> oauth2
+                        .authorizationEndpoint(endpoint -> endpoint
+                                .authorizationRequestResolver(
+                                        new CustomOAuth2AuthorizationRequestResolver(clientRegistrationRepository)))
                         .successHandler(oAuth2LoginSuccessHandler)
                         .failureHandler(oAuth2LoginFailureHandler))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))

--- a/apps/be/src/test/java/com/capstone/logue/auth/security/CustomOAuth2AuthorizationRequestResolverTest.java
+++ b/apps/be/src/test/java/com/capstone/logue/auth/security/CustomOAuth2AuthorizationRequestResolverTest.java
@@ -1,0 +1,110 @@
+package com.capstone.logue.auth.security;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CustomOAuth2AuthorizationRequestResolverTest {
+
+    @Mock
+    private ClientRegistrationRepository clientRegistrationRepository;
+
+    private CustomOAuth2AuthorizationRequestResolver resolver;
+
+    @BeforeEach
+    void setUp() {
+        resolver = new CustomOAuth2AuthorizationRequestResolver(clientRegistrationRepository);
+    }
+
+    private ClientRegistration googleRegistration() {
+        return ClientRegistration.withRegistrationId("google")
+                .clientId("google-client-id")
+                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                .redirectUri("{baseUrl}/login/oauth2/code/{registrationId}")
+                .authorizationUri("https://accounts.google.com/o/oauth2/auth")
+                .tokenUri("https://oauth2.googleapis.com/token")
+                .userInfoUri("https://www.googleapis.com/oauth2/v3/userinfo")
+                .userNameAttributeName("sub")
+                .scope("openid", "email", "profile")
+                .build();
+    }
+
+    private ClientRegistration githubRegistration() {
+        return ClientRegistration.withRegistrationId("github")
+                .clientId("github-client-id")
+                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                .redirectUri("{baseUrl}/login/oauth2/code/{registrationId}")
+                .authorizationUri("https://github.com/login/oauth/authorize")
+                .tokenUri("https://github.com/login/oauth/access_token")
+                .userInfoUri("https://api.github.com/user")
+                .userNameAttributeName("id")
+                .scope("read:user")
+                .build();
+    }
+
+    private MockHttpServletRequest requestFor(String registrationId) {
+        MockHttpServletRequest request = new MockHttpServletRequest(
+                "GET", "/oauth2/authorization/" + registrationId);
+        request.setScheme("http");
+        request.setServerName("localhost");
+        request.setServerPort(8080);
+        return request;
+    }
+
+    @Test
+    @DisplayName("resolve(request): Google 경로 요청이면 prompt=select_account가 추가된다")
+    void resolve_withGoogleRequest_addsPrompt() {
+        when(clientRegistrationRepository.findByRegistrationId("google"))
+                .thenReturn(googleRegistration());
+
+        OAuth2AuthorizationRequest result = resolver.resolve(requestFor("google"));
+
+        assertThat(result).isNotNull();
+        assertThat(result.getAdditionalParameters()).containsEntry("prompt", "select_account");
+    }
+
+    @Test
+    @DisplayName("resolve(request): 매칭되지 않는 경로면 null을 반환한다")
+    void resolve_withNonMatchingPath_returnsNull() {
+        OAuth2AuthorizationRequest result = resolver.resolve(
+                new MockHttpServletRequest("GET", "/some/other/path"));
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("resolve(request, registrationId): Google ID면 prompt=select_account가 추가된다")
+    void resolveWithRegistrationId_withGoogleId_addsPrompt() {
+        when(clientRegistrationRepository.findByRegistrationId("google"))
+                .thenReturn(googleRegistration());
+
+        OAuth2AuthorizationRequest result = resolver.resolve(requestFor("google"), "google");
+
+        assertThat(result).isNotNull();
+        assertThat(result.getAdditionalParameters()).containsEntry("prompt", "select_account");
+    }
+
+    @Test
+    @DisplayName("resolve(request, registrationId): Google이 아닌 ID면 prompt 파라미터를 추가하지 않는다")
+    void resolveWithRegistrationId_withNonGoogleId_doesNotAddPrompt() {
+        when(clientRegistrationRepository.findByRegistrationId("github"))
+                .thenReturn(githubRegistration());
+
+        OAuth2AuthorizationRequest result = resolver.resolve(requestFor("github"), "github");
+
+        assertThat(result).isNotNull();
+        assertThat(result.getAdditionalParameters()).doesNotContainKey("prompt");
+    }
+}

--- a/apps/be/src/test/java/com/capstone/logue/global/config/SecurityConfigOAuth2IntegrationTest.java
+++ b/apps/be/src/test/java/com/capstone/logue/global/config/SecurityConfigOAuth2IntegrationTest.java
@@ -1,0 +1,56 @@
+package com.capstone.logue.global.config;
+
+import com.capstone.logue.auth.handler.OAuth2LoginFailureHandler;
+import com.capstone.logue.auth.handler.OAuth2LoginSuccessHandler;
+import com.capstone.logue.auth.provider.JWTProvider;
+import com.capstone.logue.global.discord.DiscordWebhookService;
+import com.capstone.logue.user.controller.UserController;
+import com.capstone.logue.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * SecurityConfig의 oauth2Login 설정에서
+ * CustomOAuth2AuthorizationRequestResolver가 올바르게 등록되어
+ * Google 인증 리다이렉트 URL에 prompt=select_account가 포함되는지 검증합니다.
+ */
+@WebMvcTest(UserController.class)
+@Import(SecurityConfig.class)
+class SecurityConfigOAuth2IntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private UserRepository userRepository;
+
+    @MockitoBean
+    private JWTProvider jwtProvider;
+
+    @MockitoBean
+    private OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+
+    @MockitoBean
+    private OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
+
+    @MockitoBean
+    private DiscordWebhookService discordWebhookService;
+
+    @Test
+    @DisplayName("GET /oauth2/authorization/google 리다이렉트 URL에 prompt=select_account가 포함된다")
+    void oauth2AuthorizationRequest_containsPromptSelectAccount() throws Exception {
+        mockMvc.perform(get("/oauth2/authorization/google"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(header().string("Location", containsString("prompt=select_account")));
+    }
+}


### PR DESCRIPTION
## 요약
- 로그아웃 후 브라우저에 Google SSO 세션이 남아있어 계정 선택 화면 없이 자동 인증되는 문제 수정 (Google OAuth 인증 URL 생성 시 prompt=select_account 파라미터를 추가하여 재로그인 시 항상 계정 선택 화면 표시)

## 변경 사항
- [x] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [ ] 로컬 테스트 완료
- 테스트 방법:
  - Google 계정으로 로그인 후 로그아웃
  - 재로그인 시 Google 계정 선택 화면이 표시되는지 확인
  - 브라우저에 Google SSO 세션이 남아있는 상태에서도 자동 인증되지 않는지 확인

## 스크린샷/로그 (선택)
- 필요한 경우 첨부

## 롤백/리스크
- 리스크 포인트: 없음 (prompt=select_account는 표준 Google OAuth2 파라미터로 인증 플로우 자체에 영향 없음)
- 롤백 방법: CustomOAuth2AuthorizationRequestResolver 삭제 및 SecurityConfig 변경분 revert

## 관련 이슈
Closes #379


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth2 로그인 시 계정 선택 프롬프트 기능을 추가했습니다. 사용자가 OAuth2 인증 과정에서 사용할 계정을 명확하게 선택할 수 있도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->