### PR TITLE
fix(fe): 데이터 경고 영역 깨진 한국어 문구 수정 (#434)

### DIFF
--- a/apps/fe/src/app/(main)/analysis/[id]/_components/AnalysisWarningList.tsx
+++ b/apps/fe/src/app/(main)/analysis/[id]/_components/AnalysisWarningList.tsx
@@ -20,7 +20,7 @@ export default function AnalysisWarningList({
         className={`inline-flex items-center gap-4 text-orange-500 ${titleClassName}`}
       >
         <AlertIcon aria-hidden className="icon-16 text-orange-500" />
-        <span>?곗씠??寃쎄퀬</span>
+        <span>데이터 경고</span>
       </div>
       <ul className={listClassName}>
         {warnings.map((warning) => (

--- a/apps/fe/src/app/(main)/analysis/[id]/_components/CriterionSelect.tsx
+++ b/apps/fe/src/app/(main)/analysis/[id]/_components/CriterionSelect.tsx
@@ -25,7 +25,7 @@ type MultiProps = CommonProps & {
   values: string[];
   maxSelect?: number;
   onChange: (next: string[]) => void;
-  /** ?듭뀡 由ъ뒪???곷떒???쒖떆?섎뒗 ?ㅻ뜑 (?? "理쒕? 2媛??좏깮") */
+  /** 옵션 목록 상단에 표시되는 헤더 (예: "최대 2개 선택") */
   headerLabel?: string;
 };
 
@@ -53,10 +53,10 @@ export default function CriterionSelect(props: CriterionSelectProps) {
 
   const buttonLabel =
     props.values.length === 0
-      ? '?좏깮'
+      ? '선택'
       : props.values.length === 1
         ? props.values[0]
-        : `${props.values[0]} ??${props.values.length - 1}`;
+        : `${props.values[0]} 외 ${props.values.length - 1}`;
 
   return (
     <ListboxDropdownShell

--- a/apps/fe/src/components/Dropdown/Dropdown.tsx
+++ b/apps/fe/src/components/Dropdown/Dropdown.tsx
@@ -23,7 +23,7 @@ export default function Dropdown({
   options,
   value,
   onChange,
-  placeholder = '?좏깮',
+  placeholder = '선택',
   icon,
   className = '',
   helperText,


### PR DESCRIPTION
## 요약
- 소스에 깨진 한국어 리터럴이 남아 데이터 경고 제목과 선택 라벨이 mojibake로 표시되던 문제를 정상 문구로 복구했습니다.

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

상세:
- 데이터 경고 제목을 `데이터 경고`로 교체했습니다.
- 공통 Dropdown 기본 placeholder를 `선택`으로 교체했습니다.
- 분석 기준 다중 선택 라벨을 `선택` / `첫 값 외 N` 형식으로 교체했습니다.

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `rg -n "\?곗씠|\?좏깮|\?듭뀡|\?\?\$\{|寃쎄퀬" src`
  - `eslint .`
  - `vitest run --project unit` (21 files, 108 tests passed)
  - `NEXT_PUBLIC_API_URL=https://api-stg.asklogue.co next build --webpack`

## 스크린샷/로그 (선택)
- 해당 없음

## 롤백/리스크
- 리스크 포인트: 정적 UI 문구 변경만 포함되어 런타임 로직 영향은 낮습니다.
- 롤백 방법: 본 커밋 revert

## 관련 이슈
Closes #434