### PR TITLE
feat(ai): LLM 호출 usage·estimated_cost_usd 이벤트 emit 배선 (#426)

### DIFF
--- a/apps/ai/llm/__init__.py
+++ b/apps/ai/llm/__init__.py
@@ -1,6 +1,6 @@
 """LLM 호출 공통 모듈 (OpenAI Structured Outputs)."""
 
-from llm.client import LLMClient, LLMResponseEmptyError
+from llm.client import LLMClient, LLMResponseEmptyError, TokenUsage
 from llm.prompt_loader import load_system_prompt, prompt_version_id
 from llm.retry import RETRYABLE_EXCEPTIONS, with_retry
 
@@ -8,6 +8,7 @@ __all__ = [
     "LLMClient",
     "LLMResponseEmptyError",
     "RETRYABLE_EXCEPTIONS",
+    "TokenUsage",
     "load_system_prompt",
     "prompt_version_id",
     "with_retry",

--- a/apps/ai/llm/client.py
+++ b/apps/ai/llm/client.py
@@ -10,6 +10,7 @@ user payload / Pydantic response_model / model 식별자 / temperature / max_out
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 import json
 import logging
 from typing import Any, TypeVar
@@ -24,6 +25,41 @@ from llm.retry import RETRYABLE_EXCEPTIONS, with_retry
 logger = logging.getLogger("logue_ai")
 
 T = TypeVar("T", bound=BaseModel)
+
+
+@dataclass(frozen=True)
+class TokenUsage:
+    """OpenAI usage 응답을 비용 계산·로깅에 쓰기 좋게 정규화한 토큰 사용량.
+
+    `cached_input_tokens` 는 `input_tokens` 의 부분집합 (prompt_tokens_details.cached_tokens).
+    usage 가 없는 응답(스텁·예외 경로)에서는 전부 0 으로 채운다.
+    """
+
+    input_tokens: int = 0
+    cached_input_tokens: int = 0
+    output_tokens: int = 0
+    total_tokens: int = 0
+
+
+def _extract_usage(completion: Any) -> TokenUsage:
+    """OpenAI completion.usage 를 TokenUsage 로 정규화한다 (필드 누락에 방어적).
+
+    Structured Outputs 응답은 `usage.prompt_tokens` · `completion_tokens` · `total_tokens`
+    와 `usage.prompt_tokens_details.cached_tokens` 를 제공한다. 일부 필드가 없거나
+    usage 자체가 None 인 경우에도 0 으로 안전하게 채운다.
+    """
+    usage = getattr(completion, "usage", None)
+    if usage is None:
+        return TokenUsage()
+
+    details = getattr(usage, "prompt_tokens_details", None)
+    cached = getattr(details, "cached_tokens", 0) if details is not None else 0
+    return TokenUsage(
+        input_tokens=int(getattr(usage, "prompt_tokens", 0) or 0),
+        cached_input_tokens=int(cached or 0),
+        output_tokens=int(getattr(usage, "completion_tokens", 0) or 0),
+        total_tokens=int(getattr(usage, "total_tokens", 0) or 0),
+    )
 
 
 class LLMResponseEmptyError(Exception):
@@ -58,12 +94,13 @@ class LLMClient:
         model: str,
         temperature: float = 0.0,
         max_output_tokens: int | None = None,
-    ) -> T:
-        """system_prompt + user_payload 를 OpenAI 에 전달해 response_model 인스턴스를 반환한다.
+    ) -> tuple[T, TokenUsage]:
+        """system_prompt + user_payload 를 OpenAI 에 전달해 (response_model, 토큰 usage) 를 반환한다.
 
-        - user_payload 가 dict 면 JSON 직렬화 (ensure_ascii=False — 한글 그대로)
+        - user_payload 가 dict 면 JSON 직렬화 (ensure_ascii=False 로 한글 그대로)
         - response_format 에 Pydantic 모델 클래스를 전달하여 Structured Outputs 강제
         - parsed=None (refusal 등) 은 `LLMResponseEmptyError` 로 raise
+        - 반환 tuple 의 두 번째 요소는 비용 계산·로깅용 `TokenUsage`
         """
         user_message = (
             user_payload
@@ -89,4 +126,4 @@ class LLMClient:
             raise LLMResponseEmptyError(
                 "OpenAI 응답이 비어있습니다 (parsed=None — refusal 또는 컨텐츠 필터 가능성)."
             )
-        return parsed
+        return parsed, _extract_usage(completion)

--- a/apps/ai/observability/__init__.py
+++ b/apps/ai/observability/__init__.py
@@ -7,6 +7,7 @@
 from observability.cost import calculate_cost_usd
 from observability.hashing import sha256_of
 from observability.logger import LLMEventBuilder, emit_event
+from observability.recording import record_llm_call
 from observability.redaction import redact_chart_data, redact_data_source
 
 
@@ -14,6 +15,7 @@ __all__ = [
     "LLMEventBuilder",
     "calculate_cost_usd",
     "emit_event",
+    "record_llm_call",
     "redact_chart_data",
     "redact_data_source",
     "sha256_of",

--- a/apps/ai/observability/recording.py
+++ b/apps/ai/observability/recording.py
@@ -1,0 +1,59 @@
+"""LLM 호출 1회의 usage·estimated_cost_usd 를 단일 JSONL 이벤트로 emit 하는 헬퍼.
+
+`LLMEventBuilder` + `calculate_cost_usd` 를 묶어 서비스(v1_baseline) 호출부가 한 줄로
+호출 단위 비용을 기록하게 한다. 이벤트는 stdout 으로 흐르고 CloudWatch 가 수집한다.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from observability.cost import calculate_cost_usd
+from observability.logger import LLMEventBuilder
+
+
+class _Usage(Protocol):
+    """record_llm_call 이 읽는 토큰 사용량 구조 (llm.client.TokenUsage 와 호환)."""
+
+    input_tokens: int
+    cached_input_tokens: int
+    output_tokens: int
+    total_tokens: int
+
+
+def record_llm_call(
+    *,
+    api_name: str,
+    request_id: str,
+    model: str,
+    temperature: float,
+    max_output_tokens: int,
+    usage: _Usage,
+) -> None:
+    """호출 단위 usage·estimated_cost_usd 이벤트 한 줄을 emit 한다.
+
+    cost 는 `calculate_cost_usd` 단가표 기반 추정값이며, 미등록 모델은 0.0 으로 기록돼
+    운영자가 단가표 누락을 알아챌 수 있게 한다.
+    """
+    estimated_cost_usd = calculate_cost_usd(
+        model=model,
+        input_tokens=usage.input_tokens,
+        cached_input_tokens=usage.cached_input_tokens,
+        output_tokens=usage.output_tokens,
+    )
+    (
+        LLMEventBuilder(api_name=api_name, request_id=request_id)
+        .with_llm_call(
+            model=model,
+            temperature=temperature,
+            max_output_tokens=max_output_tokens,
+        )
+        .with_usage(
+            input_tokens=usage.input_tokens,
+            cached_input_tokens=usage.cached_input_tokens,
+            output_tokens=usage.output_tokens,
+            total_tokens=usage.total_tokens,
+        )
+        .with_cost(estimated_cost_usd)
+        .emit()
+    )

--- a/apps/ai/services/file_analysis/v1_baseline.py
+++ b/apps/ai/services/file_analysis/v1_baseline.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from llm import LLMClient, load_system_prompt
 from config.model_config import model_config_for
+from observability import record_llm_call
 from schemas.api.file_analysis import FileAnalysisRequest, FileAnalysisResponse
 from schemas.llm_input.file_analysis_input import FileAnalysisLLMInput
 
@@ -46,9 +47,16 @@ def run(req: FileAnalysisRequest) -> FileAnalysisResponse:
     """
     llm_input = FileAnalysisLLMInput.from_request(req)
 
-    return _get_client().complete_structured(
+    response, usage = _get_client().complete_structured(
         system_prompt=load_system_prompt("file_analysis"),
         user_payload=llm_input.model_dump(exclude={"request_id"}),
         response_model=FileAnalysisResponse,
         **_cfg.as_llm_kwargs(),
     )
+    record_llm_call(
+        api_name="file_analysis",
+        request_id=req.request_id,
+        usage=usage,
+        **_cfg.as_llm_kwargs(),
+    )
+    return response

--- a/apps/ai/services/question_analysis/v1_baseline.py
+++ b/apps/ai/services/question_analysis/v1_baseline.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from llm import LLMClient, load_system_prompt
 from config.model_config import model_config_for
+from observability import record_llm_call
 from schemas.api.question_analysis import QuestionAnalysisRequest, QuestionAnalysisResponse
 from schemas.llm_input.question_analysis_input import QuestionAnalysisLLMInput
 
@@ -46,9 +47,16 @@ def run(req: QuestionAnalysisRequest) -> QuestionAnalysisResponse:
     """
     llm_input = QuestionAnalysisLLMInput.from_request(req)
 
-    return _get_client().complete_structured(
+    response, usage = _get_client().complete_structured(
         system_prompt=load_system_prompt("question_analysis"),
         user_payload=llm_input.model_dump(exclude={"request_id"}),
         response_model=QuestionAnalysisResponse,
         **_cfg.as_llm_kwargs(),
     )
+    record_llm_call(
+        api_name="question_analysis",
+        request_id=req.request_id,
+        usage=usage,
+        **_cfg.as_llm_kwargs(),
+    )
+    return response

--- a/apps/ai/services/result_summary/v1_baseline.py
+++ b/apps/ai/services/result_summary/v1_baseline.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from llm import LLMClient, load_system_prompt
 from config.model_config import model_config_for
+from observability import record_llm_call
 from schemas.api.result_summary import AnalysisSummaryRequest, AnalysisSummaryResponse
 from schemas.llm_input.result_summary_input import AnalysisSummaryLLMInput
 
@@ -47,9 +48,16 @@ def run(req: AnalysisSummaryRequest) -> AnalysisSummaryResponse:
     """
     llm_input = AnalysisSummaryLLMInput.from_request(req)
 
-    return _get_client().complete_structured(
+    response, usage = _get_client().complete_structured(
         system_prompt=load_system_prompt("result_summary"),
         user_payload=llm_input.model_dump(exclude={"request_id"}),
         response_model=AnalysisSummaryResponse,
         **_cfg.as_llm_kwargs(),
     )
+    record_llm_call(
+        api_name="result_summary",
+        request_id=req.request_id,
+        usage=usage,
+        **_cfg.as_llm_kwargs(),
+    )
+    return response

--- a/apps/ai/tests/test_file_analysis_v1_baseline.py
+++ b/apps/ai/tests/test_file_analysis_v1_baseline.py
@@ -24,7 +24,7 @@ import httpx
 import pytest
 from openai import APITimeoutError
 
-from llm import LLMResponseEmptyError
+from llm import LLMResponseEmptyError, TokenUsage
 from schemas.api.file_analysis import (
     Catalog,
     ColumnMeta,
@@ -37,6 +37,13 @@ from schemas.api.file_analysis import (
     SourceWarningKey,
 )
 from services.file_analysis import v1_baseline
+
+
+# complete_structured 는 (response, TokenUsage) 를 반환한다. 호출 인자/반환 검증
+# 테스트에서는 usage 값 자체가 의미 없으므로 고정 더미를 쓴다.
+_USAGE = TokenUsage(
+    input_tokens=100, cached_input_tokens=0, output_tokens=50, total_tokens=150
+)
 
 
 # ────────────────────────────────────────────────────────────────
@@ -155,7 +162,7 @@ def test_run_calls_llm_with_model_gpt4_nano(
     mock_client: MagicMock, mock_prompt: None
 ) -> None:
     req = _make_request()
-    mock_client.complete_structured.return_value = _make_valid_response(req)
+    mock_client.complete_structured.return_value = (_make_valid_response(req), _USAGE)
 
     v1_baseline.run(req)
 
@@ -167,7 +174,7 @@ def test_run_calls_llm_with_temperature_zero(
     mock_client: MagicMock, mock_prompt: None
 ) -> None:
     req = _make_request()
-    mock_client.complete_structured.return_value = _make_valid_response(req)
+    mock_client.complete_structured.return_value = (_make_valid_response(req), _USAGE)
 
     v1_baseline.run(req)
 
@@ -179,7 +186,7 @@ def test_run_calls_llm_with_max_output_tokens_1600(
     mock_client: MagicMock, mock_prompt: None
 ) -> None:
     req = _make_request()
-    mock_client.complete_structured.return_value = _make_valid_response(req)
+    mock_client.complete_structured.return_value = (_make_valid_response(req), _USAGE)
 
     v1_baseline.run(req)
 
@@ -192,7 +199,7 @@ def test_run_calls_llm_with_response_model_file_analysis_response(
 ) -> None:
     """response_model 이 FileAnalysisResponse 클래스 자체여야 Structured Outputs 가 동작한다."""
     req = _make_request()
-    mock_client.complete_structured.return_value = _make_valid_response(req)
+    mock_client.complete_structured.return_value = (_make_valid_response(req), _USAGE)
 
     v1_baseline.run(req)
 
@@ -205,7 +212,7 @@ def test_run_excludes_request_id_from_user_payload(
 ) -> None:
     """user_payload 에 request_id 가 없어야 한다 (LLM 판단에 불필요)."""
     req = _make_request()
-    mock_client.complete_structured.return_value = _make_valid_response(req)
+    mock_client.complete_structured.return_value = (_make_valid_response(req), _USAGE)
 
     v1_baseline.run(req)
 
@@ -218,7 +225,7 @@ def test_run_includes_data_source_and_catalog_in_user_payload(
 ) -> None:
     """LLM 이 판단에 사용하는 핵심 필드는 user_payload 에 포함되어야 한다."""
     req = _make_request()
-    mock_client.complete_structured.return_value = _make_valid_response(req)
+    mock_client.complete_structured.return_value = (_make_valid_response(req), _USAGE)
 
     v1_baseline.run(req)
 
@@ -232,7 +239,7 @@ def test_run_passes_system_prompt_from_loader(
 ) -> None:
     """load_system_prompt 의 반환값이 system_prompt kwarg 로 그대로 전달돼야 한다."""
     req = _make_request()
-    mock_client.complete_structured.return_value = _make_valid_response(req)
+    mock_client.complete_structured.return_value = (_make_valid_response(req), _USAGE)
 
     v1_baseline.run(req)
 
@@ -245,7 +252,7 @@ def test_run_loads_system_prompt_with_name_file_analysis(
 ) -> None:
     """load_system_prompt 가 "file_analysis" 이름으로 호출되는지 확인."""
     req = _make_request()
-    mock_client.complete_structured.return_value = _make_valid_response(req)
+    mock_client.complete_structured.return_value = (_make_valid_response(req), _USAGE)
 
     captured: dict[str, str] = {}
 
@@ -270,12 +277,58 @@ def test_run_returns_llm_response_as_is(
     """LLMClient 반환값을 변환 없이 그대로 돌려줘야 한다."""
     req = _make_request()
     expected = _make_valid_response(req)
-    mock_client.complete_structured.return_value = expected
+    mock_client.complete_structured.return_value = (expected, _USAGE)
 
     result = v1_baseline.run(req)
 
     assert result is expected
     assert isinstance(result, FileAnalysisResponse)
+
+
+# ────────────────────────────────────────────────────────────────
+# 2.5 관측 이벤트 — 호출 단위 usage·cost emit
+# ────────────────────────────────────────────────────────────────
+
+def test_run_emits_llm_call_cost_event(
+    mock_client: MagicMock, mock_prompt: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """실호출 경로에서 api_name·usage·estimated_cost_usd 이벤트 1줄이 emit 돼야 한다."""
+    import json
+
+    req = _make_request()
+    mock_client.complete_structured.return_value = (
+        _make_valid_response(req),
+        TokenUsage(
+            input_tokens=1000,
+            cached_input_tokens=200,
+            output_tokens=300,
+            total_tokens=1300,
+        ),
+    )
+
+    v1_baseline.run(req)
+
+    events = [
+        json.loads(line)
+        for line in capsys.readouterr().out.strip().split("\n")
+        if line
+    ]
+    llm_events = [e for e in events if e.get("event_type") == "llm_call"]
+    assert len(llm_events) == 1
+
+    event = llm_events[0]
+    assert event["api_name"] == "file_analysis"
+    assert event["request_id"] == "req_test"
+    assert event["llm"]["model"] == "gpt-4.1-nano"
+    assert event["usage"]["input_tokens"] == 1000
+    assert event["usage"]["cached_input_tokens"] == 200
+    assert event["usage"]["output_tokens"] == 300
+
+    # gpt-4.1-nano: non-cached input 800*0.10 + cached 200*0.025 + output 300*0.40 (per 1M)
+    expected_cost = round(
+        (800 * 0.10 + 200 * 0.025 + 300 * 0.40) / 1_000_000, 6
+    )
+    assert event["cost"]["estimated_cost_usd"] == expected_cost
 
 
 # ────────────────────────────────────────────────────────────────

--- a/apps/ai/tests/test_llm_client.py
+++ b/apps/ai/tests/test_llm_client.py
@@ -13,7 +13,7 @@ import pytest
 from openai import APITimeoutError
 from pydantic import BaseModel
 
-from llm.client import LLMClient, LLMResponseEmptyError
+from llm.client import LLMClient, LLMResponseEmptyError, TokenUsage
 
 
 class DummyResponse(BaseModel):
@@ -21,9 +21,24 @@ class DummyResponse(BaseModel):
     score: int
 
 
-def _stub_completion(parsed: DummyResponse | None) -> MagicMock:
+def _make_usage(
+    *, prompt: int = 0, cached: int = 0, completion: int = 0, total: int = 0
+) -> MagicMock:
+    """OpenAI usage 응답 모양의 스텁 (prompt_tokens_details.cached_tokens 포함)."""
+    usage = MagicMock()
+    usage.prompt_tokens = prompt
+    usage.completion_tokens = completion
+    usage.total_tokens = total
+    usage.prompt_tokens_details.cached_tokens = cached
+    return usage
+
+
+def _stub_completion(
+    parsed: DummyResponse | None, *, usage: MagicMock | None = None
+) -> MagicMock:
     completion = MagicMock()
     completion.choices = [MagicMock(message=MagicMock(parsed=parsed))]
+    completion.usage = usage
     return completion
 
 
@@ -43,7 +58,7 @@ def test_complete_structured_returns_parsed_model(client: LLMClient) -> None:
     parse_mock = MagicMock(return_value=_stub_completion(expected))
     client._client.chat.completions.parse = parse_mock  # type: ignore[attr-defined]
 
-    result = client.complete_structured(
+    parsed, _usage = client.complete_structured(
         system_prompt="rules",
         user_payload={"q": "x"},
         response_model=DummyResponse,
@@ -51,7 +66,7 @@ def test_complete_structured_returns_parsed_model(client: LLMClient) -> None:
         max_output_tokens=300,
     )
 
-    assert result == expected
+    assert parsed == expected
     call_kwargs = parse_mock.call_args.kwargs
     assert call_kwargs["model"] == "gpt-4.1-nano"
     assert call_kwargs["response_format"] is DummyResponse
@@ -59,6 +74,43 @@ def test_complete_structured_returns_parsed_model(client: LLMClient) -> None:
     assert call_kwargs["messages"][0] == {"role": "system", "content": "rules"}
     assert call_kwargs["messages"][1]["role"] == "user"
     assert "q" in call_kwargs["messages"][1]["content"]
+
+
+def test_complete_structured_returns_normalized_token_usage(client: LLMClient) -> None:
+    expected = DummyResponse(message="hi", score=1)
+    usage = _make_usage(prompt=2000, cached=500, completion=600, total=2600)
+    parse_mock = MagicMock(return_value=_stub_completion(expected, usage=usage))
+    client._client.chat.completions.parse = parse_mock  # type: ignore[attr-defined]
+
+    parsed, token_usage = client.complete_structured(
+        system_prompt="x",
+        user_payload="y",
+        response_model=DummyResponse,
+        model="gpt-4.1-nano",
+    )
+
+    assert parsed == expected
+    assert isinstance(token_usage, TokenUsage)
+    assert token_usage.input_tokens == 2000
+    assert token_usage.cached_input_tokens == 500
+    assert token_usage.output_tokens == 600
+    assert token_usage.total_tokens == 2600
+
+
+def test_complete_structured_usage_defaults_to_zero_when_missing(client: LLMClient) -> None:
+    """usage 가 없는 응답에서도 TokenUsage 가 0 으로 안전하게 채워져야 한다."""
+    expected = DummyResponse(message="hi", score=1)
+    parse_mock = MagicMock(return_value=_stub_completion(expected, usage=None))
+    client._client.chat.completions.parse = parse_mock  # type: ignore[attr-defined]
+
+    _parsed, token_usage = client.complete_structured(
+        system_prompt="x",
+        user_payload="y",
+        response_model=DummyResponse,
+        model="gpt-4.1-nano",
+    )
+
+    assert token_usage == TokenUsage()
 
 
 def test_complete_structured_serializes_dict_user_payload_as_utf8_json(
@@ -118,14 +170,14 @@ def test_complete_structured_retries_once_on_timeout_then_succeeds(
     )
     client._client.chat.completions.parse = parse_mock  # type: ignore[attr-defined]
 
-    result = client.complete_structured(
+    parsed, _usage = client.complete_structured(
         system_prompt="x",
         user_payload="y",
         response_model=DummyResponse,
         model="gpt-4.1-nano",
     )
 
-    assert result == expected
+    assert parsed == expected
     assert parse_mock.call_count == 2
 
 

--- a/apps/ai/tests/test_question_analysis_v1_baseline.py
+++ b/apps/ai/tests/test_question_analysis_v1_baseline.py
@@ -24,7 +24,7 @@ import httpx
 import pytest
 from openai import APITimeoutError
 
-from llm import LLMResponseEmptyError
+from llm import LLMResponseEmptyError, TokenUsage
 from schemas.api.question_analysis import (
     Catalog,
     DataSource,
@@ -36,6 +36,13 @@ from schemas.api.question_analysis import (
     QuestionAnalysisResponse,
 )
 from services.question_analysis import v1_baseline
+
+
+# complete_structured 는 (response, TokenUsage) 를 반환한다. 호출 인자/반환 검증
+# 테스트에서는 usage 값 자체가 의미 없으므로 고정 더미를 쓴다.
+_USAGE = TokenUsage(
+    input_tokens=100, cached_input_tokens=0, output_tokens=50, total_tokens=150
+)
 
 
 # ────────────────────────────────────────────────────────────────
@@ -139,7 +146,7 @@ def test_run_calls_llm_with_model_gpt4_mini(
     mock_client: MagicMock, mock_prompt: None
 ) -> None:
     req = _make_request()
-    mock_client.complete_structured.return_value = _make_valid_response(req)
+    mock_client.complete_structured.return_value = (_make_valid_response(req), _USAGE)
 
     v1_baseline.run(req)
 
@@ -151,7 +158,7 @@ def test_run_calls_llm_with_temperature_zero(
     mock_client: MagicMock, mock_prompt: None
 ) -> None:
     req = _make_request()
-    mock_client.complete_structured.return_value = _make_valid_response(req)
+    mock_client.complete_structured.return_value = (_make_valid_response(req), _USAGE)
 
     v1_baseline.run(req)
 
@@ -163,7 +170,7 @@ def test_run_calls_llm_with_max_output_tokens_1200(
     mock_client: MagicMock, mock_prompt: None
 ) -> None:
     req = _make_request()
-    mock_client.complete_structured.return_value = _make_valid_response(req)
+    mock_client.complete_structured.return_value = (_make_valid_response(req), _USAGE)
 
     v1_baseline.run(req)
 
@@ -176,7 +183,7 @@ def test_run_excludes_request_id_from_user_payload(
 ) -> None:
     """user_payload 에 request_id 가 없어야 한다 — LLM 판단에 불필요한 필드."""
     req = _make_request()
-    mock_client.complete_structured.return_value = _make_valid_response(req)
+    mock_client.complete_structured.return_value = (_make_valid_response(req), _USAGE)
 
     v1_baseline.run(req)
 
@@ -189,7 +196,7 @@ def test_run_loads_system_prompt_with_name_question_analysis(
 ) -> None:
     """load_system_prompt 가 "question_analysis" 이름으로 호출되는지 확인."""
     req = _make_request()
-    mock_client.complete_structured.return_value = _make_valid_response(req)
+    mock_client.complete_structured.return_value = (_make_valid_response(req), _USAGE)
 
     captured: dict[str, str] = {}
 
@@ -214,7 +221,7 @@ def test_run_returns_llm_response_as_is(
     """LLMClient 반환값을 변환 없이 그대로 돌려줘야 한다."""
     req = _make_request()
     expected = _make_valid_response(req)
-    mock_client.complete_structured.return_value = expected
+    mock_client.complete_structured.return_value = (expected, _USAGE)
 
     result = v1_baseline.run(req)
 

--- a/apps/ai/tests/test_result_summary_v1_baseline.py
+++ b/apps/ai/tests/test_result_summary_v1_baseline.py
@@ -23,7 +23,7 @@ import httpx
 import pytest
 from openai import APITimeoutError
 
-from llm import LLMResponseEmptyError
+from llm import LLMResponseEmptyError, TokenUsage
 from schemas.api.result_summary import (
     AnalysisCriteria,
     AnalysisSummaryRequest,
@@ -33,6 +33,13 @@ from schemas.api.result_summary import (
     Segment,
 )
 from services.result_summary import v1_baseline
+
+
+# complete_structured 는 (response, TokenUsage) 를 반환한다. 호출 인자/반환 검증
+# 테스트에서는 usage 값 자체가 의미 없으므로 고정 더미를 쓴다.
+_USAGE = TokenUsage(
+    input_tokens=100, cached_input_tokens=0, output_tokens=50, total_tokens=150
+)
 
 
 # ────────────────────────────────────────────────────────────────
@@ -109,7 +116,7 @@ def test_run_calls_llm_with_model_gpt4_nano(
     mock_client: MagicMock, mock_prompt: None
 ) -> None:
     req = _make_request()
-    mock_client.complete_structured.return_value = _make_valid_response(req)
+    mock_client.complete_structured.return_value = (_make_valid_response(req), _USAGE)
 
     v1_baseline.run(req)
 
@@ -121,7 +128,7 @@ def test_run_calls_llm_with_temperature_zero_point_one(
     mock_client: MagicMock, mock_prompt: None
 ) -> None:
     req = _make_request()
-    mock_client.complete_structured.return_value = _make_valid_response(req)
+    mock_client.complete_structured.return_value = (_make_valid_response(req), _USAGE)
 
     v1_baseline.run(req)
 
@@ -133,7 +140,7 @@ def test_run_calls_llm_with_max_output_tokens_300(
     mock_client: MagicMock, mock_prompt: None
 ) -> None:
     req = _make_request()
-    mock_client.complete_structured.return_value = _make_valid_response(req)
+    mock_client.complete_structured.return_value = (_make_valid_response(req), _USAGE)
 
     v1_baseline.run(req)
 
@@ -146,7 +153,7 @@ def test_run_excludes_request_id_from_user_payload(
 ) -> None:
     """user_payload 에 request_id 가 없어야 한다 — LLM 판단에 불필요한 필드."""
     req = _make_request()
-    mock_client.complete_structured.return_value = _make_valid_response(req)
+    mock_client.complete_structured.return_value = (_make_valid_response(req), _USAGE)
 
     v1_baseline.run(req)
 
@@ -159,7 +166,7 @@ def test_run_loads_system_prompt_with_name_result_summary(
 ) -> None:
     """load_system_prompt 가 "result_summary" 이름으로 호출되는지 확인."""
     req = _make_request()
-    mock_client.complete_structured.return_value = _make_valid_response(req)
+    mock_client.complete_structured.return_value = (_make_valid_response(req), _USAGE)
 
     captured: dict[str, str] = {}
 
@@ -184,7 +191,7 @@ def test_run_returns_llm_response_as_is(
     """LLMClient 반환값을 변환 없이 그대로 돌려줘야 한다."""
     req = _make_request()
     expected = _make_valid_response(req)
-    mock_client.complete_structured.return_value = expected
+    mock_client.complete_structured.return_value = (expected, _USAGE)
 
     result = v1_baseline.run(req)
 


### PR DESCRIPTION
## 요약
- 한 분석 플로우(파일분석 → 질문분석 → 결과요약)는 LLM을 3회 호출하지만 호출 단위 토큰 usage·estimated_cost_usd가 어디에도 남지 않았다. 이미 있던 `observability/cost.py`·`LLMEventBuilder`를 실제 호출 경로에 연결해 호출 1건당 비용 이벤트(JSONL → CloudWatch)를 남긴다 (#426 1단계).
- 이후 단계(플로우 상관 ID·플로우 단위 합산, prompt_version·validation 등 필드 보강)는 범위에서 제외했다.

## 변경 사항
- [x] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

상세:
- `LLMClient.complete_structured`가 `(response, TokenUsage)`를 반환하도록 변경하고, `completion.usage`(cached 포함)를 방어적으로 정규화한다.
- `observability.record_llm_call` 헬퍼를 추가해 api_name·request_id·model·usage·estimated_cost_usd를 단일 이벤트로 emit한다.
- file_analysis / question_analysis / result_summary 실호출 경로(v1_baseline)에서 호출 직후 emit한다. mock 모드(ANAL_LLM_MOCK=true)는 실제 비용이 없어 emit하지 않는다.

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `PYTHONPATH= ANAL_LLM_MOCK=true OPENAI_API_KEY=sk-test-dummy uv run pytest -q` → 196 passed
  - usage 정규화·0 기본값, 호출 단위 cost 이벤트 emit 검증 테스트 추가

## 스크린샷/로그 (선택)
- file_analysis 호출 1건 emit 예시(요약):
  `{"event_type":"llm_call","api_name":"file_analysis","request_id":"...","llm":{"model":"gpt-4.1-nano",...},"usage":{"input_tokens":1000,"cached_input_tokens":200,"output_tokens":300,"total_tokens":1300},"cost":{"estimated_cost_usd":0.000205}}`

## 롤백/리스크
- 리스크 포인트: `complete_structured`의 반환 계약이 단일 모델에서 `(response, TokenUsage)` 튜플로 바뀐다. 프로덕션 호출부는 3개 v1_baseline뿐이며 모두 갱신했고, 단가표 미등록 모델은 cost 0.0으로 기록되어 운영자가 누락을 알아챌 수 있다.
- 롤백 방법: 본 PR 커밋 revert

## 관련 이슈
Closes #426
