### PR TITLE
perf(be): getSummary 컬럼 N+1 조회 제거

### DIFF
--- a/apps/be/src/main/java/com/capstone/logue/anal/repository/AnalysisFlowColumnRepository.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/repository/AnalysisFlowColumnRepository.java
@@ -3,6 +3,7 @@ package com.capstone.logue.anal.repository;
 import com.capstone.logue.global.entity.AnalysisFlowColumn;
 import java.util.Collection;
 import java.util.List;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -10,6 +11,8 @@ import org.springframework.data.repository.query.Param;
 
 public interface AnalysisFlowColumnRepository extends JpaRepository<AnalysisFlowColumn, Long> {
 
+    // getSummary 의 컬럼별 dataSourceColumn LAZY 로딩 N+1 을 fetch join 으로 제거한다.
+    @EntityGraph(attributePaths = "dataSourceColumn")
     List<AnalysisFlowColumn> findByAnalysisFlowIdOrderByIdAsc(Long analysisFlowId);
 
     /**


### PR DESCRIPTION
## 요약
getSummary 의 컬럼별 dataSourceColumn LAZY 로딩 N+1 을 fetch join 으로 제거합니다.

## 변경
- `AnalysisFlowColumnRepository.findByAnalysisFlowIdOrderByIdAsc` 에 `@EntityGraph(attributePaths = "dataSourceColumn")` 적용
- 40컬럼 데이터소스 기준 data_source_columns 조회 38회 -> 1회 (fetch join)

## 검증
- compileJava + AnalServiceTest 통과
- 머지 후 stg 에서 getSummary 단건 쿼리수 재측정 예정

Closes #440