### PR TITLE
fix(ai): QUESTION_DATA_MISMATCH 결정론 추론을 DIMENSION/MEASURE 모호 신호로 확장 (#428)

### DIFF
--- a/apps/ai/rules/warning_rules.py
+++ b/apps/ai/rules/warning_rules.py
@@ -119,17 +119,41 @@ def infer_date_conflict_warning(
     ]
 
 
+def _qdm_name_prefix(column_name: str) -> str:
+    """컬럼명의 첫 토큰(`_` 기준, 소문자)을 반환한다.
+
+    suffix 공유(예: `activated_users` 와 `paid_users` 의 `users`)는 정상 데이터셋에서도
+    흔하므로 모호 신호로 보지 않는다. prefix 만 비교해 오탐을 피한다.
+    """
+    return column_name.split("_", 1)[0].lower()
+
+
+def _columns_look_ambiguous(a, b) -> bool:
+    """두 컬럼이 같은 의미를 가리킬 가능성(모호)을 결정론적으로 판정한다.
+
+    신호 두 가지 중 하나라도 만족하면 모호로 본다.
+    1. sample_values 값 공간이 겹친다 (같은 카테고리 값을 공유 = 같은 축).
+    2. 이름 prefix(첫 토큰)를 공유한다 (예: `device`, `device_type`, `device_kind`).
+    """
+    a_vals = {str(v).lower() for v in (a.sample_values or [])}
+    b_vals = {str(v).lower() for v in (b.sample_values or [])}
+    if a_vals and b_vals and (a_vals & b_vals):
+        return True
+    return _qdm_name_prefix(a.column_name) == _qdm_name_prefix(b.column_name)
+
+
 def infer_qdm_warning(
     response: QuestionAnalysisResponse,
     request: QuestionAnalysisRequest,
 ) -> list[FlowWarning]:
     """데이터 기반으로 QUESTION_DATA_MISMATCH warning 을 결정론적으로 추론한다.
 
-    FLAG 또는 STATUS_CONDITION role 의 컬럼이 동일 role 에서 2개 이상이면
-    질문-데이터 매핑이 모호하므로 QUESTION_DATA_MISMATCH 를 반환한다.
-    DIMENSION/MEASURE 는 정상 데이터셋에서도 복수 존재하므로 제외한다.
-    catalog.flow_warning_keys 에 QUESTION_DATA_MISMATCH 가 정의돼 있지 않으면
-    추론하지 않는다.
+    role 별 모호 판정 기준이 다르다.
+    - FLAG / STATUS_CONDITION: 정상 데이터셋에서 0~1개라 2개 이상이면 곧 모호.
+    - DIMENSION / MEASURE: 정상 데이터셋도 복수(채널+디바이스, measure 다수)라 개수만으로는
+      판정하지 않는다. 같은 role 컬럼 쌍이 sample_values 가 겹치거나 이름 prefix 를 공유할 때만
+      모호로 본다 (`_columns_look_ambiguous`).
+    catalog.flow_warning_keys 에 QUESTION_DATA_MISMATCH 가 정의돼 있지 않으면 추론하지 않는다.
     """
     if response.analysis_criteria is None:
         return []
@@ -138,20 +162,35 @@ def infer_qdm_warning(
     if FlowWarningKey.QUESTION_DATA_MISMATCH not in catalog_codes:
         return []
 
-    target_roles = {SemanticRoleType.FLAG, SemanticRoleType.STATUS_CONDITION}
-
-    role_to_columns: dict[SemanticRoleType, list[str]] = {}
+    by_role: dict[SemanticRoleType, list] = {}
     for col in request.data_source.columns:
-        if col.semantic_role in target_roles:
-            role_to_columns.setdefault(col.semantic_role, []).append(col.column_name)
+        by_role.setdefault(col.semantic_role, []).append(col)
 
     related_fields: list[str] = []
+
+    def _add(names: list[str]) -> None:
+        for n in names:
+            if n not in related_fields:
+                related_fields.append(n)
+
+    # 개수 기준 (singular-by-contract roles)
     for role in (SemanticRoleType.FLAG, SemanticRoleType.STATUS_CONDITION):
-        cols = role_to_columns.get(role, [])
+        cols = by_role.get(role, [])
         if len(cols) >= 2:
-            for c in cols:
-                if c not in related_fields:
-                    related_fields.append(c)
+            _add([c.column_name for c in cols])
+
+    # 모호 신호 기준 (plural-by-contract roles)
+    for role in (SemanticRoleType.DIMENSION, SemanticRoleType.MEASURE):
+        cols = by_role.get(role, [])
+        if len(cols) < 2:
+            continue
+        ambiguous: set[str] = set()
+        for i in range(len(cols)):
+            for j in range(i + 1, len(cols)):
+                if _columns_look_ambiguous(cols[i], cols[j]):
+                    ambiguous.add(cols[i].column_name)
+                    ambiguous.add(cols[j].column_name)
+        _add([c.column_name for c in cols if c.column_name in ambiguous])
 
     if not related_fields:
         return []

--- a/apps/ai/tests/test_warning_inference.py
+++ b/apps/ai/tests/test_warning_inference.py
@@ -380,3 +380,113 @@ def test_apply_adds_qdm_warning() -> None:
     assert any(
         w.code == FlowWarningKey.QUESTION_DATA_MISMATCH for w in response.warnings
     )
+
+
+# ---------- QDM DIMENSION/MEASURE 모호 신호 (sample_values 겹침 / 이름 prefix) ----------
+
+
+def _request_with_columns(
+    specs: list[tuple[str, str, list]],
+    *,
+    with_qdm_key: bool = True,
+) -> QuestionAnalysisRequest:
+    """specs = (column_name, semantic_role, sample_values) 목록으로 요청을 구성한다."""
+    columns: list[DataSourceColumn] = [
+        DataSourceColumn(
+            column_name="signed_at", data_type="datetime",
+            semantic_role="DATE_CRITERIA", null_ratio=0.0, sample_values=[],
+        )
+    ]
+    for name, role, samples in specs:
+        columns.append(
+            DataSourceColumn(
+                column_name=name,
+                data_type="double" if role == "MEASURE" else "string",
+                semantic_role=role, null_ratio=0.0, sample_values=samples,
+            )
+        )
+    flow_warning_keys: list[FlowWarningKeyCatalog] = []
+    if with_qdm_key:
+        flow_warning_keys.append(
+            FlowWarningKeyCatalog(code="QUESTION_DATA_MISMATCH", name="...", comment="..."),
+        )
+    return QuestionAnalysisRequest(
+        request_id="req_cols", conversation_id=1, question=Question(content="?"),
+        data_source=DataSource(id=1, columns=columns),
+        catalog=Catalog(
+            analysis_types=["COMPARISON", "RANKING"], metric_types=["RATIO"],
+            predefined_metrics=[
+                PredefinedMetric(
+                    metric_name="cr", display_name="전환율", metric_type="RATIO",
+                    formula_numerator="a", formula_denominator="b",
+                ),
+            ],
+            supported_periods=["this_week", "last_week"],
+            flow_warning_keys=flow_warning_keys,
+        ),
+    )
+
+
+def test_dimension_overlapping_sample_values_infers_qdm() -> None:
+    req = _request_with_columns([
+        ("channel", "DIMENSION", ["paid_search", "organic"]),
+        ("source", "DIMENSION", ["paid_search", "organic"]),
+        ("device", "DIMENSION", ["mobile", "desktop"]),
+    ])
+    warnings = infer_qdm_warning(_response(_criteria()), req)
+    assert len(warnings) == 1
+    rf = warnings[0].related_fields or []
+    assert "channel" in rf and "source" in rf
+    assert "device" not in rf  # 값 공간이 달라 모호 대상 아님
+
+
+def test_dimension_shared_prefix_infers_qdm() -> None:
+    req = _request_with_columns([
+        ("device", "DIMENSION", ["mobile", "desktop", "tablet"]),
+        ("device_type", "DIMENSION", ["smartphone"]),
+        ("device_kind", "DIMENSION", ["touch"]),
+    ])
+    warnings = infer_qdm_warning(_response(_criteria()), req)
+    assert len(warnings) == 1
+    assert {"device", "device_type", "device_kind"} <= set(warnings[0].related_fields or [])
+
+
+def test_distinct_dimensions_no_qdm() -> None:
+    req = _request_with_columns([
+        ("channel", "DIMENSION", ["paid_search", "organic", "referral"]),
+        ("device", "DIMENSION", ["mobile", "desktop", "tablet"]),
+    ])
+    assert infer_qdm_warning(_response(_criteria()), req) == []
+
+
+def test_measure_shared_suffix_no_qdm() -> None:
+    # activated_users / paid_users: suffix 'users' 공유하나 prefix 와 값이 달라 오탐 금지.
+    req = _request_with_columns([
+        ("activated_users", "MEASURE", []),
+        ("paid_users", "MEASURE", []),
+        ("landing_sessions", "MEASURE", []),
+    ])
+    assert infer_qdm_warning(_response(_criteria()), req) == []
+
+
+def test_real_fixtures_qdm_behaviour() -> None:
+    """실제 eval fixture 로 AMB(모호)=QDM, 정상 dataset-a/b=무발생 을 고정한다."""
+    import json
+    from eval.composers.question_analysis import compose_request
+    from eval.loader import CASES_DIR
+
+    def _req(category: str, case_id: str) -> QuestionAnalysisRequest:
+        spec = json.loads((CASES_DIR / "question_analysis" / category / f"{case_id}.json").read_text())["spec"]
+        return QuestionAnalysisRequest.model_validate(compose_request(spec))
+
+    def _has_qdm(req: QuestionAnalysisRequest) -> bool:
+        return any(
+            w.code == FlowWarningKey.QUESTION_DATA_MISMATCH
+            for w in infer_qdm_warning(_response(_criteria()), req)
+        )
+
+    assert _has_qdm(_req("amb", "AMB-01"))   # dataset-c channel/source 값 겹침
+    assert _has_qdm(_req("amb", "AMB-02"))   # dataset-c 동일
+    assert _has_qdm(_req("amb", "AMB-07"))   # device* prefix 공유
+    assert not _has_qdm(_req("cmp", "CMP-01"))  # dataset-a 정상
+    assert not _has_qdm(_req("cmp", "CMP-08"))  # dataset-b 정상


### PR DESCRIPTION
## 요약
- QDM 결정론 추론을 DIMENSION/MEASURE 까지 확장. 개수가 아니라 (sample_values 겹침 OR 이름 prefix 공유) 신호로 판정하여 AMB-01, AMB-02, AMB-07 을 결정론적으로 잡고 정상 데이터셋 오탐을 피함

## 변경 사항
- [x] 버그 수정

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - cd apps/ai && python -m pytest -q (201 passed)
  - 실제 fixture 합성 테스트로 AMB-01/02/07 QDM 발동, CMP-01(dataset-a)/CMP-08(dataset-b) 무발동(오탐 0) 고정

## 롤백/리스크
- 리스크 포인트: DIMENSION/MEASURE 는 개수가 아닌 값 겹침/이름 prefix 신호만 사용하므로 채널+디바이스, activated_users+paid_users 같은 정상 컬럼은 발동하지 않음. FLAG/STATUS_CONDITION 은 기존 개수 기준 유지
- 롤백 방법: 본 커밋 revert

## 관련 이슈
Closes #428