### PR TITLE
refactor(be): getSummary 분석 플로우 중복 조회 통합

### DIFF
--- a/apps/be/src/main/java/com/capstone/logue/anal/service/AnalService.java
+++ b/apps/be/src/main/java/com/capstone/logue/anal/service/AnalService.java
@@ -179,9 +179,7 @@ public class AnalService {
      */
     public GetSummaryResponse getSummary(Long conversationId, Long analysisFlowId) {
 
-        validateConversationAccess(conversationId, analysisFlowId);
-        AnalysisFlow analysisFlow = analysisFlowRepository.findById(analysisFlowId)
-                .orElseThrow(() -> new LogueException(ErrorCode.ANALYSIS_FLOW_NOT_FOUND));
+        AnalysisFlow analysisFlow = validateConversationAccess(conversationId, analysisFlowId);
 
         AiTaggingJob job = aiTaggingJobRepository
                 .findTopByAnalysisFlowIdAndStageOrderByCreatedAtDescIdDesc(analysisFlowId, JobStage.DATA_STATUS)
@@ -302,7 +300,7 @@ public class AnalService {
      *                        분석 흐름을 찾을 수 없는 경우 (AN003),
      *                        분석 흐름이 해당 대화에 속하지 않는 경우 (A002)
      */
-    private void validateConversationAccess(Long conversationId, Long analysisFlowId) {
+    private AnalysisFlow validateConversationAccess(Long conversationId, Long analysisFlowId) {
         Conversation conversation = conversationRepository.findById(conversationId)
                 .orElseThrow(() -> new LogueException(ErrorCode.CONVERSATION_NOT_FOUND));
 
@@ -317,5 +315,7 @@ public class AnalService {
         if (!analysisFlow.getConversation().getId().equals(conversationId)) {
             throw new LogueException(ErrorCode.FORBIDDEN);
         }
+
+        return analysisFlow;
     }
 }


### PR DESCRIPTION
## 요약
getSummary 가 `validateConversationAccess` 에서 AnalysisFlow 를 조회한 뒤 본문에서 동일 플로우를 한 번 더 findById 하던 중복을 제거합니다.

## 변경
- `validateConversationAccess` 가 조회한 `AnalysisFlow` 를 반환
- getSummary 가 재조회 대신 반환값 재사용 (analysis_flows findById 1회 절감)
- FORBIDDEN / NOT_FOUND 예외 의미는 그대로 유지

## 검증
- compileJava + anal 서비스 테스트 통과

Closes #442