### PR TITLE
fix(ai): QUESTION_DATA_MISMATCH 오탐 수정 - sample_values 겹침을 범주형 컬럼에만 적용 (#435)

### DIFF
--- a/apps/ai/rules/warning_rules.py
+++ b/apps/ai/rules/warning_rules.py
@@ -128,18 +128,31 @@ def _qdm_name_prefix(column_name: str) -> str:
     return column_name.split("_", 1)[0].lower()
 
 
+def _is_categorical(col) -> bool:
+    """sample_values 겹침이 모호 신호로 의미 있는 범주형(문자열) 컬럼인지 판정한다.
+
+    숫자형(`integer`/`double`) 컬럼은 작은 정수(0/1/2 등)를 자연히 공유하므로 값 겹침이
+    모호 신호가 되지 못한다(예: `landing_sessions` 와 `signup_complete`). 값 겹침 신호는
+    `string` 컬럼에만 적용한다.
+    """
+    return getattr(col, "data_type", None) == "string"
+
+
 def _columns_look_ambiguous(a, b) -> bool:
     """두 컬럼이 같은 의미를 가리킬 가능성(모호)을 결정론적으로 판정한다.
 
     신호 두 가지 중 하나라도 만족하면 모호로 본다.
-    1. sample_values 값 공간이 겹친다 (같은 카테고리 값을 공유 = 같은 축).
-    2. 이름 prefix(첫 토큰)를 공유한다 (예: `device`, `device_type`, `device_kind`).
+    1. 이름 prefix(첫 토큰)를 공유한다 (예: `device`, `device_type`, `device_kind`).
+    2. (범주형 한정) sample_values 값 공간이 겹친다 (같은 카테고리 값을 공유 = 같은 축).
+       숫자형 컬럼은 정수 공유 오탐을 막기 위해 값 겹침을 보지 않는다.
     """
-    a_vals = {str(v).lower() for v in (a.sample_values or [])}
-    b_vals = {str(v).lower() for v in (b.sample_values or [])}
-    if a_vals and b_vals and (a_vals & b_vals):
+    if _qdm_name_prefix(a.column_name) == _qdm_name_prefix(b.column_name):
         return True
-    return _qdm_name_prefix(a.column_name) == _qdm_name_prefix(b.column_name)
+    if _is_categorical(a) and _is_categorical(b):
+        a_vals = {str(v).lower() for v in (a.sample_values or [])}
+        b_vals = {str(v).lower() for v in (b.sample_values or [])}
+        return bool(a_vals and b_vals and (a_vals & b_vals))
+    return False
 
 
 def infer_qdm_warning(

--- a/apps/ai/tests/test_warning_inference.py
+++ b/apps/ai/tests/test_warning_inference.py
@@ -469,6 +469,16 @@ def test_measure_shared_suffix_no_qdm() -> None:
     assert infer_qdm_warning(_response(_criteria()), req) == []
 
 
+def test_numeric_columns_overlapping_values_no_qdm() -> None:
+    # 숫자형 컬럼은 작은 정수(0/1/2)를 자연히 공유한다. 값 겹침만으로 모호 판정하면 안 됨
+    # (prod 오탐 회귀 가드: landing_sessions/signup_complete 가 needConfirm 으로 새던 케이스).
+    req = _request_with_columns([
+        ("landing_sessions", "MEASURE", [1, 0, 2]),
+        ("signup_complete", "MEASURE", [1, 0, 1]),
+    ])
+    assert infer_qdm_warning(_response(_criteria()), req) == []
+
+
 def test_real_fixtures_qdm_behaviour() -> None:
     """실제 eval fixture 로 AMB(모호)=QDM, 정상 dataset-a/b=무발생 을 고정한다."""
     import json


### PR DESCRIPTION
## 요약
- QDM 결정론 추론의 sample_values 겹침 신호를 범주형(string) 컬럼에만 적용. 숫자형 컬럼(integer/double)은 작은 정수를 자연히 공유해 항상 겹쳐서 오탐하던 문제 수정

## 변경 사항
- [x] 버그 수정

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - cd apps/ai && python -m pytest -q (202 passed)
  - 신규 회귀 가드: 숫자형 landing_sessions/signup_complete 값 겹침 시 QDM 미발생 확인
  - 기존 AMB-01/02(문자열 channel/source 겹침), AMB-07(device* prefix) 그대로 발생 확인(real fixture 테스트)

## 롤백·리스크
- 리스크 포인트: 이름 prefix 신호와 FLAG/STATUS_CONDITION 개수 신호는 그대로 유지. 문자열 컬럼 값 겹침 판정만 유지하고 숫자형은 제외
- 영향: prod 에서 숫자형 MEASURE 가 needConfirm/dataWarning 으로 잘못 노출되고 QUESTION_DATA_MISMATCH(BLOCKING)로 확정까지 막히던 문제 해소
- 롤백 방법: 본 커밋 revert

## 관련 이슈
Closes #435